### PR TITLE
fix(runtime): resolve occasional `ERR_INVALID_ARG_TYPE` error in Node.js console output

### DIFF
--- a/.changeset/tiny-lies-check.md
+++ b/.changeset/tiny-lies-check.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Resolve occasional `ERR_INVALID_ARG_TYPE` error when previewing a site built using Next.js Pages router.

--- a/packages/runtime/src/next/api-handler/handlers/proxy-preview-mode.ts
+++ b/packages/runtime/src/next/api-handler/handlers/proxy-preview-mode.ts
@@ -158,6 +158,6 @@ async function proxyPreviewModeApiRouteHandler(
 
   const arrayBuffer = await response.arrayBuffer()
 
-  res.write(arrayBuffer)
+  res.write(new Uint8Array(arrayBuffer))
   res.end()
 }


### PR DESCRIPTION
Resolve occasional `TypeError [ERR_INVALID_ARG_TYPE]: The "chunk" argument must be of type string or an instance of Buffer or Uint8Array. Received an instance of Array Buffer` when previewing a site built using Next.js Pages router.