### PR TITLE
hotfix: next plugin errors when `headers` is null.

### DIFF
--- a/.changeset/polite-chairs-approve.md
+++ b/.changeset/polite-chairs-approve.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/next-plugin': patch
+---
+
+Hotfix: next plugin errors when `headers` is null.

--- a/packages/makeswift-next-plugin/index.js
+++ b/packages/makeswift-next-plugin/index.js
@@ -59,7 +59,7 @@ module.exports =
         }
       },
       async headers() {
-        const headers = await nextConfig.headers?.()
+        const headers = (await nextConfig.headers?.()) ?? []
 
         return [
           ...headers,


### PR DESCRIPTION
Holy `js` didn't catch this.

The error:
<img width="1103" alt="image" src="https://user-images.githubusercontent.com/13066728/197583819-9878b73d-aed0-4bcf-8d80-953d1c113069.png">

With this hotfix, I tested with no `headers`, CORS is working. Tested with `headers`, other `headers` are still applied.