### PR TITLE
fix(runtime): wraps the RuntimeProvider component in suspense boundary

### DIFF
--- a/.changeset/yellow-turtles-check.md
+++ b/.changeset/yellow-turtles-check.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Wraps the `RuntimeProvider` component in a `Suspense` boundary as it uses `React.lazy`. Not wrapping the component would cause a hydration mismatch between the server and client.

--- a/packages/runtime/src/next/components/page.tsx
+++ b/packages/runtime/src/next/components/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { memo, useMemo } from 'react'
+import { Suspense, memo, useMemo } from 'react'
 
 import { RuntimeProvider } from '../../runtimes/react'
 import { Page as PageMeta } from '../../components/page'
@@ -29,9 +29,11 @@ export const Page = memo(({ snapshot }: PageProps) => {
   })
 
   return (
-    <RuntimeProvider client={client} rootElements={rootElements} preview={snapshot.preview}>
-      {/* We use a key here to reset the Snippets state in the PageMeta component */}
-      <PageMeta key={snapshot.document.data.key} document={snapshot.document} />
-    </RuntimeProvider>
+    <Suspense>
+      <RuntimeProvider client={client} rootElements={rootElements} preview={snapshot.preview}>
+        {/* We use a key here to reset the Snippets state in the PageMeta component */}
+        <PageMeta key={snapshot.document.data.key} document={snapshot.document} />
+      </RuntimeProvider>
+    </Suspense>
   )
 })


### PR DESCRIPTION
Wraps the `RuntimeProvider` component in a `Suspense` boundary as it uses `React.lazy`. Not wrapping the component would cause a hydration mismatch between the server and client.