### PR TITLE
chore: move `MakeswiftComponentType` to main.js

### DIFF
--- a/.changeset/modern-drinks-yawn.md
+++ b/.changeset/modern-drinks-yawn.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Move `MakeswiftComponentType` from `@makeswift/runtime/components` to `@makeswift/runtime`

--- a/packages/runtime/src/components/builtin/index.ts
+++ b/packages/runtime/src/components/builtin/index.ts
@@ -12,5 +12,3 @@ export { default as Root } from './Root'
 export { default as SocialLinks } from './SocialLinks'
 export { default as Text } from './Text'
 export { default as Video } from './Video'
-
-export { MakeswiftComponentType } from './constants'

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -20,3 +20,4 @@ export type {
 } from './prop-controllers'
 export type { Element } from './state/react-page'
 export { createDocument } from './state/react-page'
+export { MakeswiftComponentType } from './components/builtin/constants'


### PR DESCRIPTION
We need MakeswiftComponentType on the builder, but we don't want to import it from `@makeswift/runtime/components` because we only need the constant, and not other things that's included in the components entrypoint.