### PR TITLE
fix: CORS issues with headers

### DIFF
--- a/.changeset/thin-mirrors-behave.md
+++ b/.changeset/thin-mirrors-behave.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Fix issue where patched fetch API was sending Preview Mode header to a separate origin, causing CORS problems.

--- a/packages/runtime/src/next/preview-mode.tsx
+++ b/packages/runtime/src/next/preview-mode.tsx
@@ -28,11 +28,17 @@ if (window.parent !== window) {
       } else {
         const originalFetch = window.fetch
 
-        window.fetch = function patchedFetch(input, init) {
-          return originalFetch.call(this, input, {
-            ...init,
-            headers: { ...init?.headers, [headerName]: secret },
-          })
+        window.fetch = function patchedFetch(resource, options) {
+          const request = new Request(resource, options)
+
+          if (new URL(request.url).origin !== window.location.origin) {
+            return originalFetch.call(this, resource, options)
+          }
+
+          return originalFetch.call(
+            this,
+            new Request(request, { headers: { [headerName]: secret } }),
+          )
         }
       }
     }


### PR DESCRIPTION
When sending a request to a separate origin, we need to make sure we don't include the Preview Mode header because the
Access-Control-Allow-Headers response header might prevent the request. Because we're patching `fetch` we need to make sure normal requests don't fail.