### PR TITLE
fix: SocialLinks options

### DIFF
--- a/.changeset/afraid-ears-smell.md
+++ b/.changeset/afraid-ears-smell.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Fix SocialLinks component options.

--- a/.changeset/bright-tools-rhyme.md
+++ b/.changeset/bright-tools-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Remove X and Slack from `SocialLinkType`.

--- a/.changeset/twenty-points-jump.md
+++ b/.changeset/twenty-points-jump.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Add `'discord'` to `SocialLinkType`.

--- a/packages/runtime/src/components/builtin/SocialLinks/SocialLinks.tsx
+++ b/packages/runtime/src/components/builtin/SocialLinks/SocialLinks.tsx
@@ -3,13 +3,12 @@ import { ComponentPropsWithoutRef, forwardRef, Ref } from 'react'
 import { Link } from '../../shared/Link'
 import { colorToString } from '../../utils/colorToString'
 import { ColorValue as Color } from '../../utils/types'
-import { SocialLinksOptions } from './options'
+import { SocialLinksOptions, SocialLinksOptionType } from './options'
 import GutterContainer from '../../shared/GutterContainer'
 import SocialLinksPlaceholder from './components/SocialLinksPlaceholder'
 import {
   ResponsiveValue,
   ElementIDValue,
-  SocialLinksValue,
   ResponsiveIconRadioGroupValue,
   ResponsiveSelectValue,
   GapXValue,
@@ -21,7 +20,10 @@ import { useResponsiveStyle } from '../../utils/responsive-style'
 
 type Props = {
   id?: ElementIDValue
-  links?: SocialLinksValue
+  links?: {
+    links: { id: string; payload: { type: SocialLinksOptionType; url: string } }[]
+    openInNewTab: boolean
+  }
   shape?: ResponsiveIconRadioGroupValue<'naked' | 'circle' | 'rounded' | 'square'>
   size?: ResponsiveIconRadioGroupValue<'small' | 'medium' | 'large'>
   hoverStyle?: ResponsiveSelectValue<'none' | 'grow' | 'shrink' | 'fade'>

--- a/packages/runtime/src/components/builtin/SocialLinks/options.tsx
+++ b/packages/runtime/src/components/builtin/SocialLinks/options.tsx
@@ -47,7 +47,9 @@ export const SocialLinksOptions = [
   { type: 'twitter', label: 'Twitter', icon: <LogoTwitter20 />, brandColor: '#1da1f2' },
   { type: 'whatsapp', label: 'WhatsApp', icon: <LogoWhatsapp20 />, brandColor: '#25d366' },
   { type: 'vimeo', label: 'Vimeo', icon: <LogoVimeo20 />, brandColor: '#1ab7ea' },
-  { type: 'X', label: 'X', icon: <LogoX20 />, brandColor: 'black' },
+  { type: 'x', label: 'X', icon: <LogoX20 />, brandColor: 'black' },
   { type: 'yelp', label: 'Yelp', icon: <LogoYelp20 />, brandColor: '#af0606' },
   { type: 'youtube', label: 'YouTube', icon: <LogoYoutube20 />, brandColor: '#ff0000' },
 ] as const
+
+export type SocialLinksOptionType = typeof SocialLinksOptions[number]['type']

--- a/packages/runtime/src/prop-controllers/descriptors.ts
+++ b/packages/runtime/src/prop-controllers/descriptors.ts
@@ -994,6 +994,7 @@ export function getShapePropControllerSwatchIds(
 type SocialLinkType =
   | 'angellist'
   | 'codepen'
+  | 'discord'
   | 'dribbble'
   | 'facebook'
   | 'github'

--- a/packages/runtime/src/prop-controllers/descriptors.ts
+++ b/packages/runtime/src/prop-controllers/descriptors.ts
@@ -1004,7 +1004,6 @@ type SocialLinkType =
   | 'pinterest'
   | 'reddit'
   | 'rss'
-  | 'slack'
   | 'snapchat'
   | 'soundcloud'
   | 'spotify'
@@ -1014,7 +1013,6 @@ type SocialLinkType =
   | 'twitter'
   | 'vimeo'
   | 'whatsapp'
-  | 'x'
   | 'yelp'
   | 'youtube'
 


### PR DESCRIPTION
The TypeScript types weren't reflective of the supported options for the SocialLink component and there was a typo where the type for the X social link was in uppercase instead of lowercase.