### PR TITLE
fix: pass className prop on Button

### DIFF
--- a/.changeset/spotty-trees-drive.md
+++ b/.changeset/spotty-trees-drive.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+Fix Form button alignment prop not being applied

--- a/packages/runtime/src/components/builtin/Button/Button.tsx
+++ b/packages/runtime/src/components/builtin/Button/Button.tsx
@@ -262,6 +262,7 @@ const Button = forwardRef<HTMLAnchorElement, Props>(function Button(
     textStyle,
     width,
     margin,
+    className,
     ...restOfProps
   },
   ref,
@@ -271,7 +272,7 @@ const Button = forwardRef<HTMLAnchorElement, Props>(function Button(
       {...restOfProps}
       ref={ref}
       id={id}
-      className={cx(toClass(responsiveWidth(width, 'auto')))}
+      className={cx(toClass(responsiveWidth(width, 'auto')), className)}
       // @ts-expect-error: HTMLAnchorElement `color` attribute conflicts with prop
       color={color}
       link={link}


### PR DESCRIPTION
This fix a bug in Form component where we extend
the Button, but the style isn't applied
because we didn't pass the className