### PR TITLE
feat: use localized pathname on LinkControl

### DIFF
--- a/.changeset/light-drinks-heal.md
+++ b/.changeset/light-drinks-heal.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Use localized pathname on `LinkControl` and `Button` component if available.

--- a/.changeset/spicy-trainers-accept.md
+++ b/.changeset/spicy-trainers-accept.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Use the new REST API endpoint for `page-pathname-slices`.

--- a/packages/runtime/src/api/graphql/documents/queries.ts
+++ b/packages/runtime/src/api/graphql/documents/queries.ts
@@ -1,20 +1,15 @@
 import {
   FileFragment,
   GlobalElementFragment,
-  PagePathnameSliceFragment,
   SwatchFragment,
   TableFragment,
   TypographyFragment,
 } from './fragments'
 
 export const IntrospectedResourcesQuery = /* GraphQL */ `
-  query IntrospectedResources($fileIds: [ID!]!, $pageIds: [ID!]!, $tableIds: [ID!]!) {
+  query IntrospectedResources($fileIds: [ID!]!, $tableIds: [ID!]!) {
     files(ids: $fileIds) {
       ...File
-    }
-
-    pagePathnamesById(ids: $pageIds) {
-      ...PagePathnameSlice
     }
 
     tables(ids: $tableIds) {
@@ -23,7 +18,6 @@ export const IntrospectedResourcesQuery = /* GraphQL */ `
   }
 
   ${FileFragment}
-  ${PagePathnameSliceFragment}
   ${TableFragment}
 `
 
@@ -55,16 +49,6 @@ export const TypographyQuery = /* GraphQL */ `
   }
 
   ${TypographyFragment}
-`
-
-export const PagePathnamesByIdQuery = /* GraphQL */ `
-  query PagePathnamesById($pageIds: [ID!]!) {
-    pagePathnamesById(ids: $pageIds) {
-      ...PagePathnameSlice
-    }
-  }
-
-  ${PagePathnameSliceFragment}
 `
 
 export const TableQuery = /* GraphQL */ `

