### PR TITLE
fix: forward link prop in ImageContainer

### DIFF
--- a/.changeset/happy-swans-punch.md
+++ b/.changeset/happy-swans-punch.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+Fix regression introduced in 0.0.18 where link wasn't working on Image component.

--- a/packages/runtime/src/components/builtin/Image/Image.tsx
+++ b/packages/runtime/src/components/builtin/Image/Image.tsx
@@ -83,16 +83,9 @@ function imageSizes(width?: Props['width']): string {
 
 const ImageContainer = styled.div.withConfig({
   shouldForwardProp: prop =>
-    ![
-      'margin',
-      'padding',
-      'border',
-      'borderRadius',
-      'boxShadow',
-      'opacity',
-      'link',
-      'dimensions',
-    ].includes(prop.toString()),
+    !['margin', 'padding', 'border', 'borderRadius', 'boxShadow', 'opacity', 'dimensions'].includes(
+      prop.toString(),
+    ),
 })<{
   margin?: Props['margin']
   padding?: Props['padding']


### PR DESCRIPTION
This is creating issue in live pages, where link is not working
in Image, because we're not forwarding the prop from ImageContainer
to Link component.