### PR TITLE
feat: fix Preview Mode proxy in Next.js v14

### DIFF
--- a/.changeset/angry-eggs-drive.md
+++ b/.changeset/angry-eggs-drive.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Fix Preview Mode proxy for localized pages in Next.js v14.

--- a/packages/runtime/src/next/api-handler/handlers/proxy-preview-mode.ts
+++ b/packages/runtime/src/next/api-handler/handlers/proxy-preview-mode.ts
@@ -29,8 +29,9 @@ export default async function proxyPreviewMode(
   ) as keyof NextApiRequest | undefined
   if (NextRequestMetaSymbol) {
     const nextRequestMeta = req[NextRequestMetaSymbol]
-    const initUrl = nextRequestMeta?.__NEXT_INIT_URL
-    const isLocaleStripped = nextRequestMeta?.__nextStrippedLocale
+    const initUrl = nextRequestMeta?.__NEXT_INIT_URL ?? nextRequestMeta?.initURL
+    const isLocaleStripped =
+      nextRequestMeta?.__nextStrippedLocale ?? nextRequestMeta?.didStripLocale
 
     try {
       if (isLocaleStripped && initUrl) req.url = new URL(initUrl).pathname


### PR DESCRIPTION
The hack we used to handle stripped locale paths broke when Next.js internals changed in v14.