### PR TITLE
fix: element from point for global elements

### DIFF
--- a/.changeset/happy-spoons-reply.md
+++ b/.changeset/happy-spoons-reply.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Fix element from point selection issue for nested documents (i.e., global elements).

--- a/packages/runtime/src/state/modules/read-only-documents.ts
+++ b/packages/runtime/src/state/modules/read-only-documents.ts
@@ -43,7 +43,7 @@ export function getInitialState({
   return initialState
 }
 
-function getDocuments(state: State): Map<string, Document> {
+export function getDocuments(state: State): Map<string, Document> {
   return state
 }
 

--- a/packages/runtime/src/state/react-builder-preview.ts
+++ b/packages/runtime/src/state/react-builder-preview.ts
@@ -375,12 +375,18 @@ function elementKeysFromElementFromPoint(
       getState(),
       elementFromPoint,
     )
+    const acendingDepthDocumentKeys = ReactPage.getDocumentKeysSortedByDepth(getState())
+    const descendingDepthDocumentKeys = acendingDepthDocumentKeys.slice().reverse()
 
     let currentElement: Element | null = elementFromPoint
     let keys = null
 
     while (currentElement != null) {
-      for (const [documentKey, byElementKey] of elementImperativeHandles) {
+      for (const documentKey of descendingDepthDocumentKeys) {
+        const byElementKey = elementImperativeHandles.get(documentKey)
+
+        if (byElementKey == null) continue
+
         for (const [elementKey, elementImperativeHandle] of byElementKey) {
           if (elementImperativeHandle.getDomNode() === currentElement) {
             return { documentKey, elementKey }

--- a/packages/runtime/src/state/react-page.ts
+++ b/packages/runtime/src/state/react-page.ts
@@ -136,6 +136,28 @@ function getDocumentElements(state: State, documentKey: string): Map<string, Doc
   return normalizeElement(document.rootElement, descriptors)
 }
 
+/**
+ * Returns all document keys sorted by depth, i.e., parent documents come before child documents.
+ *
+ * @todo Make this selector more efficient.
+ */
+export function getDocumentKeysSortedByDepth(state: State): string[] {
+  const documents = Documents.getDocuments(getDocumentsStateSlice(state))
+  const keys = Array.from(documents.keys())
+
+  if (keys.length < 2) return keys
+
+  const elements = new Map<string, Map<string, Documents.Element>>()
+
+  keys.forEach(key => {
+    elements.set(key, getDocumentElements(state, key))
+  })
+
+  keys.sort((a, b) => (elements.get(a)?.has(b) ? -1 : 1))
+
+  return keys
+}
+
 export function getElement(
   state: State,
   documentKey: string,


### PR DESCRIPTION
Global element root element handles were conflicting with the handle of the element reference itself. This was resulting in element from point always returning the element handle for the element reference, even when focused on a global element.