### PR TITLE
chore: remove circular deps for MakeswiftApiHandler

### DIFF
--- a/packages/runtime/src/api/react.tsx
+++ b/packages/runtime/src/api/react.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { createContext, ReactNode, useContext } from 'react'
 
 import * as MakeswiftApiClient from '../state/makeswift-api-client'

--- a/packages/runtime/src/components/page/Page.tsx
+++ b/packages/runtime/src/components/page/Page.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { ReactElement, Children, createElement, useMemo, useEffect, useRef, useState } from 'react'
 import { useSyncExternalStore } from 'use-sync-external-store/shim'
 import parse from 'html-react-parser'

--- a/packages/runtime/src/controls/rich-text/translation.ts
+++ b/packages/runtime/src/controls/rich-text/translation.ts
@@ -9,7 +9,7 @@ import {
   RichTextDTO,
   ObjectType,
 } from './dto-types'
-import { Inline, InlineType, RichTextDAO, BlockType } from '../../slate'
+import { Inline, InlineType, RichTextDAO, BlockType } from '../../slate/types'
 
 // reimplemented from slate source for code splitting
 function isText(node: any): node is Text {

--- a/packages/runtime/src/controls/shape.ts
+++ b/packages/runtime/src/controls/shape.ts
@@ -1,5 +1,9 @@
-import { PropControllerMessage } from '../prop-controllers'
-import { AnyPropController, createPropController, Send } from '../prop-controllers/instances'
+import {
+  AnyPropController,
+  createPropController,
+  Send,
+  PropControllerMessage,
+} from '../prop-controllers/instances'
 import { PropController } from '../prop-controllers/base'
 import { CopyContext } from '../state/react-page'
 import { ControlDefinition, ControlDefinitionData } from './control'

--- a/packages/runtime/src/next/client.ts
+++ b/packages/runtime/src/next/client.ts
@@ -35,9 +35,14 @@ import {
   TypographyQueryVariables,
 } from '../api/graphql/generated/types'
 import { CacheData } from '../api/react'
-import { ListControlData, ListControlType, ShapeControlData, ShapeControlType } from '../controls'
-import { PropControllerDescriptor } from '../prop-controllers'
-import { ListValue, ShapeValue, Types } from '../prop-controllers/descriptors'
+import { ShapeControlData, ShapeControlType } from '../controls/shape'
+import { ListControlData, ListControlType } from '../controls/list'
+import {
+  ListValue,
+  ShapeValue,
+  Types,
+  Descriptor as PropControllerDescriptor,
+} from '../prop-controllers/descriptors'
 import {
   getElementChildren,
   getElementSwatchIds,

--- a/packages/runtime/src/next/document.tsx
+++ b/packages/runtime/src/next/document.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { cache } from '@emotion/css'
 import createEmotionServer from '@emotion/server/create-instance'
 import NextDocument, {

--- a/packages/runtime/src/prop-controllers/descriptors.ts
+++ b/packages/runtime/src/prop-controllers/descriptors.ts
@@ -11,6 +11,7 @@ import type { Element, Data } from '../state/react-page'
 import type { ResponsiveColor } from '../runtimes/react/controls'
 import { NumberControlDefinition } from '../controls/number'
 import { NumberControlValue } from '../runtimes/react/controls/number'
+import { StyleControlType } from '../controls/style'
 import {
   CheckboxControlDefinition,
   ColorControlDefinition,
@@ -24,7 +25,6 @@ import {
   TextAreaControlDefinition,
   TextInputControlDefinition,
   StyleControlDefinition,
-  StyleControlType,
   RichTextV2ControlDefinition,
   StyleV2ControlDefinition,
 } from '../controls'

--- a/packages/runtime/src/runtimes/react/index.tsx
+++ b/packages/runtime/src/runtimes/react/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import {
   ComponentPropsWithoutRef,
   createContext,


### PR DESCRIPTION
## What/why?

Removes the circular dependencies for the `MakeswiftApiHandler` route and also starts to add `use client` directives where needed.

_**Note: The modules using `use client` still won't work since rollup strips these directives on build.**_

## Next steps
We now got it to a point where we can start to build a new module for supporting NextJS route handlers. We need to determine what the public API will need to look like before we can continue down that path.

## Testing/proof
Got the app directory working up to the point of needing a new interface for route handlers:
<img width="788" alt="Screenshot 2023-06-01 at 08 48 06" src="https://github.com/makeswift/makeswift/assets/10539418/d0c7e302-1cf1-4f57-b128-36bfc563972f">
