### PR TITLE
chore: ignore `/apps` directory in changeset

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": ["*nextjs-app-router*", "*nextjs-pages-router*"]
 }


### PR DESCRIPTION
Despite the apps we have being `private: true` they are included in our since they depend on @makeswift/runtime and it is being update. So I am manually ignoring them.