### PR TITLE
feat: enable versioning by default

### DIFF
--- a/.changeset/sixty-islands-exist.md
+++ b/.changeset/sixty-islands-exist.md
@@ -13,7 +13,7 @@ Upgrade guide from version `0.12.x` to `0.13.x`:
    b. Add the new `siteVersion` parameter.
 
    ```diff
-     export async function getStaticProps(ctx){
+     export async function getStaticProps(ctx) {
       const makeswift = new Makeswift(process.env.MAKESWIFT_SITE_API_KEY, { runtime })
 
       const snapshot = await makeswift.getPageSnapshot(path, {

--- a/.changeset/sixty-islands-exist.md
+++ b/.changeset/sixty-islands-exist.md
@@ -1,0 +1,58 @@
+---
+'@makeswift/runtime': minor
+---
+
+Starting from version `0.13.0`, **versioning is now enabled by default**. With versioning, users can easily publish all changes to their website with just a few clicks. Published changes are saved so you can revert to previous versions if needed.
+
+Upgrade guide from version `0.12.x` to `0.13.x`:
+
+1. Update `getPageSnapshot` Parameters:
+
+   a. Remove the `preview` parameter.
+
+   b. Add the new `siteVersion` parameter.
+
+   ```diff
+     export async function getStaticProps(ctx){
+      const makeswift = new Makeswift(process.env.MAKESWIFT_SITE_API_KEY, { runtime })
+
+      const snapshot = await makeswift.getPageSnapshot(path, {
+   -    preview: ctx.preview,
+   +    siteVersion: Makeswift.getSiteVersion(ctx.previewData),
+        locale: ctx.locale,
+      });
+     }
+   ```
+
+2. For users who have **never used versioning**:
+
+   - No further actions are required.
+
+3. For users who have used versioning:
+
+   a. Remove the `siteVersion` parameter from the `Makeswift` constructor.
+
+   ```diff
+     const makeswift = new Makeswift(process.env.MAKESWIFT_SITE_API_KEY, {
+       runtime: runtime,
+   -   siteVersion: Makeswift.getSiteVersion(ctx.previewData),
+     });
+   ```
+
+   b. Remove the `siteVersion` parameter from the `MakeswiftApiHandler`.
+
+   ```diff
+      export default MakeswiftApiHandler(process.env.MAKESWIFT_SITE_API_KEY, {
+   -    siteVersions: true,
+      });
+   ```
+
+   c. If you use `client.getPage`, you need to also update the parameters:
+
+   ```diff
+      const page = await client.getPage(path, {
+   -    preview,
+   +    siteVersion: Makeswift.getSiteVersion(ctx.previewData),
+        locale
+      })
+   ```

--- a/packages/runtime/src/next/api-handler/handlers/manifest.ts
+++ b/packages/runtime/src/next/api-handler/handlers/manifest.ts
@@ -20,7 +20,7 @@ export type ManifestResponse = Manifest | ManifestError
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<ManifestResponse>,
-  { apiKey, siteVersions }: { apiKey: string; siteVersions: boolean },
+  { apiKey }: { apiKey: string },
 ): Promise<void> {
   if (req.query.secret !== apiKey) {
     return res.status(401).json({ message: 'Unauthorized' })
@@ -33,8 +33,8 @@ export default async function handler(
     clientSideNavigation: true,
     elementFromPoint: false,
     customBreakpoints: true,
-    siteVersions,
-    unstable_siteVersions: siteVersions,
+    siteVersions: true,
+    unstable_siteVersions: true,
     localizedPageSSR: true,
   })
 }

--- a/packages/runtime/src/next/index.tsx
+++ b/packages/runtime/src/next/index.tsx
@@ -98,7 +98,7 @@ export async function getStaticProps(
   })
   const path = '/' + (ctx.params?.path ?? []).join('/')
   const snapshot = await makeswift.getPageSnapshot(path, {
-    preview: ctx.previewData?.makeswift === true,
+    siteVersion: Makeswift.getSiteVersion(ctx.previewData),
   })
 
   if (snapshot == null) return { notFound: true, revalidate: REVALIDATE_SECONDS }
@@ -115,7 +115,9 @@ export async function getServerSideProps(
     apiOrigin: getApiOrigin(),
   })
   const path = '/' + (ctx.params?.path ?? []).join('/')
-  const snapshot = await makeswift.getPageSnapshot(path, { preview: true })
+  const snapshot = await makeswift.getPageSnapshot(path, {
+    siteVersion: Makeswift.getSiteVersion(ctx.previewData),
+  })
 
   if (snapshot == null) return { notFound: true }
 

--- a/packages/runtime/src/next/index.tsx
+++ b/packages/runtime/src/next/index.tsx
@@ -17,7 +17,7 @@ import {
   GetStaticPropsResult,
 } from 'next'
 import { Makeswift } from './client'
-import { MakeswiftPreviewData } from './preview-mode'
+import { MakeswiftPreviewData, MakeswiftSiteVersion } from './preview-mode'
 
 function getApiOrigin(): string {
   const apiOriginString = process['env'].MAKESWIFT_API_HOST ?? 'https://api.makeswift.com'
@@ -116,7 +116,7 @@ export async function getServerSideProps(
   })
   const path = '/' + (ctx.params?.path ?? []).join('/')
   const snapshot = await makeswift.getPageSnapshot(path, {
-    siteVersion: Makeswift.getSiteVersion(ctx.previewData),
+    siteVersion: MakeswiftSiteVersion.Working,
   })
 
   if (snapshot == null) return { notFound: true }


### PR DESCRIPTION
Thoughts about this MR:

1. Should we make make `siteVersion` parameter optional on public methods `getPage()` and `getPages()`?
2. Should we make the `siteVersion` parameter an object parameter like this?
```ts
async getGlobalElement(id, { siteVersion })
```
3. I think for "internal methods" like `getSwatch`, we need to make the `siteVersion` required, because otherwise we will forget to pass the `siteVersion` when we use it internally. But for external API, I'm making those optional for now, not sure which one is better here.
4. On that note, it's so weird to have a Makeswift client, but we expose our "internal methods" like `getSwatch`. In the future, it might be better to separate Makeswift client that users will use, and a Makeswift client that we use internally.