### PR TITLE
fix: stop destroy socket too early

### DIFF
--- a/.changeset/hip-chicken-occur.md
+++ b/.changeset/hip-chicken-occur.md
@@ -1,0 +1,5 @@
+---
+'makeswift': patch
+---
+
+Fix an issue with the CLI's HTTP connection that would break usage in the Arc web browser.

--- a/packages/makeswift/src/init.ts
+++ b/packages/makeswift/src/init.ts
@@ -223,13 +223,6 @@ async function getSiteMetadata({
               envVars,
             })
           })
-
-          // Google Chrome very aggressively holds on to the socket
-          for (const socket of sockets) {
-            if (!socket.destroyed) {
-              socket.destroy()
-            }
-          }
         })
       })
       .listen(port)


### PR DESCRIPTION
We were having issues with Arc browser because we were destroying the HTTP server socket too early. When a request would come in, it would be immediately canceled. The code snippet seemed to indicate that Chrome would hold on to the connection, keeping it open, but after testing it, this didn't seem to be the case. For this reason, I removed the code snippet since it didn't seem to have any beneficial effects at the moment.