### PR TITLE
fix(runtime): pages are not editable when running in dev w/ NextJS 14.2

### DIFF
--- a/.changeset/chilly-peaches-wonder.md
+++ b/.changeset/chilly-peaches-wonder.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': minor
+---
+
+Next.js 14.2 compatibility fix: decouple `PreviewProvider`'s message channel setup from the middleware creation to make store initialization compatible with React's strict mode.

--- a/packages/runtime/src/runtimes/react/components/PreviewProvider.tsx
+++ b/packages/runtime/src/runtimes/react/components/PreviewProvider.tsx
@@ -30,6 +30,11 @@ export default function PreviewProvider({ client, children, rootElements }: Prop
   )
 
   useEffect(() => {
+    store.setup()
+    return () => store.teardown()
+  }, [store])
+
+  useEffect(() => {
     const unregisterDocuments = Array.from(rootElements?.entries() ?? []).map(
       ([documentKey, rootElement]) =>
         store.dispatch(registerDocumentEffect(ReactPage.createDocument(documentKey, rootElement))),


### PR DESCRIPTION
Decouple `MessageChannel` creation from the middleware creation to make store initalization compatible with React's [strict mode](https://react.dev/reference/react/StrictMode). 

Next.js has React's strict mode [enabled by default](https://nextjs.org/docs/pages/api-reference/next-config-js/reactStrictMode) in dev; when running w/ Next.js 14.2 and [App Router](https://nextjs.org/docs/app) in dev, creation of the channel in the middleware was resulting in a secondary "ghost" store instance that was handling some of the dispatch methods, leading to a de-synchronized runtime state.