### PR TITLE
fix: Preview Mode rewrites

### DIFF
--- a/.changeset/rotten-peas-beg.md
+++ b/.changeset/rotten-peas-beg.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/next-plugin': patch
+---
+
+Fix Preview Mode rewrite source so that it matches `/`.

--- a/packages/makeswift-next-plugin/index.js
+++ b/packages/makeswift-next-plugin/index.js
@@ -36,7 +36,7 @@ module.exports =
                   value: '(?<secret>.+)',
                 },
               ],
-              source: '/:path*',
+              source: '/:path(.*)',
               destination: '/api/makeswift/proxy-preview-mode',
             },
             {
@@ -47,7 +47,7 @@ module.exports =
                   value: '(?<secret>.+)',
                 },
               ],
-              source: '/:path*',
+              source: '/:path(.*)',
               destination: '/api/makeswift/proxy-preview-mode',
             },
             ...(Array.isArray(rewrites) ? [] : rewrites?.beforeFiles ?? []),


### PR DESCRIPTION
For some reason, when deployed on Vercel, rewrites weren't matching the `/` path. It seems that Vercel's infratructure uses different logic to match rewrites than Next.js.