### PR TITLE
chore: update CLI create-next-app to 13.1.6

### DIFF
--- a/packages/makeswift/package.json
+++ b/packages/makeswift/package.json
@@ -33,7 +33,7 @@
     "@babel/traverse": "^7.18.13",
     "chalk": "^4.1.2",
     "commander": "^9.4.0",
-    "create-next-app": "^12.3.1",
+    "create-next-app": "^13.1.6",
     "cross-spawn": "^7.0.3",
     "detect-port": "^1.3.0",
     "fs-extra": "^10.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3788,10 +3788,10 @@ cosmiconfig@^6.0.0:
     path-type "^4.0.0"
     yaml "^1.7.2"
 
-create-next-app@^12.3.1:
-  version "12.3.1"
-  resolved "https://registry.yarnpkg.com/create-next-app/-/create-next-app-12.3.1.tgz#251c53600d8a7eb0362b2b2a6fcd5529eaca2e82"
-  integrity sha512-dDEO+hs++58j+OdzK9ZZi4P8OPggERiXJ+p0SQhbqHfOgVxb3g/5H++XpCM0zy0nOS+1TCGeWp7+k+DW8GRYkA==
+create-next-app@^13.1.6:
+  version "13.1.6"
+  resolved "https://registry.yarnpkg.com/create-next-app/-/create-next-app-13.1.6.tgz#5d8fa03b44be1a1ddb0dad3eb5b80d9cc720415c"
+  integrity sha512-L0DajZKvef1aXt/kIxVWzlBYDH3/FVstGRM160M7/XWs4f6VyELgqfM9P0Tz0chDKg0DLhe1YQBZpyllY7rQhw==
 
 create-require@^1.1.0:
   version "1.1.1"


### PR DESCRIPTION
I can't find the change logs specific to `create-next-app`. This is the [commit history](https://github.com/vercel/next.js/commits/canary/packages/create-next-app) if we want to see all the changes.

I tested both for creating a fresh init and integrating from a create-next-app. It seems that both are still working. Not sure if there's anything specific that I need to test