### PR TITLE
fix: don't allow empty string for next/link href

### DIFF
--- a/.changeset/sour-clocks-sit.md
+++ b/.changeset/sour-clocks-sit.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+Avoid passing an empty string to `next/link` `href` prop.

--- a/packages/runtime/src/components/shared/Link/index.tsx
+++ b/packages/runtime/src/components/shared/Link/index.tsx
@@ -22,7 +22,7 @@ export const Link = forwardRef<HTMLAnchorElement, Props>(function Link(
     link?.type === 'SCROLL_TO_ELEMENT' ? link.payload.elementIdConfig?.elementKey : null
   const elementId = useElementId(elementKey)
 
-  let href = ''
+  let href = '#'
   let target: '_blank' | '_self' | undefined
   let block: 'start' | 'center' | 'end' | undefined
 


### PR DESCRIPTION
Passing an empty string causes Next.js to pick the current page, which
can result in issues if the current page is a dynamic route, since the
path doesn't exist. i.e., `/[[...path]]`.