### PR TITLE
feat: add type field to Number control

### DIFF
--- a/.changeset/cuddly-eels-sell.md
+++ b/.changeset/cuddly-eels-sell.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Added `type` field to the `Number` control

--- a/.changeset/strong-bananas-shake.md
+++ b/.changeset/strong-bananas-shake.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Refeactored the `Checkbox` and `Color` control to use the locally scoped key variable

--- a/packages/runtime/src/controls/checkbox.ts
+++ b/packages/runtime/src/controls/checkbox.ts
@@ -7,7 +7,7 @@ export const CheckboxControlDataTypeValueV1 = 'checkbox::v1'
 export type CheckboxControlDataV0 = boolean
 
 export type CheckboxControlDataV1 = {
-  [ControlDataTypeKey]: typeof CheckboxControlDataTypeValueV1
+  [CheckboxControlDataTypeKey]: typeof CheckboxControlDataTypeValueV1
   value: boolean,
 }
 

--- a/packages/runtime/src/controls/color.ts
+++ b/packages/runtime/src/controls/color.ts
@@ -10,7 +10,7 @@ export const ColorControlDataTypeValueV1 = 'color::v1'
 export type ColorControlDataV0 = ColorData
 
 export type ColorControlDataV1 = ColorControlDataV0 & {
-  [ControlDataTypeKey]: typeof ColorControlDataTypeValueV1
+  [ColorControlDataTypeKey]: typeof ColorControlDataTypeValueV1
 }
 
 export type ColorControlData = ColorControlDataV0 | ColorControlDataV1

--- a/packages/runtime/src/controls/number.ts
+++ b/packages/runtime/src/controls/number.ts
@@ -1,4 +1,17 @@
-export type NumberControlData = number
+import { ControlDataTypeKey } from "./control-data-type-key"
+
+export const NumberControlDataTypeKey = ControlDataTypeKey
+
+export const NumberControlDataTypeValueV1 = 'number::v1'
+
+export type NumberControlDataV0 = number
+
+export type NumberControlDataV1 = {
+  [NumberControlDataTypeKey]: typeof NumberControlDataTypeValueV1
+  value: number,
+}
+
+export type NumberControlData = NumberControlDataV0 | NumberControlDataV1
 
 export const NumberControlType = 'makeswift::controls::number'
 
@@ -15,10 +28,11 @@ type NumberControlConfig = {
 export type NumberControlDefinition<C extends NumberControlConfig = NumberControlConfig> = {
   type: typeof NumberControlType
   config: C
+  version?: 1
 }
 
 export function Number<C extends NumberControlConfig>(
   config: C = {} as C,
 ): NumberControlDefinition<C> {
-  return { type: NumberControlType, config }
+  return { type: NumberControlType, config, version: 1 }
 }

--- a/packages/runtime/src/runtimes/react/controls/number.ts
+++ b/packages/runtime/src/runtimes/react/controls/number.ts
@@ -1,11 +1,16 @@
-import { NumberControlData, NumberControlDefinition } from '../../../controls'
+import { match } from 'ts-pattern'
+import { NumberControlData, NumberControlDataTypeKey, NumberControlDataTypeValueV1, NumberControlDefinition } from '../../../controls'
 
 export type NumberControlValue<T extends NumberControlDefinition> =
-  undefined extends T['config']['defaultValue'] ? NumberControlData | undefined : NumberControlData
+  undefined extends T['config']['defaultValue'] ? number | undefined : number
 
 export function useNumber<T extends NumberControlDefinition>(
-  numberControlData: number | undefined,
-  controlDefinition: T,
+  data: NumberControlData | undefined,
+  definition: T,
 ): NumberControlValue<T> {
-  return (numberControlData ?? controlDefinition.config.defaultValue) as NumberControlValue<T>
+  const value: number | undefined = match(data)
+    .with({ [NumberControlDataTypeKey]: NumberControlDataTypeValueV1 }, (val) => val.value)
+    .otherwise(val => val) ?? definition.config.defaultValue
+
+  return value as NumberControlValue<T>
 }


### PR DESCRIPTION
Adds the `type` and `version` field for the `Number` control.

I also "refactored" the previous `Checkbox` and `Color` control to use the locally scope key variable.