### PR TITLE
fix: [ ] ' in table column causing data to not be recorded.

### DIFF
--- a/.changeset/unlucky-carrots-remain.md
+++ b/.changeset/unlucky-carrots-remain.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Fix apostrophe in table column causing form data to not be recorded.

--- a/packages/runtime/src/components/builtin/Form/components/Field/index.tsx
+++ b/packages/runtime/src/components/builtin/Form/components/Field/index.tsx
@@ -85,6 +85,11 @@ type Props = {
   tableFormField: TableFormField
 }
 
+// Escape characters: [ ] '
+function escapeCharacters(string: string) {
+  return string.replace(/[[\]']/g, '\\$&')
+}
+
 export default function Field({
   tableColumn,
   tableFormField: {
@@ -125,11 +130,17 @@ export default function Field({
     return errorMessage
   }
 
+  // We're using `['${tableColumn.name}']` to avoid default Formik nested object behavior
+  // which was causing an issue for table column names containing a dot.
+  // https://formik.org/docs/guides/arrays#avoid-nesting
+  // We need to escape square brackets [ ] because it's also used by Lodash
+  // set array: https://lodash.com/docs/4.17.15#set, which is used by Formik.
+  // We need to escape ' because otherwise Formik will wrap the field name inside a ''
+  // for example, if we have hello'world, Formik will name the field 'hello'world'
+  const formikFieldName = `['${escapeCharacters(tableColumn.name)}']`
+
   return (
-    // We're using `['${tableColumn.name}']` to avoid default Formik nested object behavior
-    // which was causing an issue for table column names containing a dot.
-    // https://formik.org/docs/guides/arrays#avoid-nesting
-    <FormikField name={`['${tableColumn.name}']`} validate={validate}>
+    <FormikField name={formikFieldName} validate={validate}>
       {({ field, form }: any) =>
         hidden ? (
           <input {...field} ref={input} type="hidden" />


### PR DESCRIPTION
## Background

Previously, we had an issue where a dot `.` in a table column name was causing the data for that column to not be recorded. This was caused by [Formik nested object behavior](https://formik.org/docs/guides/arrays#avoid-nesting). We fixed that by wrapping the value to be `['${tableColumn.name}']`.

## New problem

This causes a new problem where an apostrophe `'` in a table column name was causing the data for that column to not be recorded again. This is happening because Formik is wrapping the name inside a quote`'`. For example, if we have a column name of `hello'world`, formik will change it to `'hello'world`.

## Fix

We fix this by escaping the `'` character, before passing it to Formik. We also need to escape `[` and `]` because it's used by [Lodash set array](https://lodash.com/docs/4.17.15#set) that Formik is using.

## Proof

To make sure that no other characters are causing the same problem, I test it by making a table column name with all ASCII characters:
```
!"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~
```
I also tested a random Unicode string:
```
⽡≱⎒⥬⇍┅ⅎ⽭⊥⼅⸠⢒␙ⅉ⬅₝⧣ⷃ⪇⏘⌔⣊Ⲧ▧⦺⑕⦩⎢⥌➘ⓢ⵾Ⓙ⨮ ⃋⇻ⵎ⓶⮦⧽⮢⾔ⳤ┒␩⑲⣂ⶽ⣃⃎⸅⢷⋗␡⃖➙⧮⎣⾑⤠⤗⨨≇⇊❘✝⿽✧⛮⾆₫◉⾐ℌ┈⧰⾂⦀⩌✄⏵⢥↪⛧‎⸫℥ⳡ⃐⨤⮦⸬☧⾴⛧⃔⬌ⲱ␤
```


https://user-images.githubusercontent.com/13066728/205008308-8794a89e-d26e-4df5-b3dc-10e2f8f9f5d5.mp4

