### PR TITLE
New element selection algorithm based on Document.elementFromPoint

### DIFF
--- a/.changeset/few-trains-stare.md
+++ b/.changeset/few-trains-stare.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Use builder pointer information and DOM APIs to reliably determine the active element. This guarantees that the Makeswift builder can properly select elements even if their CSS box models overlap (e.g., absolute and fixed position elements).

--- a/packages/runtime/src/components/builtin/Box/Box.tsx
+++ b/packages/runtime/src/components/builtin/Box/Box.tsx
@@ -90,6 +90,9 @@ const Box = forwardRef(function Box(
   useImperativeHandle(
     ref,
     () => ({
+      getDomNode() {
+        return boxElementObjectRef.current
+      },
       getBoxModel() {
         const paddingBoxElement = innerRef.current
         const borderBoxElement = innerRef.current

--- a/packages/runtime/src/components/builtin/Form/Form.tsx
+++ b/packages/runtime/src/components/builtin/Form/Form.tsx
@@ -301,6 +301,9 @@ const Form = forwardRef(function Form(
   useImperativeHandle(
     ref,
     () => ({
+      getDomNode() {
+        return refEl instanceof Element ? refEl : null
+      },
       getBoxModel() {
         return refEl instanceof Element ? getBox(refEl) : null
       },

--- a/packages/runtime/src/components/builtin/Text/EditableText.tsx
+++ b/packages/runtime/src/components/builtin/Text/EditableText.tsx
@@ -69,6 +69,11 @@ const EditableText = forwardRef(function EditableText(
   useImperativeHandle(
     ref,
     () => ({
+      getDomNode() {
+        const el = editor?.findDOMNode([])
+
+        return el instanceof Element ? el : null
+      },
       getBoxModel() {
         const el = editor?.findDOMNode([])
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -13,6 +13,7 @@ export {
   unregisterDocument,
   setBuilderEditMode,
   changePathname,
+  builderPointerMove,
 } from './state/actions'
 export type { Operation } from './state/modules/read-write-documents'
 export type { ComponentMeta } from './state/modules/components-meta'

--- a/packages/runtime/src/next/api-handler.ts
+++ b/packages/runtime/src/next/api-handler.ts
@@ -34,6 +34,7 @@ export type MakeswiftApiHandlerManifestResponse = {
   previewMode: boolean
   interactionMode: boolean
   clientSideNavigation: boolean
+  elementFromPoint: boolean
 }
 export type MakeswiftApiHandlerFontsResponse = Fonts
 export type MakeswiftApiHandlerElementTreeResponse = { elementTree: any }
@@ -114,6 +115,7 @@ export function MakeswiftApiHandler(
           previewMode: true,
           interactionMode: true,
           clientSideNavigation: true,
+          elementFromPoint: true,
         })
       }
 

--- a/packages/runtime/src/runtimes/react/element-imperative-handle.ts
+++ b/packages/runtime/src/runtimes/react/element-imperative-handle.ts
@@ -36,4 +36,29 @@ export class ElementImperativeHandle<
 
     this.lastPropControllers = propControllers
   }
+
+  getDomNode(): Element | null {
+    const current = this.getCurrent()
+
+    if (isDomNodeHandle(current)) return current.getDomNode()
+
+    return current instanceof Element ? current : null
+  }
+}
+
+type DomNodeHandle = {
+  getDomNode(): Element | null
+}
+
+export function isDomNodeHandle(value: unknown): value is DomNodeHandle {
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    'getDomNode' in value &&
+    typeof (value as { getDomNode: unknown }).getDomNode === 'function'
+  ) {
+    return true
+  }
+
+  return false
 }

--- a/packages/runtime/src/state/actions.ts
+++ b/packages/runtime/src/state/actions.ts
@@ -15,6 +15,7 @@ import { IntrospectedResourcesQueryResult } from '../api/graphql/generated/types
 import { IntrospectedResourceIds } from '../api/introspection'
 import { ElementImperativeHandle } from '../runtimes/react/element-imperative-handle'
 import { BuilderEditMode } from './modules/builder-edit-mode'
+import type { Point } from './modules/pointer'
 
 export const ActionTypes = {
   INIT: 'INIT',
@@ -75,6 +76,9 @@ export const ActionTypes = {
   CHANGE_PATHNAME: 'CHANGE_PATHNAME',
   CHANGE_PATHNAME_START: 'CHANGE_PATHNAME_START',
   CHANGE_PATHNAME_COMPLETE: 'CHANGE_PATHNAME_COMPLETE',
+
+  BUILDER_POINTER_MOVE: 'BUILDER_POINTER_MOVE',
+  ELEMENT_FROM_POINT_CHANGE: 'ELEMENT_FROM_POINT_CHANGE',
 } as const
 
 type InitAction = { type: typeof ActionTypes.INIT }
@@ -279,6 +283,16 @@ type ChangePathnameCompleteAction = {
   type: typeof ActionTypes.CHANGE_PATHNAME_COMPLETE
 }
 
+type BuilderPointerMoveAction = {
+  type: typeof ActionTypes.BUILDER_POINTER_MOVE
+  payload: { pointer: Point | null }
+}
+
+type ElementFromPointChangeAction = {
+  type: typeof ActionTypes.ELEMENT_FROM_POINT_CHANGE
+  payload: { keys: { documentKey: string; elementKey: string } | null }
+}
+
 export type Action =
   | InitAction
   | CleanUpAction
@@ -319,6 +333,8 @@ export type Action =
   | ChangePathnameAction
   | ChangePathnameStartAction
   | ChangePathnameCompleteAction
+  | BuilderPointerMoveAction
+  | ElementFromPointChangeAction
 
 export function init(): InitAction {
   return { type: ActionTypes.INIT }
@@ -660,4 +676,17 @@ export function changePathnameComplete(): ChangePathnameCompleteAction {
   return {
     type: ActionTypes.CHANGE_PATHNAME_COMPLETE,
   }
+}
+
+export function builderPointerMove(pointer: Point | null): BuilderPointerMoveAction {
+  return { type: ActionTypes.BUILDER_POINTER_MOVE, payload: { pointer } }
+}
+
+export function elementFromPointChange(
+  keys: {
+    documentKey: string
+    elementKey: string
+  } | null,
+): ElementFromPointChangeAction {
+  return { type: ActionTypes.ELEMENT_FROM_POINT_CHANGE, payload: { keys } }
 }

--- a/packages/runtime/src/state/modules/element-imperative-handles.ts
+++ b/packages/runtime/src/state/modules/element-imperative-handles.ts
@@ -1,0 +1,40 @@
+import { ElementImperativeHandle } from '../../runtimes/react/element-imperative-handle'
+import { Action, ActionTypes } from '../actions'
+
+type State = Map<string, Map<string, ElementImperativeHandle>>
+
+export function getElementImperativeHandles(
+  state: State,
+): Map<string, Map<string, ElementImperativeHandle>> {
+  return state
+}
+
+function getInitialState(): State {
+  return new Map()
+}
+
+export function reducer(state: State = getInitialState(), action: Action): State {
+  switch (action.type) {
+    case ActionTypes.REGISTER_COMPONENT_HANDLE:
+      return new Map(state).set(
+        action.payload.documentKey,
+        new Map(new Map(state.get(action.payload.documentKey) ?? [])).set(
+          action.payload.elementKey,
+          action.payload.componentHandle,
+        ),
+      )
+
+    case ActionTypes.UNREGISTER_COMPONENT_HANDLE: {
+      const byElementKey = new Map(state.get(action.payload.documentKey) ?? [])
+
+      const deleted = byElementKey.delete(action.payload.elementKey)
+
+      if (!deleted) return state
+
+      return new Map(state).set(action.payload.documentKey, byElementKey)
+    }
+
+    default:
+      return state
+  }
+}

--- a/packages/runtime/src/state/modules/pointer.ts
+++ b/packages/runtime/src/state/modules/pointer.ts
@@ -1,0 +1,25 @@
+import { Action, ActionTypes } from '../actions'
+
+export type Point = { x: number; y: number }
+
+type State = {
+  pointer: Point | null
+}
+
+function getInitialState(): State {
+  return { pointer: null }
+}
+
+export function getPointer(state: State): Point | null {
+  return state.pointer
+}
+
+export function reducer(state: State = getInitialState(), action: Action): State {
+  switch (action.type) {
+    case ActionTypes.BUILDER_POINTER_MOVE:
+      return { ...state, pointer: action.payload.pointer }
+
+    default:
+      return state
+  }
+}


### PR DESCRIPTION
- Use builder pointer information and DOM APIs to reliably determine the active element. This guarantees that the Makeswift builder can properly select elements even if their CSS box models overlap (e.g., absolute and fixed position elements).

Resolves PRD-1294 and PRD-1293