### PR TITLE
chore: finish setup for slate plugins

### DIFF
--- a/.changeset/happy-turkeys-itch.md
+++ b/.changeset/happy-turkeys-itch.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Export types for slate rich text plugins.

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -15,7 +15,8 @@
     "next.js",
     "next/plugin.js",
     "builder.js",
-    "controls.js"
+    "controls.js",
+    "slate.js"
   ],
   "exports": {
     ".": {

--- a/packages/runtime/src/controls/rich-text/dto-types.ts
+++ b/packages/runtime/src/controls/rich-text/dto-types.ts
@@ -18,7 +18,7 @@ export const ObjectType = {
 
 export type ObjectType = typeof ObjectType[keyof typeof ObjectType]
 
-interface ValueJSON {
+export interface ValueJSON {
   object?: typeof ObjectType.Value | undefined
   document?: DocumentJSON | undefined
   selection?: SelectionJSON | undefined

--- a/packages/runtime/vite.config.ts
+++ b/packages/runtime/vite.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
         next: path.resolve(__dirname, 'src', 'next'),
         builder: path.resolve(__dirname, 'src', 'builder'),
         controls: path.resolve(__dirname, 'src', 'controls'),
+        slate: path.resolve(__dirname, 'src', 'slate'),
       },
       output: {
         entryFileNames: '[name].[format].js',


### PR DESCRIPTION
I'm moving the slate plugins into leo, but I don't want to forget these changes that were required to access the plugin from `@makeswift/runtime/slate`