### PR TITLE
fix: column with a dot not recording data

### DIFF
--- a/.changeset/grumpy-suits-retire.md
+++ b/.changeset/grumpy-suits-retire.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Fix table column names containing a period cause the form to not record data for that column.

--- a/packages/runtime/src/components/builtin/Form/components/Field/index.tsx
+++ b/packages/runtime/src/components/builtin/Form/components/Field/index.tsx
@@ -126,7 +126,10 @@ export default function Field({
   }
 
   return (
-    <FormikField name={tableColumn.name} validate={validate}>
+    // We're using `['${tableColumn.name}']` to avoid default Formik nested object behavior
+    // which was causing an issue for table column names containing a dot.
+    // https://formik.org/docs/guides/arrays#avoid-nesting
+    <FormikField name={`['${tableColumn.name}']`} validate={validate}>
       {({ field, form }: any) =>
         hidden ? (
           <input {...field} ref={input} type="hidden" />


### PR DESCRIPTION
https://user-images.githubusercontent.com/13066728/204128016-2b3971ae-557e-415e-b646-f9f7eb075efc.mp4

The malformed form (no pun intended) was causing the `CreateTableRecord` mutation to send the wrong data for the field containing a dot.

I tested the fix and it's properly added to the database.