### PR TITLE
Configure Github Action for canary releases

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -1,0 +1,65 @@
+name: Canary Release
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency: ${{ github.workflow}}-${{ github.ref }}
+
+jobs:
+  release:
+    name: Canary Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out git repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup Git User
+        uses: fregante/setup-git-user@v2
+      - name: Set up pnpm 8.x
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - name: Set up Node.js 18.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --ignore-scripts --frozen-lockfile
+
+      - name: Merge To Canary Branch
+        run: |
+          git checkout canary
+          git merge origin/main --strategy-option=theirs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Now we pre-release
+      - name: Enter Pre-Release Mode (Idempotently)
+        run: |
+          pnpm exec changeset pre enter canary || true
+          pnpm exec changeset version
+
+      - name: Commit Change To Pre-Release Mode
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'Enter prerelease mode and version packages'
+          branch: canary
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish
+        run: |
+          pnpm exec changeset publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Push Changes To Branch
+        run: git push origin canary --follow-tags
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Approach

On a merge to `main`, this job will run.

This job:

- checks out `canary`
- merges `main` into it
- Puts the branch into pre-release mode, if it isn't already
- Versions the packages (`pnpm exec changeset version`)
- Commits the above changes ([example here](https://github.com/makeswift/makeswift/commit/3c2461719e5abdfc03bf3cef6b886d37a628ff4a))
- Runs `pnpm exec changeset publish` (this step is untested)
- Pushes any new commits up to the `canary` branch


To read why I went with a merge-based approach, [see here](https://www.notion.so/makeswift/Merge-Based-Canary-Branching-Workflow-064e3de018234229874a77434e4734d4?pm=c).