### PR TITLE
feat: add on demand product page revalidation

### DIFF
--- a/examples/bigcommerce/components/header.tsx
+++ b/examples/bigcommerce/components/header.tsx
@@ -21,7 +21,7 @@ export function Header({ className, links }: Props) {
   return (
     <div className={`${className} flex gap-3 flex-wrap justify-between items-center`}>
       <div className="flex space-x-5 items-center">
-        <Link href={'/'}>
+        <Link href={'/home'}>
           <a>
             <svg
               width="28"

--- a/examples/bigcommerce/lib/config.ts
+++ b/examples/bigcommerce/lib/config.ts
@@ -8,6 +8,7 @@ export type Config = {
   makeswift: {
     siteApiKey: string
     productTemplatePathname: string
+    revalidationSecret: string
   }
 }
 
@@ -33,6 +34,7 @@ export function getConfig(): Config {
     makeswift: {
       siteApiKey: getEnvVarOrThrow('MAKESWIFT_SITE_API_KEY'),
       productTemplatePathname: '/__product__',
+      revalidationSecret: 'secret',
     },
   }
 }

--- a/examples/bigcommerce/package.json
+++ b/examples/bigcommerce/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@headlessui/react": "^1.6.6",
-    "@makeswift/runtime": "^0.1.4",
+    "@makeswift/runtime": "^0.1.8",
     "next": "12.2.3",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/examples/bigcommerce/pages/api/revalidate.ts
+++ b/examples/bigcommerce/pages/api/revalidate.ts
@@ -1,0 +1,19 @@
+import { getProducts } from 'lib/bigcommerce'
+import { getConfig } from 'lib/config'
+import { NextApiRequest, NextApiResponse } from 'next'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const config = getConfig()
+
+  if (req.query.secret !== config.makeswift.revalidationSecret) {
+    return res.status(401).json({ message: 'Invalid token' })
+  }
+
+  try {
+    const products = await getProducts()
+    await Promise.all(products.map(product => res.revalidate(`/product/${product.entityId}`)))
+    return res.json({ revalidated: true })
+  } catch (err) {
+    return res.status(500).send('Error revalidating')
+  }
+}

--- a/examples/bigcommerce/yarn.lock
+++ b/examples/bigcommerce/yarn.lock
@@ -379,10 +379,10 @@
   dependencies:
     next-transpile-modules "^9.0.0"
 
-"@makeswift/runtime@^0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@makeswift/runtime/-/runtime-0.1.4.tgz#5792537a932dacc67197398d30b1076434867bb6"
-  integrity sha512-Wizu3IT8c2pH9whhzKEuBbRjNshGc6tTFo614854u9cEYkZ0xjDR2zVRegBZhDmCnmS6Q9pCCV8JZznQOyhohg==
+"@makeswift/runtime@^0.1.8":
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/@makeswift/runtime/-/runtime-0.1.8.tgz#ae14ffce5ef433549d63826781808cd8744141b9"
+  integrity sha512-5H1KcX4TMk17UT1KXDABi7esG/DV1YIowqYtamX2VG9ANlqfAm38mgWrPFgYFfFS7jgicVPSSfNlJbvCGRtQ3Q==
   dependencies:
     "@apollo/client" "^3.5.10"
     "@convertkit/slate-lists" "^0.2.4"

--- a/examples/shopify/lib/config.ts
+++ b/examples/shopify/lib/config.ts
@@ -11,6 +11,7 @@ type PrivateConfig = {
   makeswift: {
     siteApiKey: string
     productTemplatePathname: string
+    revalidationSecret: string
   }
 }
 
@@ -40,6 +41,7 @@ export function getConfig(): Config {
     makeswift: {
       siteApiKey: process.env.MAKESWIFT_SITE_API_KEY,
       productTemplatePathname: '/__product__',
+      revalidationSecret: 'secret',
     },
   }
 }

--- a/examples/shopify/package.json
+++ b/examples/shopify/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@headlessui/react": "^1.6.6",
-    "@makeswift/runtime": "^0.1.4",
+    "@makeswift/runtime": "^0.1.8",
     "next": "^12.1.6",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",

--- a/examples/shopify/pages/api/revalidate.ts
+++ b/examples/shopify/pages/api/revalidate.ts
@@ -1,0 +1,19 @@
+import { getConfig } from 'lib/config'
+import { getProducts } from 'lib/shopify'
+import { NextApiRequest, NextApiResponse } from 'next'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const config = getConfig()
+
+  if (req.query.secret !== config.makeswift.revalidationSecret) {
+    return res.status(401).json({ message: 'Invalid token' })
+  }
+
+  try {
+    const products = await getProducts()
+    await Promise.all(products.map(product => res.revalidate(`/product/${product.id}`)))
+    return res.json({ revalidated: true })
+  } catch (err) {
+    return res.status(500).send('Error revalidating')
+  }
+}

--- a/examples/shopify/yarn.lock
+++ b/examples/shopify/yarn.lock
@@ -379,10 +379,10 @@
   dependencies:
     next-transpile-modules "^9.0.0"
 
-"@makeswift/runtime@^0.1.4":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@makeswift/runtime/-/runtime-0.1.6.tgz#c403ba0befc2ac6b24ac32534c56ef71e18a42ed"
-  integrity sha512-C4U4n4HVqc7kW9MQbx6AcyCbyZzib/X6GVPZqVZdkYddsjOola5YGHngQJw5YpDe1VRYDktDYhBTSFSP6Awu/g==
+"@makeswift/runtime@^0.1.8":
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/@makeswift/runtime/-/runtime-0.1.8.tgz#ae14ffce5ef433549d63826781808cd8744141b9"
+  integrity sha512-5H1KcX4TMk17UT1KXDABi7esG/DV1YIowqYtamX2VG9ANlqfAm38mgWrPFgYFfFS7jgicVPSSfNlJbvCGRtQ3Q==
   dependencies:
     "@apollo/client" "^3.5.10"
     "@convertkit/slate-lists" "^0.2.4"


### PR DESCRIPTION
Regardless of the 404'ing, I don't think we are going to get passed on demand revalidation for the product pages

As for reproducing the problem of 404 on the home page: I found that when I created the Makeswift site and published pages before I deployed the custom host there wasn't really any issues with there being a 404. I think I am going to advice users during the video to take that route