### PR TITLE
fix: fix bug in translation of detached typography

### DIFF
--- a/.changeset/red-mirrors-agree.md
+++ b/.changeset/red-mirrors-agree.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Fix a bug in translating `Text` components containing detached typography.

--- a/packages/runtime/src/slate/TypographyPlugin/__tests__/normalization.test.tsx
+++ b/packages/runtime/src/slate/TypographyPlugin/__tests__/normalization.test.tsx
@@ -128,7 +128,6 @@ describe('GIVEN normalizing typography', () => {
 
       expect(editor.children).toEqual(result.children)
     })
-
     it('WHEN the only non matching node is an empty text THEN it is ignored', () => {
       const editor = EditorV2(
         <Paragraph>
@@ -271,6 +270,47 @@ describe('GIVEN normalizing typography', () => {
             <Text>f</Text>
           </Sub>
           <Text typography={resultingTypography}>g</Text>
+        </Paragraph>,
+      )
+
+      editor.typographyNormalizationDirection = 'up'
+      SlateEditor.normalize(editor, { force: true })
+
+      expect(editor.children).toEqual(result.children)
+    })
+    it('WHEN normalizing detached typography THEN the correct styles bubble up', () => {
+      const typography = {
+        style: [
+          {
+            deviceId: 'desktop',
+            value: {
+              fontSize: { value: 18, unit: 'px' },
+            },
+          },
+          {
+            deviceId: 'mobile',
+            value: { fontSize: { value: 16, unit: 'px' }, lineHeight: null, fontWeight: null },
+          },
+        ],
+      }
+
+      const editor = EditorV2(
+        <Paragraph>
+          <Text typography={typography}>a</Text>
+          <Code>
+            <Text typography={typography}>b</Text>
+          </Code>
+          <Text />
+        </Paragraph>,
+      )
+
+      const result = EditorV2(
+        <Paragraph typography={typography}>
+          <Text>a</Text>
+          <Code>
+            <Text>b</Text>
+          </Code>
+          <Text />
         </Paragraph>,
       )
 

--- a/packages/runtime/src/slate/TypographyPlugin/normalizeTypographyUp.ts
+++ b/packages/runtime/src/slate/TypographyPlugin/normalizeTypographyUp.ts
@@ -66,8 +66,7 @@ function shallowInverseAnd<A extends Record<string, unknown>, B extends Record<s
   const xor = {} as A & B
 
   bKeys.forEach(key => {
-    if ((aPrime[key] == null && bPrime[key] == null) || !deepEqual(aPrime[key], bPrime[key as any]))
-      xor[key] = aPrime[key]
+    if (!deepEqual(aPrime[key], bPrime[key as any])) xor[key] = aPrime[key]
   })
 
   return xor

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,7 @@
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**"]
+      "outputs": ["dist/**",  ".next/**", "!.next/cache/**"]
     },
     "test": {
       "dependsOn": ["^build"]


### PR DESCRIPTION
Prior to translation we normalize all our `typography` richtext data to the highest ancestor for the simplest possible markup. To do this we go through children determining what parts of `typography` they share. Any `typography` data that is shared is pushed up the tree, while unique `typography` data is left behind.

We do an `and` and an `xor` to determine what is shared and unique. In the case of detached `typography` the logic was incorrect. It was pushing data up the tree wtihout removing it from the original location. This left our normalization in a infinite loop.

My hunch is I added this special case as an optimization, so I am just removing it.