### PR TITLE
fix: falsy check on Style control utils

### DIFF
--- a/.changeset/tender-hairs-argue.md
+++ b/.changeset/tender-hairs-argue.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Fix falsy check on Style control CSS utility functions. This caused falsy `0` values to be ignored for margin, padding, border, and border radius.

--- a/packages/runtime/src/css/border-radius.ts
+++ b/packages/runtime/src/css/border-radius.ts
@@ -51,19 +51,19 @@ export function borderRadiusPropertyDataToStyle(
   const borderBottomLeftRadius = data.borderBottomLeftRadius ?? defaultValue.borderBottomLeftRadius
   const style: CSSObject = {}
 
-  if (borderTopLeftRadius) {
+  if (borderTopLeftRadius != null) {
     style.borderTopLeftRadius = lengthPercentageDataToString(borderTopLeftRadius)
   }
 
-  if (borderTopRightRadius) {
+  if (borderTopRightRadius != null) {
     style.borderTopRightRadius = lengthPercentageDataToString(borderTopRightRadius)
   }
 
-  if (borderBottomRightRadius) {
+  if (borderBottomRightRadius != null) {
     style.borderBottomRightRadius = lengthPercentageDataToString(borderBottomRightRadius)
   }
 
-  if (borderBottomLeftRadius) {
+  if (borderBottomLeftRadius != null) {
     style.borderBottomLeftRadius = lengthPercentageDataToString(borderBottomLeftRadius)
   }
 

--- a/packages/runtime/src/css/border.ts
+++ b/packages/runtime/src/css/border.ts
@@ -64,10 +64,10 @@ export function borderPropertyDataToStyle(
   const borderLeft = data.borderLeft ?? defaultValue.borderLeft
   const style: CSSObject = {}
 
-  if (borderTop) style.borderTop = borderSideToString(borderTop)
-  if (borderRight) style.borderRight = borderSideToString(borderRight)
-  if (borderBottom) style.borderBottom = borderSideToString(borderBottom)
-  if (borderLeft) style.borderLeft = borderSideToString(borderLeft)
+  if (borderTop != null) style.borderTop = borderSideToString(borderTop)
+  if (borderRight != null) style.borderRight = borderSideToString(borderRight)
+  if (borderBottom != null) style.borderBottom = borderSideToString(borderBottom)
+  if (borderLeft != null) style.borderLeft = borderSideToString(borderLeft)
 
   return style
 }

--- a/packages/runtime/src/css/margin.ts
+++ b/packages/runtime/src/css/margin.ts
@@ -38,10 +38,10 @@ export function marginPropertyDataToStyle(
   const marginLeft = data.marginLeft ?? defaultValue.marginLeft
   const style: CSSObject = {}
 
-  if (marginTop) style.marginTop = lengthDataToString(marginTop)
-  if (marginRight) style.marginRight = lengthDataToString(marginRight)
-  if (marginBottom) style.marginBottom = lengthDataToString(marginBottom)
-  if (marginLeft) style.marginLeft = lengthDataToString(marginLeft)
+  if (marginTop != null) style.marginTop = lengthDataToString(marginTop)
+  if (marginRight != null) style.marginRight = lengthDataToString(marginRight)
+  if (marginBottom != null) style.marginBottom = lengthDataToString(marginBottom)
+  if (marginLeft != null) style.marginLeft = lengthDataToString(marginLeft)
 
   return style
 }

--- a/packages/runtime/src/css/padding.ts
+++ b/packages/runtime/src/css/padding.ts
@@ -42,10 +42,10 @@ export function paddingPropertyDataToStyle(
   const paddingLeft = data.paddingLeft ?? defaultValue.paddingLeft
   const style: CSSObject = {}
 
-  if (paddingTop) style.paddingTop = lengthDataToString(paddingTop)
-  if (paddingRight) style.paddingRight = lengthDataToString(paddingRight)
-  if (paddingBottom) style.paddingBottom = lengthDataToString(paddingBottom)
-  if (paddingLeft) style.paddingLeft = lengthDataToString(paddingLeft)
+  if (paddingTop != null) style.paddingTop = lengthDataToString(paddingTop)
+  if (paddingRight != null) style.paddingRight = lengthDataToString(paddingRight)
+  if (paddingBottom != null) style.paddingBottom = lengthDataToString(paddingBottom)
+  if (paddingLeft != null) style.paddingLeft = lengthDataToString(paddingLeft)
 
   return style
 }


### PR DESCRIPTION
We did a falsy check instead of checking for `undefined` or `null` explicitly, causing `0` values to be ignored for margin, padding, border, and border-radius, due to `0` being falsy.