### PR TITLE
Fix images not loading when using Next.js version 12.2.x

### DIFF
--- a/.changeset/twenty-mirrors-laugh.md
+++ b/.changeset/twenty-mirrors-laugh.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/next-plugin': patch
+---
+
+Fix images are not loading when using Next.js version `12.2.x`.

--- a/packages/makeswift-next-plugin/index.js
+++ b/packages/makeswift-next-plugin/index.js
@@ -37,7 +37,7 @@ module.exports =
   ({ resolveSymlinks, appOrigin = 'https://app.makeswift.com' } = {}) =>
   (nextConfig = {}) => {
     /** @type {NextConfig} */
-    const enhancedConfig = {
+    let enhancedConfig = {
       ...nextConfig,
       images: {
         ...nextConfig.images,
@@ -116,6 +116,23 @@ module.exports =
       throw new Error(
         'Makeswift requires a minimum Next.js version of 12.2.0. Please upgrade to Next.js version ^12.2.0 if you want to use Next.js v12, or version ^13.0.0 if you want to use Next.js v13.',
       )
+    }
+
+    if (satisfies(nextVersion, '<12.3.0')) {
+      enhancedConfig = {
+        ...enhancedConfig,
+        experimental: {
+          ...enhancedConfig.experimental,
+          images: {
+            ...enhancedConfig.experimental?.images,
+            remotePatterns: [
+              ...(enhancedConfig.experimental?.images?.remotePatterns ?? []),
+              ...NEXT_IMAGE_REMOTE_PATTERNS,
+              ...NEXT_IMAGE_REVIEW_APP_REMOTE_PATTERNS,
+            ],
+          },
+        },
+      }
     }
 
     if (satisfies(nextVersion, '<13.0.0')) {


### PR DESCRIPTION
On `@makeswift/runtime` version `0.7.0` we had an update that uses the `remotePatterns` feature, but it's only available from Next.js version `12.3.0` or higher.

So we can either drop support for `12.2.x` or add the experimental `remotePatterns` when they are using version `12.2.x`.