### PR TITLE
feat: add new icon support to runtime

### DIFF
--- a/.changeset/silent-tomatoes-cheat.md
+++ b/.changeset/silent-tomatoes-cheat.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Adds 13 new icon options to the runtime that can be used when registering components.

--- a/packages/runtime/src/state/modules/components-meta.ts
+++ b/packages/runtime/src/state/modules/components-meta.ts
@@ -1,14 +1,27 @@
 import { Action, ActionTypes } from '../actions'
 
 export const ComponentIcon = {
+  Billing: 'billing',
+  Bolt: 'bolt',
+  Button: 'button',
   Carousel: 'carousel',
+  Chats: 'chats',
   Code: 'code',
   Countdown: 'countdown',
   Cube: 'cube',
+  Database: 'database',
   Divider: 'divider',
   Form: 'form',
+  Gallery: 'gallery',
+  Help: 'help',
+  Image: 'image',
+  Layout: 'layout',
+  Lock: 'lock',
   Navigation: 'navigation',
   SocialLinks: 'social-links',
+  Star: 'star',
+  Text: 'text',
+  Users: 'users',
   Video: 'video',
 } as const
 


### PR DESCRIPTION
Introduces 13 new icons to the Makeswift runtime