### PR TITLE
fix: change runtime to use ComponentIcon const

### DIFF
--- a/.changeset/nine-windows-join.md
+++ b/.changeset/nine-windows-join.md
@@ -1,0 +1,17 @@
+---
+"@makeswift/runtime": minor
+---
+
+BREAKING: When registering component icons, use the `ComponentIcon` enum (available under `@makeswift/runtime`) instead of the original string values. Below is a table of the deprecated string values and their new enum equivalent:
+
+| Removed           | Use Instead (enum)          |
+|-------------------|-----------------------------|
+| `'Carousel40'`    | `ComponentIcon.Carousel`    |
+| `'Code40'`        | `ComponentIcon.Code`        |
+| `'Countdown40'`   | `ComponentIcon.Countdown`   |
+| `'Cube40'`        | `ComponentIcon.Cube`        |
+| `'Divider40'`     | `ComponentIcon.Divider`     |
+| `'Form40'`        | `ComponentIcon.Form`        |
+| `'Navigation40'`  | `ComponentIcon.Navigation`  |
+| `'SocialLinks40'` | `ComponentIcon.SocialLinks` |
+| `'Video40'`       | `ComponentIcon.Video`       |

--- a/packages/runtime/src/components/builtin/Carousel/register.ts
+++ b/packages/runtime/src/components/builtin/Carousel/register.ts
@@ -7,6 +7,7 @@ import { ReactRuntime } from '../../../runtimes/react'
 import { findBreakpointOverride } from '../../../state/modules/breakpoints'
 
 import { MakeswiftComponentType } from '../constants'
