### PR TITLE
feat: throw runtime error when passing `runtime` to `Page`

### DIFF
--- a/.changeset/gentle-planets-doubt.md
+++ b/.changeset/gentle-planets-doubt.md
@@ -1,0 +1,6 @@
+---
+'@makeswift/runtime': patch
+---
+
+Add console warning when `runtime` prop is passed to the `Page` component. 
+`runtime` should now be passed to the `ReactRuntimeProvider` instead of to `Page`. 

--- a/packages/runtime/src/next/components/page.tsx
+++ b/packages/runtime/src/next/components/page.tsx
@@ -11,7 +11,13 @@ export type PageProps = {
   snapshot: MakeswiftPageSnapshot
 }
 
-export const Page = memo(({ snapshot }: PageProps) => {
+export const Page = memo(({ snapshot, ...props }: PageProps) => {
+  if ('runtime' in props) {
+    throw new Error(
+      `The \`runtime\` prop is no longer supported in the \`@makeswift/runtime\` \`Page\` component as of \`0.15.0\`.
+See our docs for more information on what's changed and instructions to migrate: https://docs.makeswift.com/migrations/0.15.0`,
+    )
+  }
   const client = useMemo(
     () =>
       new MakeswiftHostApiClient({


### PR DESCRIPTION
![CleanShot 2024-03-20 at 11 48 24@2x](https://github.com/makeswift/makeswift/assets/20950876/103108d0-96ba-4192-b159-fc5a8a1bbdae)

Once documentation is public, I can update this message with a link to it.