--- a/packages/runtime/src/api/graphql/documents/queries.ts
+++ b/packages/runtime/src/api/graphql/documents/queries.ts
@@ -1,7 +1,6 @@
 import {
   FileFragment,
   GlobalElementFragment,
-  LocalizedGlobalElementFragment,
   PagePathnameSliceFragment,
   SwatchFragment,
   TableFragment,
@@ -96,16 +95,6 @@ export const GlobalElementQuery = /* GraphQL */ `
   }
 
   ${GlobalElementFragment}
-`
-
-export const LocalizedGlobalElementQuery = /* GraphQL */ `
-  query LocalizedGlobalElement($globalElementId: ID!, $locale: Locale!) {
-    localizedGlobalElement(globalElementId: $globalElementId, locale: $locale) {
-      ...LocalizedGlobalElement
-    }
-  }
-
-  ${LocalizedGlobalElementFragment}
 `
 
 export const CreateTableRecordMutation = /* GraphQL */ `

--- a/packages/runtime/src/api/graphql/generated/types.ts
+++ b/packages/runtime/src/api/graphql/generated/types.ts
@@ -152,7 +152,6 @@ export type SiteFragment = {
 
 export type IntrospectedResourcesQueryVariables = Exact<{
   fileIds: Array<Scalars['ID']> | Scalars['ID']
-  pageIds: Array<Scalars['ID']> | Scalars['ID']
   tableIds: Array<Scalars['ID']> | Scalars['ID']
 }>
 
@@ -165,7 +164,6 @@ export type IntrospectedResourcesQueryResult = {
     publicUrl: string
     dimensions: { width: number; height: number } | null
   } | null>
-  pagePathnamesById: Array<{ __typename: 'PagePathnameSlice'; id: string; pathname: string } | null>
   tables: Array<{
     __typename: 'Table'
     id: string
@@ -249,14 +247,6 @@ export type TypographyQueryResult = {
       }
     }>
   } | null
-}
-
-export type PagePathnamesByIdQueryVariables = Exact<{
-  pageIds: Array<Scalars['ID']> | Scalars['ID']
-}>
-
-export type PagePathnamesByIdQueryResult = {
-  pagePathnamesById: Array<{ __typename: 'PagePathnameSlice'; id: string; pathname: string } | null>
 }
 
 export type TableQueryVariables = Exact<{

--- a/packages/runtime/src/api/graphql/generated/types.ts
+++ b/packages/runtime/src/api/graphql/generated/types.ts
@@ -328,15 +328,6 @@ export type GlobalElementQueryResult = {
   globalElement: { __typename: 'GlobalElement'; id: string; data: Json } | null
 }
 
-export type LocalizedGlobalElementQueryVariables = Exact<{
-  globalElementId: Scalars['ID']
-  locale: Scalars['Locale']
-}>
-
-export type LocalizedGlobalElementQueryResult = {
-  localizedGlobalElement: { __typename: 'LocalizedGlobalElement'; id: string; data: Json }
-}
-
 export type CreateTableRecordMutationVariables = Exact<{
   input: CreateTableRecordInput
 }>

--- a/packages/runtime/src/api/react.tsx
+++ b/packages/runtime/src/api/react.tsx
@@ -188,7 +188,7 @@ export class MakeswiftClient {
 
   async fetchPagePathnameSlice(pageId: string): Promise<PagePathnameSlice | null> {
     return await this.makeswiftApiClient.dispatch(
-      MakeswiftApiClient.fetchAPIResource(APIResourceType.PagePathnameSlice, pageId),
+      MakeswiftApiClient.fetchAPIResource(APIResourceType.PagePathnameSlice, pageId, this.locale),
     )
   }
 

--- a/packages/runtime/src/next/api-handler/index.ts
+++ b/packages/runtime/src/next/api-handler/index.ts
@@ -132,7 +132,9 @@ export function MakeswiftApiHandler(
     }
 
     if ((m = matches<{ id: string }>('/page-pathname-slices/:id'))) {
-      return client.getPagePathnameSlice(m.params.id).then(handleResource)
+      const locale = typeof req.query.locale === 'string' ? req.query.locale : undefined
+
+      return client.getPagePathnameSlice(m.params.id, { locale }).then(handleResource)
     }
 
     if ((m = matches<{ id: string }>('/tables/:id'))) {

--- a/packages/runtime/src/state/makeswift-api-client.ts
+++ b/packages/runtime/src/state/makeswift-api-client.ts
@@ -103,7 +103,7 @@ export function fetchAPIResource<T extends APIResourceType>(
 
       case APIResourceType.PagePathnameSlice:
         resource = await fetchJson<PagePathnameSlice>(
-          `/api/makeswift/page-pathname-slices/${resourceId}`,
+          `/api/makeswift/page-pathname-slices/${resourceId}?locale=${locale}`,
         )
         break
 


### PR DESCRIPTION
This PR focuses on getting the localized pathname.

For path-based localization, we don't have to worry about the `/es` prefix, because it's already handled by NextLink. For example, if I'm on `localhost/es/localization-1`, and I have a Button component set to Localization 2 page, then the link would be `localhost/es/localization-2`. But if I'm on `foo.es/localization-1`, then the link would be `foo.es/localization-2`.

There are several decisions that we need to make when implementing this:

1. Should we modify the existing `pagePathnamesById` query, or should we make a new query?
2. Should we reuse the existing `PagePathnameSlice` fragment, or should we make a new fragment?

For localized global elements, we have a new fragment and we have a new query because we thought that we would need both the base global element and the localized global element to be able to merge it in the runtime. But this is no longer the case because we decided to merge the element tree in our API instead.

Because of that, and because we only need the localized pathname and not the base pathname, I decided to reuse the existing query and fragment.

3. If we decided to reuse the existing `pagePathnamesById` query, should we return the `pageId`, or should we return the `localizedPageId` on the `PagePathnameSlice.id` field?

On the localized global element, we made it so that you query with `globalElement` and `locale`, and the API will return the `localizedGlobalElementId` as the `id`. This is working well, but we need to maintain a mapping of `globalElementId` to `localizedGlobalElementId`.

We could do a similar thing with this `PagePathnameSlice`. We query with `pageId` and `locale`, and the API will return `localizedPageId` as the `id`.

But in this MR, right now, I return the `pageId` instead. This is working well for now, and we don't need the mapping. I also think that `PagePathnameSlice` is not necessarily the `Page`. But this might bite us in the future if the builder also fetches `pagePathnamesById` and the cache normalization replaces the localized pathname with the non-localized one because the `id` of the `PagePathnameSlice` is the same. Right now the builder are not using `pagePathnameById` and `pagePathnamesById`.

With that being said, I still like this one because we abstract away the fact that there is a localized pathname on the runtime, and only the API knows about it. The runtime just query with `pageId` and `locale`, and use the `pathname` from the result.

Thoughts @migueloller?