### PR TITLE
fix: avoid using next/link for relative paths

### DIFF
--- a/.changeset/silent-boxes-fry.md
+++ b/.changeset/silent-boxes-fry.md
@@ -1,0 +1,6 @@
+---
+'@makeswift/runtime': patch
+---
+
+Avoid using `next/link` with relative paths. `next/link` pre-pends the current page's path to
+relative paths and this is often undesirable.


### PR DESCRIPTION
Using next/link with relative paths in dynamic routes resulted in
Next.js pre-pending the route in the path and messing up the URL.