### PR TITLE
fix: snippets issues

### DIFF
--- a/.changeset/hip-wolves-talk.md
+++ b/.changeset/hip-wolves-talk.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+Fix snippets not updated immediately after changes

--- a/packages/runtime/codegen.yml
+++ b/packages/runtime/codegen.yml
@@ -6,6 +6,8 @@ generates:
     plugins:
       - typescript-operations
       - typed-document-node
+      - add:
+          content: export enum SnippetLocation { Body = 'BODY', Head = 'HEAD' }
 hooks:
   afterOneFileWrite:
     - prettier --write

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -134,6 +134,7 @@
     "uuid": "^3.3.3"
   },
   "devDependencies": {
+    "@graphql-codegen/add": "^3.1.0",
     "@graphql-codegen/cli": "2.6.2",
     "@graphql-codegen/typed-document-node": "^2.2.7",
     "@graphql-codegen/typescript-operations": "2.3.4",

--- a/packages/runtime/src/api/constants.ts
+++ b/packages/runtime/src/api/constants.ts
@@ -7,6 +7,8 @@ import {
   PagePathnameSliceFragmentDoc,
   GlobalElementFragmentDoc,
   TableFragmentDoc,
+  SnippetFragmentDoc,
+  PageFragmentDoc,
 } from './generated/graphql'
 import type { APIResourceType } from './types'
 
@@ -17,4 +19,6 @@ export const Fragments: Record<APIResourceType, DocumentNode> = {
   PagePathnameSlice: PagePathnameSliceFragmentDoc,
   GlobalElement: GlobalElementFragmentDoc,
   Table: TableFragmentDoc,
+  Snippet: SnippetFragmentDoc,
+  Page: PageFragmentDoc,
 }

--- a/packages/runtime/src/api/fragments.graphql
+++ b/packages/runtime/src/api/fragments.graphql
@@ -81,3 +81,31 @@ fragment Table on Table {
     }
   }
 }
+
+fragment Snippet on Snippet {
+  __typename
+  id
+  name
+  code
+  cleanup
+  location
+  shouldAddToNewPages
+  liveEnabled
+  builderEnabled
+}
+
+fragment Page on Page {
+  __typename
+  id
+  snippets {
+    __typename
+    id
+    name
+    code
+    cleanup
+    location
+    shouldAddToNewPages
+    liveEnabled
+    builderEnabled
+  }
+}

--- a/packages/runtime/src/api/generated/graphql.ts
+++ b/packages/runtime/src/api/generated/graphql.ts
@@ -1,4 +1,8 @@
 import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core'
