### PR TITLE
fix: disable element registration inside unfocused element reference

### DIFF
--- a/.changeset/yellow-wombats-peel.md
+++ b/.changeset/yellow-wombats-peel.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+Fix overlay for nested global components are showing the wrong selection, making you unable to edit.

--- a/packages/runtime/src/runtimes/react/index.tsx
+++ b/packages/runtime/src/runtimes/react/index.tsx
@@ -260,6 +260,8 @@ const ElementData = memo(
   }),
 )
 
+const DisableRegisterElement = createContext(false)
+
 type ElementRefereceProps = {
   elementReference: ReactPage.ElementReference
 }
@@ -299,7 +301,9 @@ const ElementReference = memo(
     return elementReferenceDocument != null ? (
       <Document document={elementReferenceDocument} ref={ref} />
     ) : (
-      <ElementData elementData={globalElementData} ref={ref} />
+      <DisableRegisterElement.Provider value={true}>
+        <ElementData elementData={globalElementData} ref={ref} />
+      </DisableRegisterElement.Provider>
     )
   }),
 )
@@ -314,20 +318,21 @@ export const Element = memo(
     const dispatch = useDispatch()
     const documentKey = useDocumentKey()
     const [handle, setHandle] = useState<unknown>(null)
+    const isRegisterElementDisabled = useContext(DisableRegisterElement)
 
     useImperativeHandle(ref, () => handle, [handle])
 
     useEffect(() => {
-      if (documentKey == null) return
+      if (documentKey == null || isRegisterElementDisabled) return
 
       return dispatch(registerComponentHandleEffect(documentKey, elementKey, handle))
-    }, [dispatch, documentKey, elementKey, handle])
+    }, [dispatch, documentKey, elementKey, handle, isRegisterElementDisabled])
 
     useEffect(() => {
-      if (documentKey == null) return
+      if (documentKey == null || isRegisterElementDisabled) return
 
       return dispatch(mountComponentEffect(documentKey, elementKey))
-    }, [dispatch, documentKey, elementKey])
+    }, [dispatch, documentKey, elementKey, isRegisterElementDisabled])
 
     return ReactPage.isElementReference(element) ? (
       <ElementReference key={elementKey} ref={setHandle} elementReference={element} />


### PR DESCRIPTION
Before, when you put two nested global components, the overlay is shown
on the wrong element.
This is happening because a nested global element have the same key,
and we're registering all elements.

This commit fix it by disabling element registration, when it's inside
an unfocused element reference. We know whether element reference
is focused or not, by checking whether the elementReferenceDocument
is null.