+import { ComponentIcon } from '../../../state/modules/components-meta'
 
 export function registerComponent(runtime: ReactRuntime) {
   return runtime.registerComponent(
@@ -14,7 +15,7 @@ export function registerComponent(runtime: ReactRuntime) {
     {
       type: MakeswiftComponentType.Carousel,
       label: 'Carousel',
-      icon: 'Carousel40',
+      icon: ComponentIcon.Carousel,
       props: {
         id: Props.ElementID(),
         images: Props.Images({

--- a/packages/runtime/src/components/builtin/Countdown/register.ts
+++ b/packages/runtime/src/components/builtin/Countdown/register.ts
@@ -4,6 +4,7 @@ import { Props } from '../../../prop-controllers'
 import { ReactRuntime } from '../../../runtimes/react'
 import { getBaseBreakpoint } from '../../../state/modules/breakpoints'
 import { MakeswiftComponentType } from '../constants'
+import { ComponentIcon } from '../../../state/modules/components-meta'
 
 export function registerComponent(runtime: ReactRuntime) {
   return runtime.registerComponent(
@@ -11,7 +12,7 @@ export function registerComponent(runtime: ReactRuntime) {
     {
       type: MakeswiftComponentType.Countdown,
       label: 'Countdown',
-      icon: 'Countdown40',
+      icon: ComponentIcon.Countdown,
       props: {
         id: Props.ElementID(),
         date: Props.Date(() => ({

--- a/packages/runtime/src/components/builtin/Divider/register.ts
+++ b/packages/runtime/src/components/builtin/Divider/register.ts
@@ -3,6 +3,7 @@ import { forwardNextDynamicRef } from '../../../next'
 import { Props } from '../../../prop-controllers'
 import { ReactRuntime } from '../../../runtimes/react'
 import { MakeswiftComponentType } from '../constants'
+import { ComponentIcon } from '../../../state/modules/components-meta'
 
 export function registerComponent(runtime: ReactRuntime) {
   return runtime.registerComponent(
@@ -10,7 +11,7 @@ export function registerComponent(runtime: ReactRuntime) {
     {
       type: MakeswiftComponentType.Divider,
       label: 'Divider',
-      icon: 'Divider40',
+      icon: ComponentIcon.Divider,
       props: {
         id: Props.ElementID(),
         variant: Props.ResponsiveSelect({

--- a/packages/runtime/src/components/builtin/Embed/register.ts
+++ b/packages/runtime/src/components/builtin/Embed/register.ts
@@ -4,6 +4,7 @@ import { forwardNextDynamicRef } from '../../../next'
 import { Props } from '../../../prop-controllers'
 import { ReactRuntime } from '../../../runtimes/react'
 import { MakeswiftComponentType } from '../constants'
+import { ComponentIcon } from '../../../state/modules/components-meta'
 
 export function registerComponent(runtime: ReactRuntime) {
   return runtime.registerComponent(
@@ -11,7 +12,7 @@ export function registerComponent(runtime: ReactRuntime) {
     {
       type: MakeswiftComponentType.Embed,
       label: 'Embed',
-      icon: 'Code40',
+      icon: ComponentIcon.Code,
       props: {
         id: Props.ElementID(),
         html: Props.TextArea({ label: 'Code', rows: 20 }),

--- a/packages/runtime/src/components/builtin/Form/register.ts
+++ b/packages/runtime/src/components/builtin/Form/register.ts
@@ -6,6 +6,7 @@ import { ReactRuntime } from '../../../runtimes/react'
 import { findBreakpointOverride, getBaseBreakpoint } from '../../../state/modules/breakpoints'
 import { MakeswiftComponentType } from '../constants'
 import { Alignments, Contrast, Contrasts, Shapes, Sizes } from './context/FormContext'
+import { ComponentIcon } from '../../../state/modules/components-meta'
 
 export function registerComponent(runtime: ReactRuntime) {
   return runtime.registerComponent(
@@ -13,7 +14,7 @@ export function registerComponent(runtime: ReactRuntime) {
     {
       type: MakeswiftComponentType.Form,
       label: 'Form',
-      icon: 'Form40',
+      icon: ComponentIcon.Form,
       props: {
         id: Props.ElementID(),
         tableId: Props.Table(),

--- a/packages/runtime/src/components/builtin/Navigation/register.ts
+++ b/packages/runtime/src/components/builtin/Navigation/register.ts
@@ -5,6 +5,7 @@ import { NavigationLinksValue, ResponsiveValue } from '../../../prop-controllers
 import { ReactRuntime } from '../../../runtimes/react'
 import { findBreakpointOverride, getBaseBreakpoint } from '../../../state/modules/breakpoints'
 import { MakeswiftComponentType } from '../constants'
+import { ComponentIcon } from '../../../state/modules/components-meta'
 
 export function registerComponent(runtime: ReactRuntime) {
   return runtime.registerComponent(
@@ -12,7 +13,7 @@ export function registerComponent(runtime: ReactRuntime) {
     {
       type: MakeswiftComponentType.Navigation,
       label: 'Navigation',
-      icon: 'Navigation40',
+      icon: ComponentIcon.Navigation,
       props: {
         id: Props.ElementID(),
         links: Props.NavigationLinks(),

--- a/packages/runtime/src/components/builtin/SocialLinks/register.ts
+++ b/packages/runtime/src/components/builtin/SocialLinks/register.ts
@@ -6,6 +6,7 @@ import { SocialLinksValue } from '../../../prop-controllers/descriptors'
 import { ReactRuntime } from '../../../runtimes/react'
 import { getBaseBreakpoint } from '../../../state/modules/breakpoints'
 import { MakeswiftComponentType } from '../constants'
+import { ComponentIcon } from '../../../state/modules/components-meta'
 
 export function registerComponent(runtime: ReactRuntime) {
   return runtime.registerComponent(
@@ -13,7 +14,7 @@ export function registerComponent(runtime: ReactRuntime) {
     {
       type: MakeswiftComponentType.SocialLinks,
       label: 'Social Links',
-      icon: 'SocialLinks40',
+      icon: ComponentIcon.SocialLinks,
       props: {
         id: Props.ElementID(),
         links: Props.SocialLinks({

--- a/packages/runtime/src/components/builtin/Video/register.ts
+++ b/packages/runtime/src/components/builtin/Video/register.ts
@@ -4,6 +4,7 @@ import { forwardNextDynamicRef } from '../../../next'
 import { Props } from '../../../prop-controllers'
 import { ReactRuntime } from '../../../runtimes/react'
 import { MakeswiftComponentType } from '../constants'
+import { ComponentIcon } from '../../../state/modules/components-meta'
 
 export function registerComponent(runtime: ReactRuntime) {
   return runtime.registerComponent(
@@ -11,7 +12,7 @@ export function registerComponent(runtime: ReactRuntime) {
     {
       type: MakeswiftComponentType.Video,
       label: 'Video',
-      icon: 'Video40',
+      icon: ComponentIcon.Video,
       props: {
         id: Props.ElementID(),
         video: Props.Video({ preset: { controls: true } }),

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -18,6 +18,7 @@ export {
 } from './state/actions'
 export type { Operation } from './state/modules/read-write-documents'
 export type { ComponentMeta } from './state/modules/components-meta'
+export { ComponentIcon } from './state/modules/components-meta'
 export type {
   PropControllerDescriptor,
   PropControllerDescriptorValueType,

--- a/packages/runtime/src/runtimes/react/index.tsx
+++ b/packages/runtime/src/runtimes/react/index.tsx
@@ -56,7 +56,7 @@ export class ReactRuntime {
     {
       type,
       label,
-      icon = 'Cube40',
+      icon = ComponentIcon.Code,
       hidden = false,
       props,
     }: { type: string; label: string; icon?: ComponentIcon; hidden?: boolean; props?: P },
@@ -95,7 +95,7 @@ export class ReactRuntime {
     {
       type,
       label,
-      icon = 'Cube40',
+      icon = ComponentIcon.Cube,
       hidden = false,
       props,
     }: { type: string; label: string; icon?: ComponentIcon; hidden?: boolean; props?: P },

--- a/packages/runtime/src/state/modules/components-meta.ts
+++ b/packages/runtime/src/state/modules/components-meta.ts
@@ -1,15 +1,18 @@
 import { Action, ActionTypes } from '../actions'
 
-export type ComponentIcon =
-  | 'Carousel40'
-  | 'Code40'
-  | 'Countdown40'
-  | 'Cube40'
-  | 'Divider40'
-  | 'Form40'
-  | 'Navigation40'
-  | 'SocialLinks40'
-  | 'Video40'
+export const ComponentIcon = {
+  Carousel: 'carousel',
+  Code: 'code',
+  Countdown: 'countdown',
+  Cube: 'cube',
+  Divider: 'divider',
+  Form: 'form',
+  Navigation: 'navigation',
+  SocialLinks: 'social-links',
+  Video: 'video',
+} as const
+
+export type ComponentIcon = typeof ComponentIcon[keyof typeof ComponentIcon]
 
 export type ComponentMeta = { label: string; icon: ComponentIcon; hidden: boolean }
 

--- a/packages/runtime/src/state/react-page.test.tsx
+++ b/packages/runtime/src/state/react-page.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, test } from 'vitest'
 import { Slot, TextInput } from '../controls'
 import { registerComponent } from './actions'
 import * as ReactPage from './react-page'
+import { ComponentIcon } from './modules/components-meta'
 
 describe('ReactPage', () => {
   const store = createTestStore()
@@ -221,7 +222,7 @@ function createTestStore(): ReactPage.Store {
   store.dispatch(
     registerComponent(
       ElementType.Box,
-      { label: 'Box', icon: 'Cube40', hidden: false },
+      { label: 'Box', icon: ComponentIcon.Cube, hidden: false },
       { children: Slot() },
     ),
   )
@@ -229,7 +230,7 @@ function createTestStore(): ReactPage.Store {
   store.dispatch(
     registerComponent(
       ElementType.Button,
-      { label: 'Button', icon: 'Code40', hidden: false },
+      { label: 'Button', icon: ComponentIcon.Cube, hidden: false },
       { children: TextInput() },
     ),
   )


### PR DESCRIPTION
This breaking change uses an ComponentIcon const instead of a string literal union in the ComponentMeta. With this change, icons are no longer specified with a size attached. All component registrations have been updated to reflect this update.