### PR TITLE
fix: path normalization

### DIFF
--- a/.changeset/itchy-waves-pay.md
+++ b/.changeset/itchy-waves-pay.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Fix path normalization for client-side navigation.

--- a/packages/runtime/src/state/react-builder-preview.ts
+++ b/packages/runtime/src/state/react-builder-preview.ts
@@ -538,8 +538,8 @@ export function messageChannelMiddleware(): Middleware<Dispatch, State, Dispatch
             break
 
           case ActionTypes.CHANGE_PATHNAME: {
-            const pathname = action.payload.pathname.replace(/^\//, '')
-            const currentPathname = Router.asPath.replace(/^\//, '')
+            const pathname = action.payload.pathname.replace(/^\//, '/')
+            const currentPathname = Router.asPath.replace(/^\//, '/')
 
             if (pathname !== currentPathname) Router.push(pathname)
             break


### PR DESCRIPTION
By pushing a relative path, Next.js client-side navigation was broken. We now ensure paths start with a "/".