### PR TITLE
fix: snippets don't run on client-side navigation

### DIFF
--- a/.changeset/quick-carpets-fly.md
+++ b/.changeset/quick-carpets-fly.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Fix snippets don't run on client-side navigation.

--- a/packages/runtime/src/next/index.tsx
+++ b/packages/runtime/src/next/index.tsx
@@ -136,7 +136,8 @@ export const Page = memo(({ snapshot }: PageProps) => {
       rootElements={new Map([[snapshot.document.id, snapshot.document.data]])}
       preview={snapshot.preview}
     >
-      <PageMeta document={snapshot.document} />
+      {/* We use a key here to reset the Snippets state in the PageMeta component */}
+      <PageMeta key={snapshot.document.data.key} document={snapshot.document} />
     </RuntimeProvider>
   )
 })


### PR DESCRIPTION
Because we're using a useState for snippets in Page, when we change the document/page, the Page component is still preserving the old state, which was for the old document/ page.

We add key to reset the snippets state, when the document/page is changed.

https://beta.reactjs.org/learn/preserving-and-resetting-state

https://user-images.githubusercontent.com/13066728/214278992-4affaa87-7b09-45f5-a66f-2c129d3f329b.mp4


