### PR TITLE
fix: global element not selectable after it's blurred

### DIFF
--- a/.changeset/curly-dragons-train.md
+++ b/.changeset/curly-dragons-train.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+Fix global component cannot be selected after it is blurred.

--- a/packages/runtime/src/runtimes/react/components/ElementReference.tsx
+++ b/packages/runtime/src/runtimes/react/components/ElementReference.tsx
@@ -8,7 +8,7 @@ import {
   ElementReference as ReactPageElementReference,
 } from '../../../state/react-page'
 import { FallbackComponent } from '../../../components/shared/FallbackComponent'
-import { ElementData } from './ElementData'
+import { Element } from './Element'
 import { Document } from './Document'
 import { DisableRegisterElement } from '../hooks/use-disable-register-element'
 
@@ -59,7 +59,8 @@ export const ElementReference = memo(
           <Document document={elementReferenceDocument} ref={ref} />
         ) : (
           <DisableRegisterElement.Provider value={true}>
-            <ElementData elementData={globalElementData} ref={ref} />
+            {/* We render Element instead of ElementData because we rely on the FindDomNode */}
+            <Element element={globalElementData} ref={ref} />
           </DisableRegisterElement.Provider>
         )}
       </DocumentCyclesContext.Provider>


### PR DESCRIPTION
This bug only happened on component that doesn't use forwardRef.

This happened because we're relying on FindDomNode when the component does not use forwardRef. Unfortunately, for ElementReference, we render the ElementData, instead of Element, which has the FindDomNode fallback.

This commit fix that issue, and we render Element instead of ElementData.