### PR TITLE
fix: send onwheel event to builder

### DIFF
--- a/.changeset/silver-news-pull.md
+++ b/.changeset/silver-news-pull.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+Fix scrolling doesn't work in content mode when hovering over a text block

--- a/packages/runtime/src/state/actions.ts
+++ b/packages/runtime/src/state/actions.ts
@@ -56,6 +56,8 @@ export const ActionTypes = {
   EVICT_API_RESOURCE: 'EVICT_API_RESOURCE',
 
   SET_IS_IN_BUILDER: 'SET_IS_IN_BUILDER',
+
+  HANDLE_WHEEL: 'HANDLE_WHEEL',
 } as const
 
 type InitAction = { type: typeof ActionTypes.INIT }
@@ -214,6 +216,11 @@ type SetIsInBuilderAction = {
   payload: boolean
 }
 
+type HandleWheelAction = {
+  type: typeof ActionTypes.HANDLE_WHEEL
+  payload: { deltaX: number; deltaY: number }
+}
+
 export type Action =
   | InitAction
   | CleanUpAction
@@ -245,6 +252,7 @@ export type Action =
   | ChangeAPIResourceAction
   | EvictAPIResourceAction
   | SetIsInBuilderAction
+  | HandleWheelAction
 
 export function init(): InitAction {
   return { type: ActionTypes.INIT }
@@ -521,4 +529,8 @@ export function evictApiResource(id: string): EvictAPIResourceAction {
 
 export function setIsInBuilder(isInBuilder: boolean): SetIsInBuilderAction {
   return { type: ActionTypes.SET_IS_IN_BUILDER, payload: isInBuilder }
+}
+
+export function handleWheel(payload: { deltaX: number; deltaY: number }): HandleWheelAction {
+  return { type: ActionTypes.HANDLE_WHEEL, payload }
 }


### PR DESCRIPTION
This will fix scrolling doesn't work in content mode
when hovering over a text block