### PR TITLE
Fix SSR hydration issue with ReactPlayer and API resource cache issues

### DIFF
--- a/.changeset/proud-otters-hammer.md
+++ b/.changeset/proud-otters-hammer.md
@@ -1,0 +1,7 @@
+---
+'@makeswift/runtime': patch
+---
+
+Fix SSR hydration mismatch due to attempting to render ReactPlayer on the server.
+
+See https://github.com/cookpete/react-player/issues/1428.

--- a/.changeset/twelve-knives-count.md
+++ b/.changeset/twelve-knives-count.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Fix issue where API resource cache was filled too late resulting in unnecessary API requests.

--- a/packages/runtime/src/api/react.tsx
+++ b/packages/runtime/src/api/react.tsx
@@ -76,10 +76,6 @@ export class MakeswiftClient {
     return MakeswiftApiClient.getSerializedState(this.makeswiftApiClient.getState())
   }
 
-  updateCacheData(cacheData: CacheData): void {
-    this.makeswiftApiClient.dispatch(MakeswiftApiClient.restoreAPIResourcesCache(cacheData))
-  }
-
   readSwatch(swatchId: string): Swatch | null {
     return MakeswiftApiClient.getAPIResource(
       this.makeswiftApiClient.getState(),

--- a/packages/runtime/src/components/builtin/Video/Video.tsx
+++ b/packages/runtime/src/components/builtin/Video/Video.tsx
@@ -1,5 +1,5 @@
 import { cx } from '@emotion/css'
-import { forwardRef, Ref } from 'react'
+import { forwardRef, Ref, useEffect, useState } from 'react'
 import ReactPlayer from 'react-player'
 
 import { ElementIDValue, VideoValue } from '../../../prop-controllers/descriptors'
@@ -21,6 +21,14 @@ const Video = forwardRef(function Video(
   ref: Ref<HTMLDivElement>,
 ) {
   const canPlayUrl = video && video.url != null && ReactPlayer.canPlay(video.url)
+  /**
+   * @see https://github.com/cookpete/react-player/issues/1428
+   */
+  const [shouldRenderReactPlayer, setShouldRenderReactPlayer] = useState(false)
+
+  useEffect(() => {
+    setShouldRenderReactPlayer(true)
+  }, [])
 
   return (
     <div
@@ -35,7 +43,7 @@ const Video = forwardRef(function Video(
     >
       <div style={{ position: 'relative', paddingTop: `${100 / ASPECT_RATIO}%` }}>
         <div style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}>
-          {canPlayUrl === true ? (
+          {shouldRenderReactPlayer && canPlayUrl === true ? (
             <ReactPlayer
               {...video}
               width="100%"

--- a/packages/runtime/src/next/index.tsx
+++ b/packages/runtime/src/next/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useState } from 'react'
+import { memo, useMemo } from 'react'
 
 import { RuntimeProvider } from '../runtimes/react'
 import { Page as PageMeta } from '../components/page'
@@ -121,17 +121,14 @@ export async function getServerSideProps(
 }
 
 export const Page = memo(({ snapshot }: PageProps) => {
-  const [client] = useState(
+  const client = useMemo(
     () =>
       new MakeswiftClient({
         uri: new URL('graphql', snapshot.apiOrigin).href,
         cacheData: snapshot.cacheData,
       }),
+    [snapshot],
   )
-
-  useEffect(() => {
-    client.updateCacheData(snapshot.cacheData)
-  }, [client, snapshot])
 
   return (
     <RuntimeProvider

--- a/packages/runtime/src/state/actions.ts
+++ b/packages/runtime/src/state/actions.ts
@@ -13,7 +13,6 @@ import type { APIResource, APIResourceType, Typography } from '../api/graphql/ty
 import type { SerializedControl } from '../builder'
 import { IntrospectedResourcesQueryResult } from '../api/graphql/generated/types'
 import { IntrospectedResourceIds } from '../api/introspection'
-import { SerializedState } from './modules/api-resources'
 
 export const ActionTypes = {
   INIT: 'INIT',
@@ -66,8 +65,6 @@ export const ActionTypes = {
   API_RESOURCE_FULFILLED: 'API_RESOURCE_FULFILLED',
   INTROSPECTED_RESOURCES_FULFILLED: 'INTROSPECTED_RESOURCES_FULFILLED',
   TYPOGRAPHIES_FULFILLED: 'TYPOGRAPHIES_FULFILLED',
-
-  RESTORE_API_RESOURCES_CACHE: 'RESTORE_API_RESOURCES_CACHE',
 } as const
 
 type InitAction = { type: typeof ActionTypes.INIT }
@@ -254,11 +251,6 @@ type TypographiesFulfilledAction = {
   payload: { typographyIds: string[]; typographies: (Typography | null)[] }
 }
 
-type RestoreAPIResourcesCacheAction = {
-  type: typeof ActionTypes.RESTORE_API_RESOURCES_CACHE
-  payload: { serializedState: SerializedState }
-}
-
 export type Action =
   | InitAction
   | CleanUpAction
@@ -295,7 +287,6 @@ export type Action =
   | APIResourceFulfilledAction
   | IntrospectedResourcesFulfilled
   | TypographiesFulfilledAction
-  | RestoreAPIResourcesCacheAction
 
 export function init(): InitAction {
   return { type: ActionTypes.INIT }
@@ -611,10 +602,4 @@ export function introspectedResourcesFulfilled(
     type: ActionTypes.INTROSPECTED_RESOURCES_FULFILLED,
     payload: { introspectedResourceIds, introspectedResources },
   }
-}
-
-export function restoreAPIResourcesCache(
-  serializedState: SerializedState,
-): RestoreAPIResourcesCacheAction {
-  return { type: ActionTypes.RESTORE_API_RESOURCES_CACHE, payload: { serializedState } }
 }

--- a/packages/runtime/src/state/makeswift-api-client.ts
+++ b/packages/runtime/src/state/makeswift-api-client.ts
@@ -6,7 +6,6 @@ import {
   Action,
   apiResourceFulfilled,
   typographiesFulfilled,
-  restoreAPIResourcesCache,
   introspectedResourcesFulfilled,
 } from './actions'
 import { APIResource, APIResourceType, Typography } from '../api'
@@ -181,8 +180,6 @@ export function fetchTypographies(typographyIds: string[]): Thunk<Promise<(Typog
     return typographies
   }
 }
-
-export { restoreAPIResourcesCache }
 
 export type Dispatch = ThunkDispatch<State, GraphQLClient, Action>
 

--- a/packages/runtime/src/state/modules/api-resources.ts
+++ b/packages/runtime/src/state/modules/api-resources.ts
@@ -46,9 +46,6 @@ export function getAPIResource<T extends APIResourceType>(
 
 export function reducer(state: State = getInitialState(), action: Action): State {
   switch (action.type) {
-    case ActionTypes.RESTORE_API_RESOURCES_CACHE:
-      return getInitialState(action.payload.serializedState)
-
     case ActionTypes.API_RESOURCE_FULFILLED: {
       const { resourceType, resourceId, resource } = action.payload
 


### PR DESCRIPTION
# Fix SSR hydration issue with ReactPlayer

See https://github.com/cookpete/react-player/issues/1428 for more information about why ReactPlayer shouldn't be rendered on the server. Ideally this is something that would be handled internally by the ReactPlayer component, but alas, we must take care of it ourselves. We should replace ReactPlayer with a more robust solution for our built-in Video component.

# Fix API resource cache late update

---
Resolves PRD-948