### PR TITLE
feat: add fonts config to the ReactRuntime

### DIFF
--- a/.changeset/tasty-bikes-warn.md
+++ b/.changeset/tasty-bikes-warn.md
@@ -1,0 +1,8 @@
+---
+'@makeswift/runtime': minor
+---
+
+Adds setting the fonts in the `ReactRuntime` rather than `MakeswiftApiHandler`.
+
+`getFonts` within the `MakeswiftApiHandler` is now considered deprecated and will
+be removed in a future version of `@makeswift/runtime`.

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -15,6 +15,7 @@ export {
   changePathname,
   builderPointerMove,
   setBreakpoints,
+  setFonts,
   setLocale,
   setLocales,
 } from './state/actions'

--- a/packages/runtime/src/next/api-handler/handlers/manifest.ts
+++ b/packages/runtime/src/next/api-handler/handlers/manifest.ts
@@ -9,6 +9,7 @@ export type Manifest = {
   elementFromPoint: boolean
   customBreakpoints: boolean
   unstable_siteVersions: boolean
+  postMessageFonts: boolean
 }
 
 type ManifestError = { message: string }
@@ -32,5 +33,6 @@ export default async function handler(
     elementFromPoint: false,
     customBreakpoints: true,
     unstable_siteVersions,
+    postMessageFonts: true,
   })
 }

--- a/packages/runtime/src/next/api-handler/index.ts
+++ b/packages/runtime/src/next/api-handler/index.ts
@@ -15,6 +15,7 @@ export type { Manifest, Font }
 type MakeswiftApiHandlerConfig = {
   appOrigin?: string
   apiOrigin?: string
+  /** @deprecated Use the `fonts` option in the `ReactRuntime` constructor instead. */
   getFonts?: GetFonts
   unstable_siteVersions?: boolean
 }

--- a/packages/runtime/src/runtimes/react/index.tsx
+++ b/packages/runtime/src/runtimes/react/index.tsx
@@ -45,6 +45,7 @@ import {
   parseBreakpointsInput,
 } from '../../state/modules/breakpoints'
 import { LocalesInput, parseLocalesInput } from '../../state/modules/locales'
