### PR TITLE
fix: remove throw that is preventing product 404

### DIFF
--- a/examples/bigcommerce/components/product-details.tsx
+++ b/examples/bigcommerce/components/product-details.tsx
@@ -46,7 +46,7 @@ export function ProductBreadcrumbs({ className }: ProductBreadcrumbProps) {
         All Plants
       </Link>
       <div className="text-black/60">/</div>
-      <Link className="text-black" href={'/'}>
+      <Link className="text-black" href={`/product/${product.entityId}`}>
         {product.name}
       </Link>
     </div>

--- a/examples/bigcommerce/lib/bigcommerce/api.ts
+++ b/examples/bigcommerce/lib/bigcommerce/api.ts
@@ -99,9 +99,7 @@ export async function getCategories(): Promise<Category[]> {
   return result.data.site.categoryTree
 }
 
-export async function getProduct(id?: number): Promise<ProductFragment> {
-  if (id == null) return DEFAULT_PRODUCT
-
+export async function getProduct(id: number): Promise<ProductFragment | null> {
   const config = getConfig()
   const apiToken = await getApiToken()
   const response = await fetch(
@@ -130,7 +128,5 @@ export async function getProduct(id?: number): Promise<ProductFragment> {
 
   const [productEdge] = result.data.site.products.edges
 
-  if (productEdge == null) throw new Error(`Product with ID "${id}" not found.`)
-
-  return productEdge.node
+  return productEdge?.node ?? null
 }

--- a/examples/bigcommerce/pages/[[...path]].tsx
+++ b/examples/bigcommerce/pages/[[...path]].tsx
@@ -6,7 +6,7 @@ import {
 } from '@makeswift/runtime/next'
 import { GetStaticPropsContext, GetStaticPropsResult } from 'next'
 
-import { getProduct, getProducts } from 'lib/bigcommerce'
+import { DEFAULT_PRODUCT, getProducts } from 'lib/bigcommerce'
 import { PageProps } from 'lib/types'
 
 type Props = MakeswiftPageProps & PageProps
@@ -19,7 +19,7 @@ export async function getStaticProps(
   if (!('props' in makeswiftResult)) return makeswiftResult
 
   const products = await getProducts()
-  const product = await getProduct()
+  const product = DEFAULT_PRODUCT
 
   return { ...makeswiftResult, props: { ...makeswiftResult.props, products, product } }
 }

--- a/examples/bigcommerce/pages/makeswift.tsx
+++ b/examples/bigcommerce/pages/makeswift.tsx
@@ -7,7 +7,7 @@ import {
 import { GetServerSidePropsContext, GetServerSidePropsResult } from 'next'
 
 import { PageProps } from 'lib/types'
-import { getProduct, getProducts } from '../lib/bigcommerce'
+import { DEFAULT_PRODUCT, getProducts } from '../lib/bigcommerce'
 
 type Props = MakeswiftPageProps & PageProps
 
@@ -19,7 +19,7 @@ export async function getServerSideProps(
   if (!('props' in makeswiftResult)) return makeswiftResult
 
   const products = await getProducts()
-  const product = await getProduct()
+  const product = DEFAULT_PRODUCT
 
   return {
     ...makeswiftResult,

--- a/examples/shopify/components/product-details.tsx
+++ b/examples/shopify/components/product-details.tsx
@@ -47,7 +47,7 @@ export function ProductBreadcrumbs({ className }: ProductBreadcrumbProps) {
         All Plants
       </Link>
       <div className="text-black/60">/</div>
-      <Link className="text-black" href={'/'}>
+      <Link className="text-black" href={`/product/${product.handle}`}>
         {product.title}
       </Link>
     </div>

--- a/examples/shopify/lib/shopify/api.ts
+++ b/examples/shopify/lib/shopify/api.ts
@@ -80,9 +80,7 @@ export async function getCollections(): Promise<Collection[]> {
   return result.data.collections.edges.map(edge => edge.node)
 }
 
-export async function getProduct(handle?: string): Promise<ProductFragment> {
-  if (handle == null) return DEFAULT_PRODUCT
-
+export async function getProduct(handle: string): Promise<ProductFragment | null> {
   const config = getConfig()
   const response = await fetch(
     `https://${config.shopify.storeName}.myshopify.com/api/2022-07/graphql.json`,

--- a/examples/shopify/lib/shopify/index.ts
+++ b/examples/shopify/lib/shopify/index.ts
@@ -1,3 +1,4 @@
 export * from './api'
 export * from './graphql'
 export * from './types'
+export * from './default-values'

--- a/examples/shopify/lib/shopify/types.ts
+++ b/examples/shopify/lib/shopify/types.ts
@@ -67,7 +67,7 @@ export type ProductsQuery = {
 }
 
 export type ProductQuery = {
-  product: ProductFragment
+  product: ProductFragment | null
 }
 
 export type CartLineFragment = {

--- a/examples/shopify/pages/[[...path]].tsx
+++ b/examples/shopify/pages/[[...path]].tsx
@@ -6,7 +6,7 @@ import {
 } from '@makeswift/runtime/next'
 import { GetStaticPropsContext, GetStaticPropsResult } from 'next'
 
-import { getProduct, getProducts } from 'lib/shopify'
+import { getProducts, DEFAULT_PRODUCT } from 'lib/shopify'
 import { PageProps } from 'lib/types'
 
 type Props = MakeswiftPageProps & PageProps
@@ -19,7 +19,7 @@ export async function getStaticProps(
   if (!('props' in makeswiftResult)) return makeswiftResult
 
   const products = await getProducts()
-  const product = await getProduct()
+  const product = DEFAULT_PRODUCT
 
   return {
     ...makeswiftResult,

--- a/examples/shopify/pages/makeswift.tsx
+++ b/examples/shopify/pages/makeswift.tsx
@@ -7,7 +7,7 @@ import {
 import { GetServerSidePropsContext, GetServerSidePropsResult } from 'next'
 
 import { PageProps } from 'lib/types'
-import { getProduct, getProducts } from 'lib/shopify'
+import { getProducts, DEFAULT_PRODUCT } from 'lib/shopify'
 
 type Props = MakeswiftPageProps & PageProps
 
@@ -19,7 +19,7 @@ export async function getServerSideProps(
   if (!('props' in makeswiftResult)) return makeswiftResult
 
   const products = await getProducts()
-  const product = await getProduct()
+  const product = DEFAULT_PRODUCT
 
   return {
     ...makeswiftResult,


### PR DESCRIPTION
Currently this line is causing `/product/foobar` to 500 instead of 404.