### PR TITLE
chore: remove localization unstable_ prefix

### DIFF
--- a/.changeset/funny-onions-sip.md
+++ b/.changeset/funny-onions-sip.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Remove the `unstable_` prefix for `unstable_i18n` and `unstable_locale`.

--- a/packages/runtime/src/next/client.ts
+++ b/packages/runtime/src/next/client.ts
@@ -418,8 +418,8 @@ export class Makeswift {
     pathname: string,
     {
       preview: previewOverride = false,
-      unstable_locale,
-    }: { preview?: boolean; unstable_locale?: string } = {},
+      locale: localeInput,
+    }: { preview?: boolean; locale?: string } = {},
   ): Promise<MakeswiftPageSnapshot | null> {
     const isUsingVersioning = this.siteVersion != null
     const siteVersion =
@@ -427,7 +427,7 @@ export class Makeswift {
       (previewOverride ? MakeswiftSiteVersion.Working : MakeswiftSiteVersion.Live)
 
     const defaultLocale = getDefaultLocale(this.runtime.store.getState())?.toString()
-    const locale = unstable_locale === defaultLocale ? null : unstable_locale
+    const locale = localeInput === defaultLocale ? null : localeInput
     const searchParams = new URLSearchParams()
     if (locale) {
       const locales = getLocales(this.runtime.store.getState()).map(locale => locale.toString())

--- a/packages/runtime/src/runtimes/react/index.tsx
+++ b/packages/runtime/src/runtimes/react/index.tsx
@@ -126,13 +126,10 @@ export class ReactRuntime {
     return ReactPage.getBreakpoints(this.store.getState())
   }
 
-  constructor({
-    breakpoints,
-    unstable_i18n,
-  }: { breakpoints?: BreakpointsInput; unstable_i18n?: LocalesInput } = {}) {
+  constructor({ breakpoints, i18n }: { breakpoints?: BreakpointsInput; i18n?: LocalesInput } = {}) {
     this.store = ReactPage.configureStore({
       breakpoints: breakpoints ? parseBreakpointsInput(breakpoints) : undefined,
-      locales: unstable_i18n ? parseLocalesInput(unstable_i18n) : undefined,
+      locales: i18n ? parseLocalesInput(i18n) : undefined,
     })
 
     registerBuiltinComponents(this)


### PR DESCRIPTION
Example usage:
```ts
export const runtime = new ReactRuntime({
  i18n: {
    locales: ["es", "en-US", "es-SE", "id-ID", "ba-LU", "aa-AL"],
    defaultLocale: "en-US",
  },
});
```
on `getPageSnapshot`:
```ts
const snapshot = await makeswift.getPageSnapshot(path, {
  preview: ctx.preview,
  locale: ctx.locale,
});
```