### PR TITLE
fix: input not rendered on a single select column

### DIFF
--- a/.changeset/flat-squids-search.md
+++ b/.changeset/flat-squids-search.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Fix the single select column not rendering radio buttons on the built-in Form component.

--- a/packages/runtime/src/components/builtin/Form/components/Field/components/RadioButton/index.tsx
+++ b/packages/runtime/src/components/builtin/Form/components/Field/components/RadioButton/index.tsx
@@ -22,9 +22,10 @@ type ContainerBaseProps = Pick<Value, 'size'>
 type ContainerProps = ContainerBaseProps &
   Omit<ComponentPropsWithoutRef<'div'>, keyof ContainerBaseProps>
 
-function Container({ size }: ContainerProps) {
+function Container({ size, className, ...restOfProps }: ContainerProps) {
   return (
     <div
+      {...restOfProps}
       className={cx(
         useStyle({ position: 'relative' }),
         useStyle(
@@ -33,6 +34,7 @@ function Container({ size }: ContainerProps) {
             width: getSize(size),
           })),
         ),
+        className,
       )}
     />
   )


### PR DESCRIPTION
It was because we were not passing the children prop on the Container