+import { Fonts, parseFontsInput } from '../../state/modules/fonts'
 
 export class ReactRuntime {
   // TODO: the static methods here are deprecated and only keep here for backward-compatibility purpose.
@@ -128,10 +129,12 @@ export class ReactRuntime {
 
   constructor({
     breakpoints,
+    fonts,
     unstable_i18n,
-  }: { breakpoints?: BreakpointsInput; unstable_i18n?: LocalesInput } = {}) {
+  }: { breakpoints?: BreakpointsInput; fonts?: Fonts; unstable_i18n?: LocalesInput } = {}) {
     this.store = ReactPage.configureStore({
       breakpoints: breakpoints ? parseBreakpointsInput(breakpoints) : undefined,
+      fonts: fonts ? parseFontsInput(fonts) : undefined,
       locales: unstable_i18n ? parseLocalesInput(unstable_i18n) : undefined,
     })
 

--- a/packages/runtime/src/state/actions.ts
+++ b/packages/runtime/src/state/actions.ts
@@ -17,6 +17,7 @@ import { BuilderEditMode } from './modules/builder-edit-mode'
 import type { Point } from './modules/pointer'
 import { Breakpoints } from './modules/breakpoints'
 import { LocaleString, localeStringSchema } from '../../types/locale'
+import { Fonts } from './modules/fonts'
 
 export const ActionTypes = {
   INIT: 'INIT',
@@ -80,6 +81,8 @@ export const ActionTypes = {
   ELEMENT_FROM_POINT_CHANGE: 'ELEMENT_FROM_POINT_CHANGE',
 
   SET_BREAKPOINTS: 'SET_BREAKPOINTS',
+
+  SET_FONTS: 'SET_FONTS',
 
   SET_LOCALES: 'SET_LOCALES',
   SET_LOCALE: 'SET_LOCALE',
@@ -290,6 +293,11 @@ export type SetBreakpointsAction = {
   payload: { breakpoints: Breakpoints }
 }
 
+export type SetFontsAction = {
+  type: typeof ActionTypes.SET_FONTS
+  payload: { fonts: Fonts }
+}
+
 type SetLocalesAction = {
   type: typeof ActionTypes.SET_LOCALES
   payload: { locales: LocaleString[] }
@@ -346,6 +354,7 @@ export type Action =
   | BuilderPointerMoveAction
   | ElementFromPointChangeAction
   | SetBreakpointsAction
+  | SetFontsAction
   | SetLocalesAction
   | SetLocaleAction
   | SetDefaultLocaleAction
@@ -690,6 +699,10 @@ export function elementFromPointChange(
 
 export function setBreakpoints(breakpoints: Breakpoints): SetBreakpointsAction {
   return { type: ActionTypes.SET_BREAKPOINTS, payload: { breakpoints } }
+}
+
+export function setFonts(fonts: Fonts): SetFontsAction {
+  return { type: ActionTypes.SET_FONTS, payload: { fonts } }
 }
 
 export function setLocales(locales: Intl.Locale[]): SetLocalesAction {

--- a/packages/runtime/src/state/modules/fonts.ts
+++ b/packages/runtime/src/state/modules/fonts.ts
@@ -1,0 +1,53 @@
+import z from 'zod'
+
+import { Action, ActionTypes } from '../actions'
+
+const FontVariant = z.object({
+  weight: z.string({ required_error: 'Font variant weight is required' }),
+  style: z.union([z.literal('italic'), z.literal('normal')], {
+    required_error: 'Font variant style is required',
+  }),
+  src: z.string().optional(),
+})
+
+export type FontVariant = z.infer<typeof FontVariant>
+
+const Font = z.object({
+  family: z.string({ required_error: 'Font family is required' }),
+  variants: z.array(FontVariant).min(1, 'At least one font variant is required'),
+})
+
+export type Font = z.infer<typeof Font>
+
+export type Fonts = Font[]
+
+export type State = Fonts
+
+export const DEFAULT_FONTS: Fonts = []
+
+export function getInitialState(fonts = DEFAULT_FONTS): State {
+  return fonts
+}
+
+export function reducer(state: State = getInitialState(), action: Action): State {
+  switch (action.type) {
+    case ActionTypes.SET_FONTS: {
+      return action.payload.fonts
+    }
+
+    default:
+      return state
+  }
+}
+
+export function parseFontsInput(input: Fonts): Fonts {
+  const parsedFonts = Font.array().safeParse(input)
+
+  if (!parsedFonts.success) {
+    const formattedError = parsedFonts.error.format()
+
+    throw new Error(`Invalid fonts input: \n\n${formattedError._errors.join('\n')}`)
+  }
+
+  return parsedFonts.data
+}

--- a/packages/runtime/src/state/react-builder-preview.ts
+++ b/packages/runtime/src/state/react-builder-preview.ts
@@ -25,6 +25,7 @@ import * as BuilderEditMode from './modules/builder-edit-mode'
 import * as Pointer from './modules/pointer'
 import * as ElementImperativeHandles from './modules/element-imperative-handles'
 import * as Breakpoints from './modules/breakpoints'
+import * as Fonts from './modules/fonts'
 import * as Locales from './modules/locales'
 import * as ReactPage from './react-page'
 import {
@@ -51,6 +52,7 @@ import {
   setLocales,
   setLocale,
   setDefaultLocale,
+  setFonts,
 } from './actions'
 import { ActionTypes } from './actions'
 import { createPropController } from '../prop-controllers/instances'
@@ -76,6 +78,7 @@ const reducer = combineReducers({
   pointer: Pointer.reducer,
   elementImperativeHandles: ElementImperativeHandles.reducer,
   breakpoints: Breakpoints.reducer,
+  fonts: Fonts.reducer,
   locales: Locales.reducer,
 })
 
@@ -499,6 +502,9 @@ export function messageChannelMiddleware(): Middleware<Dispatch, State, Dispatch
 
       const breakpoints = ReactPage.getBreakpoints(state)
       messageChannel.port1.postMessage(setBreakpoints(breakpoints))
+
+      const fonts = ReactPage.getFonts(state)
+      messageChannel.port1.postMessage(setFonts(fonts))
 
       const locales = ReactPage.getLocales(state)
       const defaultLocale = ReactPage.getDefaultLocale(state)

--- a/packages/runtime/src/state/react-page.ts
+++ b/packages/runtime/src/state/react-page.ts
@@ -16,6 +16,7 @@ import * as IsInBuilder from './modules/is-in-builder'
 import * as IsPreview from './modules/is-preview'
 import * as BuilderEditMode from './modules/builder-edit-mode'
 import * as Breakpoints from './modules/breakpoints'
+import * as Fonts from './modules/fonts'
 import * as Locales from './modules/locales'
 import * as Introspection from '../prop-controllers/introspection'
 import { Action } from './actions'
@@ -47,6 +48,7 @@ const reducer = combineReducers({
   isPreview: IsPreview.reducer,
   builderEditMode: BuilderEditMode.reducer,
   breakpoints: Breakpoints.reducer,
+  fonts: Fonts.reducer,
   locales: Locales.reducer,
 })
 
@@ -380,6 +382,10 @@ export function getBuilderEditMode(state: State): BuilderEditMode.State {
   return state.builderEditMode
 }
 
+export function getFonts(state: State): Fonts.State {
+  return state.fonts
+}
+
 export function getBreakpoints(state: State): Breakpoints.State {
   return state.breakpoints
 }
@@ -404,11 +410,13 @@ export function configureStore({
   rootElements,
   preloadedState,
   breakpoints,
+  fonts,
   locales,
 }: {
   rootElements?: Map<string, Documents.Element>
   preloadedState?: PreloadedState<State>
   breakpoints?: Breakpoints.State
+  fonts?: Fonts.State
   locales?: Locales.State
 } = {}): Store {
   return createStore(
@@ -417,6 +425,7 @@ export function configureStore({
       ...preloadedState,
       documents: Documents.getInitialState({ rootElements }),
       breakpoints: Breakpoints.getInitialState(breakpoints ?? preloadedState?.breakpoints),
+      fonts: Fonts.getInitialState(fonts ?? preloadedState?.fonts),
       locales: Locales.getInitialState(locales ?? preloadedState?.locales),
     },
     applyMiddleware(thunk),


### PR DESCRIPTION
## What/why?

Adds registering fonts as apart of the `ReactRuntime` instead of the `MakeswiftApiHandler`. This is some prep work to get fonts out of the API handlers since it should be the concern of the runtime, not the API.

![Screenshot 2023-06-23 at 14 07 15](https://github.com/makeswift/makeswift/assets/10539418/92eefbeb-2a45-40c5-b1a0-43257d9015f0)