### PR TITLE
fix: correctly render controls with versioned `ResponsiveSelect` data

### DIFF
--- a/.changeset/small-pets-attend.md
+++ b/.changeset/small-pets-attend.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+fix: correctly render controls with versioned `ResponsiveSelect` data

--- a/packages/runtime/src/next/components/tests/page-prop-controller.tsx
+++ b/packages/runtime/src/next/components/tests/page-prop-controller.tsx
@@ -3,7 +3,13 @@
 import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 
-import { Types, type Descriptor, type PropDef, type Value } from '@makeswift/prop-controllers'
+import {
+  type OptionsType,
+  Types,
+  type Descriptor,
+  type PropDef,
+  type Value,
+} from '@makeswift/prop-controllers'
 
 import { type ElementData, type ComponentType } from '../../../state/react-page'
 import { randomUUID } from 'crypto'
@@ -18,20 +24,21 @@ import {
 } from '../../../utils/tests/element-data-test-test'
 
 export const pagePropControllerTest = <
-  P extends PropDef & (() => any),
+  P extends PropDef & ((options?: any) => any),
   C extends ComponentType<{ propKey: Value<P> | undefined }>,
 >(
   propDef: P,
   value: Value<typeof propDef>,
   component: (testId: string) => C,
   assert: (element: HTMLElement) => void,
+  options?: OptionsType<P>,
 ) =>
   describe('Page', () => {
     test(`can render ${propDef.type} v0 data`, async () => {
       // Arrange
       const descriptorV0: Descriptor<typeof propDef> = {
         type: propDef.type,
-        options: {},
+        options,
       }
 
       const TestComponentType = 'TestComponent'
@@ -53,7 +60,7 @@ export const pagePropControllerTest = <
         type: TestComponentType,
         label: 'TestComponent',
         props: {
-          propKey: propDef(),
+          propKey: propDef(options),
         },
       })
 
@@ -94,7 +101,7 @@ export const pagePropControllerTest = <
         type: TestComponentType,
         label: 'TestComponent',
         props: {
-          propKey: propDef(),
+          propKey: propDef(options),
         },
       })
 

--- a/packages/runtime/src/next/components/tests/page-responsive-select-prop-controller.test.tsx
+++ b/packages/runtime/src/next/components/tests/page-responsive-select-prop-controller.test.tsx
@@ -1,0 +1,29 @@
+/** @jest-environment jsdom */
+
+import { ResponsiveSelect, type Value } from '@makeswift/prop-controllers'
+import { forwardRef } from 'react'
+
+import { pagePropControllerTest } from './page-prop-controller'
+
+pagePropControllerTest(
+  ResponsiveSelect,
+  [
+    {
+      deviceId: 'desktop',
+      value: 'dashed',
+    },
+  ],
+  testId =>
+    forwardRef<HTMLDivElement, { propKey?: Value<typeof ResponsiveSelect> }>(({ propKey }, ref) => (
+      <div ref={ref} data-testid={testId}>
+        {propKey?.at(0)?.value}
+      </div>
+    )),
+  element => expect(element).toHaveTextContent('dashed'),
+  {
+    options: [
+      { value: 'solid', label: 'Solid' },
+      { value: 'dashed', label: 'Dashed' },
+    ],
+  },
+)

--- a/packages/runtime/src/runtimes/react/controls.tsx
+++ b/packages/runtime/src/runtimes/react/controls.tsx
@@ -82,6 +82,7 @@ import {
   WidthDescriptor,
   GapX,
   ResponsiveNumber,
+  ResponsiveSelect,
   ResponsiveOpacity,
   getSocialLinksPropControllerDataSocialLinksData,
 } from '@makeswift/prop-controllers'
@@ -381,6 +382,17 @@ export function PropsValue({ element, children }: PropsValueProps): JSX.Element 
               <RenderHook
                 key={descriptor.type}
                 hook={data => usePropValue(ResponsiveNumber, data)}
+                parameters={[props[propName]]}
+              >
+                {value => renderFn({ ...propsValue, [propName]: value })}
+              </RenderHook>
+            )
+
+          case PropControllerTypes.ResponsiveSelect:
+            return (
+              <RenderHook
+                key={descriptor.type}
+                hook={data => usePropValue(ResponsiveSelect, data)}
                 parameters={[props[propName]]}
               >
                 {value => renderFn({ ...propsValue, [propName]: value })}


### PR DESCRIPTION
Add missing render hook + test. Following up https://github.com/makeswift/makeswift/pull/765.