### PR TITLE
fix: default width for Carousel, Countdown, Video

### DIFF
--- a/.changeset/neat-ligers-complain.md
+++ b/.changeset/neat-ligers-complain.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+Fix: default width for Carousel, Countdown, and Video components

--- a/packages/runtime/src/components/builtin/Carousel/Carousel.tsx
+++ b/packages/runtime/src/components/builtin/Carousel/Carousel.tsx
@@ -83,7 +83,7 @@ const Wrapper = styled.div.withConfig({
   position: relative;
   display: flex;
   flex-direction: column;
-  ${cssWidth()}
+  ${cssWidth('400px')}
   ${cssMargin()}
 
   &:focus {

--- a/packages/runtime/src/components/builtin/Countdown/Countdown.tsx
+++ b/packages/runtime/src/components/builtin/Countdown/Countdown.tsx
@@ -83,7 +83,7 @@ const Container = styled.div.withConfig({
   labelFont?: ResponsiveValue<string>
 }>`
   display: flex;
-  ${cssWidth()}
+  ${cssWidth('560px')}
   ${cssMargin()}
   ${p =>
     cssMediaRules([p.size] as const, ([size = 'medium']) => {

--- a/packages/runtime/src/components/builtin/Video/Video.tsx
+++ b/packages/runtime/src/components/builtin/Video/Video.tsx
@@ -26,7 +26,7 @@ const Container = styled.div.withConfig({
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  ${cssWidth()}
+  ${cssWidth('560px')}
   ${cssMargin()}
   ${cssBorderRadius()}
 `


### PR DESCRIPTION
It seems that these were lost when we migrated to emotion.