+export enum SnippetLocation {
+  Body = 'BODY',
+  Head = 'HEAD',
+}
 export type SwatchFragment = {
   __typename: 'Swatch'
   id: string
@@ -73,6 +77,34 @@ export type TableFragment = {
       }
     | { __typename?: 'URLTableColumn'; id: string; name: string }
   >
+}
+
+export type SnippetFragment = {
+  __typename: 'Snippet'
+  id: string
+  name: string
+  code: string
+  cleanup?: string | null
+  location: SnippetLocation
+  shouldAddToNewPages: boolean
+  liveEnabled: boolean
+  builderEnabled: boolean
+}
+
+export type PageFragment = {
+  __typename: 'Page'
+  id: string
+  snippets: Array<{
+    __typename: 'Snippet'
+    id: string
+    name: string
+    code: string
+    cleanup?: string | null
+    location: SnippetLocation
+    shouldAddToNewPages: boolean
+    liveEnabled: boolean
+    builderEnabled: boolean
+  }>
 }
 
 export const SwatchFragmentDoc = {
@@ -305,3 +337,62 @@ export const TableFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<TableFragment, unknown>
+export const SnippetFragmentDoc = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'FragmentDefinition',
+      name: { kind: 'Name', value: 'Snippet' },
+      typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Snippet' } },
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          { kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+          { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+          { kind: 'Field', name: { kind: 'Name', value: 'name' } },
+          { kind: 'Field', name: { kind: 'Name', value: 'code' } },
+          { kind: 'Field', name: { kind: 'Name', value: 'cleanup' } },
+          { kind: 'Field', name: { kind: 'Name', value: 'location' } },
+          { kind: 'Field', name: { kind: 'Name', value: 'shouldAddToNewPages' } },
+          { kind: 'Field', name: { kind: 'Name', value: 'liveEnabled' } },
+          { kind: 'Field', name: { kind: 'Name', value: 'builderEnabled' } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<SnippetFragment, unknown>
+export const PageFragmentDoc = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'FragmentDefinition',
+      name: { kind: 'Name', value: 'Page' },
+      typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Page' } },
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          { kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+          { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'snippets' },
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                { kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'name' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'code' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'cleanup' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'location' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'shouldAddToNewPages' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'liveEnabled' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'builderEnabled' } },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<PageFragment, unknown>

--- a/packages/runtime/src/api/react.tsx
+++ b/packages/runtime/src/api/react.tsx
@@ -60,6 +60,9 @@ const typePolicies: TypePolicies = {
       table(existingData, { args, toReference }) {
         return existingData ?? toReference({ __typename: 'Table', id: args?.id }, true)
       },
+      page(existingData, { args, toReference }) {
+        return existingData ?? toReference({ __typename: 'Page', id: args?.id }, true)
+      },
     },
   },
 }

--- a/packages/runtime/src/api/types.ts
+++ b/packages/runtime/src/api/types.ts
@@ -5,8 +5,18 @@ import {
   PagePathnameSliceFragment as PagePathnameSlice,
   GlobalElementFragment as GlobalElement,
   TableFragment as Table,
+  SnippetFragment as Snippet,
+  PageFragment as Page,
 } from './generated/graphql'
 
-export type APIResource = Swatch | File | Typography | PagePathnameSlice | GlobalElement | Table
+export type APIResource =
+  | Swatch
+  | File
+  | Typography
+  | PagePathnameSlice
+  | GlobalElement
+  | Table
+  | Snippet
+  | Page
 
 export type APIResourceType = APIResource['__typename']

--- a/packages/runtime/src/next.tsx
+++ b/packages/runtime/src/next.tsx
@@ -64,6 +64,7 @@ export type PageProps = {
   rootElement: Element
   makeswiftApiEndpoint: string
   cacheData: NormalizedCacheObject
+  preview: boolean
 }
 
 type APIResult = PageData & {
@@ -98,6 +99,7 @@ export async function getServerSideProps({
       rootElement: page.data,
       makeswiftApiEndpoint,
       cacheData,
+      preview: true,
     },
   }
 }
@@ -133,6 +135,7 @@ export async function getStaticProps({
       rootElement: page.data,
       makeswiftApiEndpoint,
       cacheData,
+      preview: false,
     },
     revalidate: REVALIDATE_SECONDS,
   }
@@ -142,7 +145,7 @@ export async function getStaticPaths(): Promise<GetStaticPathsResult> {
   return { paths: [], fallback: 'blocking' }
 }
 
-export function Page({ page, rootElement, makeswiftApiEndpoint, cacheData }: PageProps) {
+export function Page({ page, rootElement, makeswiftApiEndpoint, cacheData, preview }: PageProps) {
   const [client] = useState(() => new MakeswiftClient({ uri: makeswiftApiEndpoint, cacheData }))
 
   useEffect(() => {
@@ -151,7 +154,7 @@ export function Page({ page, rootElement, makeswiftApiEndpoint, cacheData }: Pag
 
   return (
     <RuntimeProvider client={client} rootElements={new Map([[page.id, rootElement]])}>
-      <PageMeta page={page} />
+      <PageMeta page={page} preview={preview} />
     </RuntimeProvider>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1370,6 +1370,14 @@
     ts-node "^9"
     tslib "^2"
 
+"@graphql-codegen/add@^3.1.0":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/add/-/add-3.1.1.tgz#e161ff1c7cdf74ce20b32f75f640f9592b9a18ca"
+  integrity sha512-XkVwcqosa0CVBlL1HaQT0gp+EUfhuQE3LzrEpzMQLwchxaj/NPVYtOJL6MUHaYDsHzLqxWrufjfbeB3y2NQgRw==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "^2.3.2"
+    tslib "~2.3.0"
+
 "@graphql-codegen/cli@2.6.2":
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/cli/-/cli-2.6.2.tgz#a9aa4656141ee0998cae8c7ad7d0bf9ca8e0c9ae"


### PR DESCRIPTION
Problems:
1. Snippets aren't updating immediately when added, removed, or edited.
This is because we got the snippets value from getServerSideProps, which
doesn't get updated when there's any change in apollo cache.
This MR use the snippets value from apollo cache when it's in preview.

2. Snippet set to "Live page" is still showing in the builder.
We forgot to pass the preview props on the Page component.

I need to add the `typescript` to the codegen because we need to access the `SnippetLocation` enum, which isn't generated if we're just using the `typescript-operations`. Let me know if there's any config to add the `SnippetLocation` enum without generating the whole thing.