### PR TITLE
fix: uncaught client exception on incomplete, protocol-only links

### DIFF
--- a/.changeset/odd-experts-punch.md
+++ b/.changeset/odd-experts-punch.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+Fix uncaught client exception on incomplete, protocol-only links

--- a/packages/runtime/src/components/shared/Link/index.tsx
+++ b/packages/runtime/src/components/shared/Link/index.tsx
@@ -13,6 +13,21 @@ type BaseProps = {
 
 type Props = BaseProps & Omit<ComponentPropsWithoutRef<'a'>, keyof BaseProps>
 
+// workaround for https://github.com/vercel/next.js/issues/66650
+const isValidHref = (href: string) => {
+  try {
+    const bases = ['http://n', 'https://n']
+    // - if `href` is a relative path, it will be resolved relative to the base URL
+    // - if `href` is a full URL, the base URL will be ignored, even if there is a mismatch of protocols
+    // - if `href` is an incomplete, protocol-only URL with a protocol that
+    //   conflicts with one of the base URL, this will throw
+    bases.forEach(base => new URL(href, base))
+  } catch (_) {
+    return false
+  }
+  return true
+}
+
 export const Link = forwardRef<HTMLAnchorElement, Props>(function Link(
   { link, onClick = () => {}, ...restOfProps }: Props,
   ref,
@@ -47,7 +62,7 @@ export const Link = forwardRef<HTMLAnchorElement, Props>(function Link(
       }
 
       case 'OPEN_URL': {
-        useNextLink = true
+        useNextLink = isValidHref(link.payload.url)
 
         href = link.payload.url
 


### PR DESCRIPTION
Workaround for https://github.com/vercel/next.js/issues/66650