### PR TITLE
chore: change basic-typescript deploy button names

### DIFF
--- a/examples/basic-typescript/README.md
+++ b/examples/basic-typescript/README.md
@@ -2,7 +2,7 @@
 
 ## Deploy your own with Vercel
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fmakeswift%2Fmakeswift%2Ftree%2Fmain%2Fexamples%2Fbasic-typescript&project-name=makeswift-basic-example&repository-name=makeswift-basic-example&redirect-url=https%3A%2F%2Fapp.makeswift.com&integration-ids=oac_51ryd7Pob5ZsyTFzNzVvpsGq)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fmakeswift%2Fmakeswift%2Ftree%2Fmain%2Fexamples%2Fbasic-typescript&project-name=makeswift-nextjs-starter&repository-name=makeswift-nextjs-starter&redirect-url=https%3A%2F%2Fapp.makeswift.com&integration-ids=oac_51ryd7Pob5ZsyTFzNzVvpsGq)
 
 ## Demo
 


### PR DESCRIPTION
Changes project and repo name to `makeswift-nextjs-starter`.