### PR TITLE
fix(runtime): "function components cannot be given refs" on the builtin `Text` component

### DIFF
--- a/.changeset/plenty-oranges-act.md
+++ b/.changeset/plenty-oranges-act.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Fix "function components cannot be given refs" warning on the built-in `Text` component

--- a/packages/runtime/src/components/builtin/Text/Text.tsx
+++ b/packages/runtime/src/components/builtin/Text/Text.tsx
@@ -1,4 +1,5 @@
 import { cx } from '@emotion/css'
+import { forwardRef } from 'react'
 import { ElementIDValue } from '../../../prop-controllers/descriptors'
 import { RichTextV2ControlValue } from '../../../runtimes/react/controls/rich-text-v2'
 
@@ -9,12 +10,12 @@ type Props = {
   margin?: string
 }
 
-function Text({ id, text, width, margin }: Props) {
+const Text = forwardRef<HTMLDivElement, Props>(({ id, text, width, margin }, ref) => {
   return (
-    <div id={id} className={cx(width, margin)}>
+    <div id={id} ref={ref} className={cx(width, margin)}>
       {text}
     </div>
   )
-}
+})
 
 export default Text


### PR DESCRIPTION
Bringing `Text` in line with the rest of the builtins.