### PR TITLE
fix: disable svgo plugin on svgr

### DIFF
--- a/.changeset/seven-ghosts-taste.md
+++ b/.changeset/seven-ghosts-taste.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+Fix social icons not sized correctly.

--- a/packages/runtime/vite.config.ts
+++ b/packages/runtime/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
   define: {
     'import.meta.vitest': false,
   },
-  plugins: [svgr(), react()],
+  plugins: [svgr({ svgo: false }), react()],
   build: {
     emptyOutDir: false,
     sourcemap: true,


### PR DESCRIPTION
This would fix one issue where social icons aren't sized correctly,
because svgo is removing the viewBox.