### PR TITLE
feat: remove client-side-routing code

### DIFF
--- a/.changeset/old-meals-bathe.md
+++ b/.changeset/old-meals-bathe.md
@@ -1,0 +1,7 @@
+---
+'@makeswift/runtime': minor
+---
+
+BREAKING: Remove client-side routing code.
+
+There should be no changes to consumers of the runtime as the builder should be the only consumer of this API. Because we are removing functionality, this warrants a breaking change.

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -12,7 +12,6 @@ export {
   scrollDocumentElement,
   unregisterDocument,
   setBuilderEditMode,
-  changePathname,
   builderPointerMove,
   setBreakpoints,
   setLocale,

--- a/packages/runtime/src/next/api-handler/handlers/manifest.ts
+++ b/packages/runtime/src/next/api-handler/handlers/manifest.ts
@@ -72,7 +72,7 @@ export default async function handler(
     previewMode: supportsPreviewMode,
     draftMode: supportsDraftMode,
     interactionMode: true,
-    clientSideNavigation: true,
+    clientSideNavigation: false,
     elementFromPoint: false,
     customBreakpoints: true,
     siteVersions: true,

--- a/packages/runtime/src/state/actions.ts
+++ b/packages/runtime/src/state/actions.ts
@@ -72,10 +72,6 @@ export const ActionTypes = {
   MAKESWIFT_CONNECTION_INIT: 'MAKESWIFT_CONNECTION_INIT',
   MAKESWIFT_CONNECTION_CHECK: 'MAKESWIFT_CONNECTION_CHECK',
 
-  CHANGE_PATHNAME: 'CHANGE_PATHNAME',
-  CHANGE_PATHNAME_START: 'CHANGE_PATHNAME_START',
-  CHANGE_PATHNAME_COMPLETE: 'CHANGE_PATHNAME_COMPLETE',
-
   BUILDER_POINTER_MOVE: 'BUILDER_POINTER_MOVE',
   ELEMENT_FROM_POINT_CHANGE: 'ELEMENT_FROM_POINT_CHANGE',
 
@@ -262,19 +258,6 @@ type SetBuilderEditModeAction = {
   payload: { editMode: BuilderEditMode }
 }
 
-type ChangePathnameAction = {
-  type: typeof ActionTypes.CHANGE_PATHNAME
-  payload: { pathname: string }
-}
-
-type ChangePathnameStartAction = {
-  type: typeof ActionTypes.CHANGE_PATHNAME_START
-}
-
-type ChangePathnameCompleteAction = {
-  type: typeof ActionTypes.CHANGE_PATHNAME_COMPLETE
-}
-
 type BuilderPointerMoveAction = {
   type: typeof ActionTypes.BUILDER_POINTER_MOVE
   payload: { pointer: Point | null }
@@ -335,9 +318,6 @@ export type Action =
   | HandlePointerMoveAction
   | APIResourceFulfilledAction
   | SetBuilderEditModeAction
-  | ChangePathnameAction
-  | ChangePathnameStartAction
-  | ChangePathnameCompleteAction
   | BuilderPointerMoveAction
   | ElementFromPointChangeAction
   | SetBreakpointsAction
@@ -647,25 +627,6 @@ export function setBuilderEditMode(editMode: BuilderEditMode): SetBuilderEditMod
   return {
     type: ActionTypes.SET_BUILDER_EDIT_MODE,
     payload: { editMode },
-  }
-}
-
-export function changePathname(pathname: string): ChangePathnameAction {
-  return {
-    type: ActionTypes.CHANGE_PATHNAME,
-    payload: { pathname },
-  }
-}
-
-export function changePathnameStart(): ChangePathnameStartAction {
-  return {
-    type: ActionTypes.CHANGE_PATHNAME_START,
-  }
-}
-
-export function changePathnameComplete(): ChangePathnameCompleteAction {
-  return {
-    type: ActionTypes.CHANGE_PATHNAME_COMPLETE,
   }
 }
 

--- a/packages/runtime/src/state/react-builder-preview.ts
+++ b/packages/runtime/src/state/react-builder-preview.ts
@@ -9,7 +9,6 @@ import {
   Store as ReduxStore,
 } from 'redux'
 import thunk, { ThunkAction, ThunkDispatch } from 'redux-thunk'
-import Router from 'next/router'
 
 import deepEqual from '../utils/deepEqual'
 
@@ -41,8 +40,6 @@ import {
   setIsInBuilder,
   handleWheel,
   handlePointerMove,
-  changePathnameStart,
-  changePathnameComplete,
   elementFromPointChange,
   setBreakpoints,
 } from './actions'
@@ -495,14 +492,6 @@ export function messageChannelMiddleware(
       const breakpoints = ReactPage.getBreakpoints(state)
       messageChannel.port1.postMessage(setBreakpoints(breakpoints))
 
-      Router.events.on('routeChangeStart', () => {
-        messageChannel.port1.postMessage(changePathnameStart())
-      })
-
-      Router.events.on('routeChangeComplete', () => {
-        messageChannel.port1.postMessage(changePathnameComplete())
-      })
-
       return (action: Action): Action => {
         switch (action.type) {
           case ActionTypes.CHANGE_ELEMENT_BOX_MODELS:
@@ -544,14 +533,6 @@ export function messageChannelMiddleware(
             messageChannel.port1.postMessage(action)
             window.getSelection()?.removeAllRanges()
             break
-
-          case ActionTypes.CHANGE_PATHNAME: {
-            const pathname = action.payload.pathname.replace(/^\//, '/')
-            const currentPathname = Router.asPath.replace(/^\//, '/')
-
-            if (pathname !== currentPathname) Router.push(pathname)
-            break
-          }
 
           case ActionTypes.SET_LOCALIZED_RESOURCE_ID: {
             client.setLocalizedResourceId(action.payload)


### PR DESCRIPTION
## What

Removes client-side routing from the state as it's being tightly coupled to Next.js routing. We want to implement client side routing, but need to think of a better way to integrate it into state.