### PR TITLE
Proof of concept 1: fix: don't render custom components when prefetch

### DIFF
--- a/.changeset/large-pets-kneel.md
+++ b/.changeset/large-pets-kneel.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+Fix error when using next/image or useRouter

--- a/packages/runtime/src/components/builtin/index.ts
+++ b/packages/runtime/src/components/builtin/index.ts
@@ -59,3 +59,23 @@ export function registerBuiltinComponents(runtime: ReactRuntime) {
     unregisterVideoComponent()
   }
 }
+
+export function isBuiltinComponent(elementType: string) {
+  const builtInComponentTypes = [
+    './components/Button/index.js',
+    './components/Box/index.js',
+    './components/Button/index.js',
+    './components/Carousel/index.js',
+    './components/Countdown/index.js',
+    './components/Divider/index.js',
+    './components/Embed/index.js',
+    './components/Form/index.js',
+    './components/Image/index.js',
+    './components/Navigation/index.js',
+    './components/Root/index.js',
+    './components/SocialLinks/index.js',
+    './components/Text/index.js',
+  ]
+
+  return builtInComponentTypes.includes(elementType)
+}


### PR DESCRIPTION
During prefetching, we don't render custom components. We're using
Apollo's getDataFromTree and the custom components would get error
 when trying to use next/image or useRouter.