### PR TITLE
fix: ref for component not found fallback

### DIFF
--- a/.changeset/fast-hotels-suffer.md
+++ b/.changeset/fast-hotels-suffer.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+Fix not-found components not being selectable in the builder.

--- a/packages/runtime/src/runtimes/react/index.tsx
+++ b/packages/runtime/src/runtimes/react/index.tsx
@@ -241,7 +241,7 @@ const ElementData = memo(
     suppressRefWarning(`\`ForwardRef(${ElementData.name})\``)
 
     if (Component == null) {
-      return <FallbackComponent ref={ref as Ref<HTMLDivElement>} text="Component not found" />
+      return <FallbackComponent ref={setHandle} text="Component not found" />
     }
 
     return (


### PR DESCRIPTION
When we started using `useImperativeHandle` in the `ElementData`
component, the forwarded ref shouldn't have been used anymore except as
the first argument of `useImperativeHandle`.