### PR TITLE
fix: hydrate App Router link with locales

### DIFF
--- a/.changeset/good-bulldogs-beg.md
+++ b/.changeset/good-bulldogs-beg.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Resolves issue where rewritten host API requests are unauthorized due to not checking the request header for the secret.

--- a/.changeset/sweet-monkeys-reply.md
+++ b/.changeset/sweet-monkeys-reply.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Button component and Link control now hydrate page links with the locale, if present. Brings automatic link localization to App Router, while still supporting Pages Router.

--- a/packages/runtime/src/api/resource-types.ts
+++ b/packages/runtime/src/api/resource-types.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod'
+
+const pagePathnameSliceSchema = z.object({
+  id: z.string(),
+  pathname: z.string(),
+  localizedPathname: z.string().optional().nullable(),
+  __typename: z.literal('PagePathnameSlice'),
+})
+
+export type PagePathnameSlice = z.infer<typeof pagePathnameSliceSchema>

--- a/packages/runtime/src/components/shared/Link/index.tsx
+++ b/packages/runtime/src/components/shared/Link/index.tsx
@@ -19,6 +19,8 @@ export const Link = forwardRef<HTMLAnchorElement, Props>(function Link(
 ) {
   const pageId = link && link.type === 'OPEN_PAGE' ? link.payload.pageId : null
   const page = usePagePathnameSlice(pageId ?? null)
+  const hasLocalizedPathname = page?.localizedPathname != null
+
   const elementKey =
     link?.type === 'SCROLL_TO_ELEMENT' ? link.payload.elementIdConfig?.elementKey : null
   const elementId = useElementId(elementKey)
@@ -36,7 +38,7 @@ export const Link = forwardRef<HTMLAnchorElement, Props>(function Link(
         if (page) {
           useNextLink = true
 
-          href = `/${page.pathname}`
+          href = `/${page.localizedPathname ?? page.pathname}`
         }
 
         target = link.payload.openInNewTab ? '_blank' : '_self'
@@ -130,6 +132,9 @@ export const Link = forwardRef<HTMLAnchorElement, Props>(function Link(
         target={target}
         onClick={handleClick}
         href={href}
+        {...(hasLocalizedPathname && {
+          locale: false,
+        })}
         // Next.js v12 has legacyBehavior set to true by default
         legacyBehavior={false}
       />

--- a/packages/runtime/src/next/api-handler/handlers/proxy-draft-mode.ts
+++ b/packages/runtime/src/next/api-handler/handlers/proxy-draft-mode.ts
@@ -44,7 +44,9 @@ async function proxyDraftModeRouteHandler(
   _context: Context,
   { apiKey }: { apiKey: string },
 ): Promise<NextResponse<ProxyDraftModeResponse>> {
-  const secret = request.nextUrl.searchParams.get('x-makeswift-draft-mode')
+  const secret =
+    request.nextUrl.searchParams.get('x-makeswift-draft-mode') ??
+    request.headers.get('X-Makeswift-Draft-Mode')
 
   if (secret !== apiKey) return new NextResponse('Unauthorized', { status: 401 })
 

--- a/packages/runtime/src/next/client.ts
+++ b/packages/runtime/src/next/client.ts
@@ -128,6 +128,7 @@ const pagePathnameSlicesAPISchema = z.array(
       id: z.string(),
       basePageId: z.string(),
       pathname: z.string(),
+      localizedPathname: z.string().optional(),
       __typename: z.literal('PagePathnameSlice'),
     })
     .nullable(),
@@ -609,9 +610,9 @@ export class Makeswift {
       if (pagePathnameSlice == null) return null
 
       return {
+        ...pagePathnameSlice,
         id: pagePathnameSlice.basePageId,
-        pathname: pagePathnameSlice.pathname,
-        __typename: pagePathnameSlice.__typename,
+        localizedPathname: pagePathnameSlice.localizedPathname ?? null,
       }
     })
   }

--- a/packages/runtime/src/runtimes/react/controls/link.ts
+++ b/packages/runtime/src/runtimes/react/controls/link.ts
@@ -19,6 +19,7 @@ export function useLinkControlValue<T extends LinkControlDefinition>(
 ): LinkControlValue<T> {
   const pageId = link && link.type === 'OPEN_PAGE' ? link.payload.pageId : null
   const page = usePagePathnameSlice(pageId ?? null)
+
   const elementKey =
     link?.type === 'SCROLL_TO_ELEMENT' ? link.payload.elementIdConfig?.elementKey : null
   const elementId = useElementId(elementKey)
@@ -30,7 +31,7 @@ export function useLinkControlValue<T extends LinkControlDefinition>(
   if (link) {
     switch (link.type) {
       case 'OPEN_PAGE': {
-        if (page) href = `/${page.pathname}`
+        if (page) href = `/${page.localizedPathname ?? page.pathname}`
 
         target = link.payload.openInNewTab ? '_blank' : '_self'
 

--- a/packages/runtime/src/runtimes/react/hooks/makeswift-api.ts
+++ b/packages/runtime/src/runtimes/react/hooks/makeswift-api.ts
@@ -6,11 +6,11 @@ import {
   File,
   GlobalElement,
   LocalizedGlobalElement,
-  PagePathnameSlice,
   Swatch,
   Table,
   Typography,
 } from '../../../api'
+import { PagePathnameSlice } from '../../../api/resource-types'
 import { useMakeswiftHostApiClient } from '../../../next/context/makeswift-host-api-client'
 
 export function useSwatch(swatchId: string | null): Swatch | null {


### PR DESCRIPTION
Hydrates Link control and Button component with localized page path, if applicable. Supports both App Router and Pages Router. Also resolves an existing bug where App Router API handler requests are unauthorized due to not reading the secret from the rewritten request header.

Demo: 

https://github.com/makeswift/makeswift/assets/8345645/b505cdb7-6f20-43a5-b93a-993664a89ec8


https://github.com/makeswift/makeswift/assets/8345645/15f0ee3c-dc44-4ae2-a51b-422e3257c104


