### PR TITLE
chore: add basic issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report-makeswift-runtime.yaml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report-makeswift-runtime.yaml
@@ -1,0 +1,47 @@
+name: "Bug Report: Makeswift Runtime"
+description: Having trouble with the Makeswift Runtime? File an issue with this template.
+labels: ["bug", "runtime"]
+body:
+  - type: textarea
+    attributes:
+      label: "Describe the bug"
+      description: "A clear and concise description of what the bug is."
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: "Steps to reproduce"
+      description: "An ordered list of steps we can follow to reproduce your issue."
+      value: |
+        **Steps:**
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+
+        **Expected Behavior:**
+
+        **Actual Behavior:**
+
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: "Screenshots/Videos"
+      description: "If applicable, add screenshots and/or videos to help explain your problem."
+  - type: textarea
+    attributes:
+      label: "Environment"
+      description: "Please provide information about your environment."
+      value: |
+        - **Binaries**
+          - Node.js version: `18.19.1`
+          - Package Manager version: `pnpm@8.6.5`
+          - Makeswift Runtime version: `0.15.0`
+        - **Operating system**
+          - Name: `macOS (M2 chip)`
+          - Version: `Sonoma 14.4.1`
+        - **Browser**
+          - Name: `chrome` 
+          - Version: `91.0.4472.124`
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/2-bug-report-makeswift-cli.yaml
+++ b/.github/ISSUE_TEMPLATE/2-bug-report-makeswift-cli.yaml
@@ -1,0 +1,47 @@
+name: "Bug Report: Makeswift CLI"
+description: Having trouble with the Makeswift CLI? File an issue with this template.
+labels: ["bug", "cli"]
+body:
+  - type: textarea
+    attributes:
+      label: "Describe the bug"
+      description: "A clear and concise description of what the bug is."
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: "Steps to reproduce"
+      description: "An ordered list of steps we can follow to reproduce your issue."
+      value: |
+        **Steps:**
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+
+        **Expected Behavior:**
+
+        **Actual Behavior:**
+
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: "Screenshots/Videos"
+      description: "If applicable, add screenshots and/or videos to help explain your problem."
+  - type: textarea
+    attributes:
+      label: "Environment"
+      description: "Please provide information about your environment."
+      value: |
+        - **Binaries**
+          - Node.js version: `18.19.1`
+          - Package Manager version: `pnpm@8.6.5`
+          - Makeswift Runtime version: `0.15.0`
+        - **Operating system**
+          - Name: `macOS (M2 chip)`
+          - Version: `Sonoma 14.4.1`
+        - **Browser**
+          - Name: `chrome` 
+          - Version: `91.0.4472.124`
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/3-bug-report-examples-catalyst.yaml
+++ b/.github/ISSUE_TEMPLATE/3-bug-report-examples-catalyst.yaml
@@ -1,0 +1,50 @@
+name: "Bug Report: BigCommerce Catalyst Example"
+description: Having trouble with the BigCommerce Catalyst example? File an issue with this template.
+labels: ["bug", "examples", "catalyst"]
+assignees:
+  - matthewvolk
+  - katiehoesley
+body:
+  - type: textarea
+    attributes:
+      label: "Describe the bug"
+      description: "A clear and concise description of what the bug is."
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: "Steps to reproduce"
+      description: "An ordered list of steps we can follow to reproduce your issue."
+      value: |
+        **Steps:**
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+
+        **Expected Behavior:**
+
+        **Actual Behavior:**
+
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: "Screenshots/Videos"
+      description: "If applicable, add screenshots and/or videos to help explain your problem."
+  - type: textarea
+    attributes:
+      label: "Environment"
+      description: "Please provide information about your environment."
+      value: |
+        - **Binaries**
+          - Node.js version: `18.19.1`
+          - Package Manager version: `pnpm@8.6.5`
+          - Makeswift Runtime version: `0.15.0`
+        - **Operating system**
+          - Name: `macOS (M2 chip)`
+          - Version: `Sonoma 14.4.1`
+        - **Browser**
+          - Name: `chrome` 
+          - Version: `91.0.4472.124`
+    validations:
+      required: true


### PR DESCRIPTION
## Description
Adds basic issue templates.

## Screenshots:
### Template chooser
![Screenshot 2024-04-19 at 2 26 48 PM](https://github.com/makeswift/makeswift/assets/28374851/2cf21424-a7b8-4f96-ae73-5d67d7e0fda9)

### Issue form
![Screenshot 2024-04-19 at 2 28 38 PM](https://github.com/makeswift/makeswift/assets/28374851/aceef9f8-3f7e-4f42-8552-b319f881eb9b)