### PR TITLE
fix: SSR for `next/image` and Next.js router

### DIFF
--- a/.changeset/dirty-lions-leave.md
+++ b/.changeset/dirty-lions-leave.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+Fix SSR issues with `next/image` and Next.js' router.

--- a/packages/runtime/src/api/react.tsx
+++ b/packages/runtime/src/api/react.tsx
@@ -15,14 +15,8 @@ import {
   InMemoryCache,
   TypePolicies,
 } from '@apollo/client'
-import { getDataFromTree } from '@apollo/client/react/ssr'
 export { gql } from '@apollo/client'
 import { createContext, ReactNode, useContext } from 'react'
-import { KeyUtils } from 'slate'
-import uuid from 'uuid/v4'
-
-import { DocumentReference, RuntimeProvider } from '../react'
-import { createDocumentReference, Element } from '../state/react-page'
 
 const typePolicies: TypePolicies = {
   Query: {
@@ -70,10 +64,15 @@ const typePolicies: TypePolicies = {
   },
 }
 
-const PrefetchContext = createContext(false)
+const isServer = typeof window === 'undefined'
+let globalApolloClient: ApolloClient<NormalizedCacheObject> | null = null
 
-export function useIsPrefetching(): boolean {
-  return useContext(PrefetchContext)
+export function garbageCollectGlobalCacheData() {
+  globalApolloClient = null
+}
+
+export function getGlobalCacheData() {
+  return globalApolloClient?.cache.extract()
 }
 
 type CreateApolloClientParams = {
@@ -86,7 +85,7 @@ export function createApolloClient({ uri, cacheData }: CreateApolloClientParams)
 
   if (cacheData) cache.restore(cacheData)
 
-  return new ApolloClient({ uri, cache })
+  return new ApolloClient({ uri, cache, ssrMode: isServer })
 }
 
 export type MakeswiftClientOptions = {
@@ -98,23 +97,10 @@ export class MakeswiftClient {
   apolloClient: ApolloClient<NormalizedCacheObject>
 
   constructor({ uri, cacheData }: MakeswiftClientOptions) {
-    this.apolloClient = createApolloClient({ uri, cacheData })
-  }
+    if (globalApolloClient == null) globalApolloClient = createApolloClient({ uri, cacheData })
+    else if (cacheData != null) globalApolloClient.cache.restore(cacheData)
 
-  async prefetch(element: Element): Promise<NormalizedCacheObject> {
-    const id = uuid()
-
-    await getDataFromTree(
-      <PrefetchContext.Provider value={true}>
-        <RuntimeProvider client={this} rootElements={new Map([[id, element]])}>
-          <DocumentReference documentReference={createDocumentReference(id)} />
-        </RuntimeProvider>
-      </PrefetchContext.Provider>,
-    )
-
-    KeyUtils.resetGenerator()
-
-    return this.apolloClient.cache.extract()
+    this.apolloClient = globalApolloClient
   }
 
   updateCacheData(cacheData: NormalizedCacheObject): void {

--- a/packages/runtime/src/components/builtin/Image/Image.tsx
+++ b/packages/runtime/src/components/builtin/Image/Image.tsx
@@ -36,7 +36,6 @@ import { placeholders } from '../../utils/placeholders'
 import { ReactRuntime, useIsInBuilder } from '../../../react'
 import { Link } from '../../shared/Link'
 import { Props } from '../../../prop-controllers'
-import { useIsPrefetching } from '../../../api/react'
 import { responsiveWidth } from '../../utils/responsive-style'
 
 type Props = {
@@ -141,7 +140,6 @@ const ImageComponent = forwardRef(function Image(
   const dataDimensions = fileData?.publicUrl ? fileData?.dimensions : placeholder.dimensions
   const [measuredDimensions, setMeasuredDimensions] = useState<Dimensions | null>(null)
   const isInBuilder = useIsInBuilder()
-  const isPrefetching = useIsPrefetching()
 
   useEffect(() => {
     if (dataDimensions) return
@@ -166,8 +164,6 @@ const ImageComponent = forwardRef(function Image(
   if (!dimensions) return null
 
   const widthClass = toClass(responsiveWidth(width, `${dimensions.width}px`))
-
-  if (isPrefetching) return null
 
   return (
     <ImageContainer

--- a/packages/runtime/src/components/shared/BackgroundsContainer/components/Backgrounds/index.tsx
+++ b/packages/runtime/src/components/shared/BackgroundsContainer/components/Backgrounds/index.tsx
@@ -8,7 +8,6 @@ import { ColorValue as Color } from '../../../../utils/types'
 import { colorToString } from '../../../../utils/colorToString'
 import Parallax from '../Parallax'
 import BackgroundVideo from '../BackgroundVideo'
-import { useIsPrefetching } from '../../../../../api/react'
 
 function getColor(color: Color | null | undefined) {
   if (color == null) return 'black'
@@ -64,10 +63,6 @@ const BackgroundsContainer = styled(Container)<{ visibility: ResponsiveValue<boo
 type Props = { backgrounds: BackgroundsPropControllerData | null | undefined }
 
 export default function Backgrounds({ backgrounds }: Props): JSX.Element {
-  const isPrefetching = useIsPrefetching()
-
-  if (isPrefetching) return <></>
-
   if (backgrounds == null) return <></>
 
   return (


### PR DESCRIPTION
We were calling Apollo's `getDataFromTree` to fill the cache. The React
tree that was being used didn't include Next.js context which caused
issue with Next.js features like `next/image` and its router.
Specifically, Next.js uses React context to provide valid domains for
`next/image` and its router values but we weren't providing these
context values when rendering components in `getStaticProps` and
`getServerSideProps` using `getDataFromTree`. We now work around this by
calling `getDataFromTree` in the `Document` component where we can
render Next.js' `AppTree`, which includes its context.