### PR TITLE
feat: introduce v4 `getPages` endpoint

### DIFF
--- a/.changeset/little-ads-return.md
+++ b/.changeset/little-ads-return.md
@@ -1,0 +1,106 @@
+---
+"@makeswift/runtime": minor
+---
+
+BREAKING: The latest upgrade to the Makeswift client `getPages` method
+introduces sorting, path filtering, and pagination. This method was not
+previously paginated - in order to get all your pages, you may now use our
+`toArray` pagination helper method, which will automatically paginate through
+all results and aggregate them into an array:
+
+```tsx
+import { client } from '@/makeswift/client'
+import { MakeswiftPage } from '@makeswift/runtime/next'
+
+async function getAllPages(): Promise<MakeswiftPage[]> {
+  return await client.getPages().toArray()
+}
+```
+
+`getPages` now returns an instance of `IterablePaginationResult`, a decorated
+async iterator which includes methods `.map` and `.filter`, in addition to
+`.toArray`, mentioned above.
+
+This change also deprecates the client `getSitemap` method, with the
+recommendation that sitemaps should now be generated using data returned from
+`getPages`. Note that the deprecation of `getSitemap` now involves the host
+being responsible for the construction of page paths in the sitemap (either with
+domain or path based localization). Below is an example that uses path-based
+localization with the `next-sitemap` library:
+
+```tsx pages/sitemap.xml.tsx
+import { getServerSideSitemapLegacy } from 'next-sitemap'
+import { MakeswiftPage } from '@makeswift/runtime/next'
+import { client } from '@makeswift/client'
+
+const DOMAIN = 'https://example.com'
+const DEFAULT_PRIORITY = 0.75
+const DEFAULT_FREQUENCY = 'hourly'
+
+function pageToSitemapItem(page: MakeswiftPage) {
+  const pageUrl = new URL(page.path, DOMAIN)
+  return {
+    loc: pageUrl.href,
+    lastmod: page.createdAt,
+    changefreq: page.sitemapFrequency ?? DEFAULT_FREQUENCY,
+    priority: page.sitemapPriority ?? DEFAULT_PRIORITY,
+    alternateRefs: page.localizedVariants.map(variant => {
+      const localizedPath = `/${variant.locale}/${variant.path}`
+      const localizedPageUrl = new URL(localizedPath, DOMAIN)
+      return {
+        hreflang: variant.locale,
+        href: localizedPageUrl.href,
+      }
+    }),
+  }
+}
+
+export async function getServerSideProps(context) {
+  const sitemap = client
+    .getPages()
+    .filter(page => !page.excludedFromSearch)
+    .map(page => pageToSitemapItem(page))
+    .toArray()
+
+  return getServerSideSitemapLegacy(context, sitemap)
+}
+
+export default function Sitemap() {}
+
+```
+
+Here's another example for Next.js's App Router built-in support for sitemaps:
+
+```ts app/sitemap.ts
+
+import { MetadataRoute } from 'next'
+import { MakeswiftPage } from '@makeswift/runtime/dist/types/next'
+import { client } from '@/lib/makeswift/client'
+
+type NextSitemapItem = MetadataRoute.Sitemap[number]
+
+const DOMAIN = 'https://example.com'
+const DEFAULT_PRIORITY = 0.75
+const DEFAULT_FREQUENCY = 'hourly'
+
+function pageToSitemapEntry(page: MakeswiftPage): NextSitemapItem {
+  const pageUrl = new URL(page.path, DOMAIN)
+  return {
+    url: pageUrl.href,
+    lastModified: page.createdAt,
+    changeFrequency: page.sitemapFrequency ?? DEFAULT_FREQUENCY,
+    priority: page.sitemapPriority ?? DEFAULT_PRIORITY,
+  }
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  return client
+    .getPages()
+    .filter(p => p.path != null)
+    .map(page => pageToSitemapEntry(page))
+    .toArray()
+}
+```
+
+BREAKING: The exported `MakeswiftPage` type now includes several more data
+fields from the Makeswift page.

--- a/apps/nextjs-app-router/src/app/[lang]/[[...path]]/page.tsx
+++ b/apps/nextjs-app-router/src/app/[lang]/[[...path]]/page.tsx
@@ -3,19 +3,27 @@ import '@/makeswift/components'
 import { getSiteVersion } from '@makeswift/runtime/next/server'
 import { notFound } from 'next/navigation'
 import { Page as MakeswiftPage } from '@makeswift/runtime/next'
-import { locales } from '@/localization'
 
 type ParsedUrlQuery = { lang: string; path?: string[] }
 
 export async function generateStaticParams() {
-  const pages = await client.getPages()
 
-  return pages.flatMap((page) =>
-    locales.map((locale) => ({
-      path: page.path.split('/').filter((segment) => segment !== ''),
-      lang: locale,
+  const pages = await client.getPages().toArray()
+
+  return pages.flatMap((page) => [
+    {
+      params: {
+        path: page.path.split('/').filter((segment) => segment !== ''),
+        lang: page.locale,
+      },
+    },
+    ...page.localizedVariants.map((variant) => ({
+      params: {
+        path: variant.path.split('/').filter((segment) => segment !== ''),
+        lang: variant.locale,
+      },
     })),
-  )
+  ])
 }
 
 export default async function Page({ params }: { params: ParsedUrlQuery }) {

--- a/apps/nextjs-pages-router/src/pages/[[...path]].tsx
+++ b/apps/nextjs-pages-router/src/pages/[[...path]].tsx
@@ -18,7 +18,7 @@ type ParsedUrlQuery = { path?: string[] }
 export async function getStaticPaths(): Promise<
   GetStaticPathsResult<ParsedUrlQuery>
 > {
-  const pages = await client.getPages()
+  const pages = await client.getPages().toArray()
 
   return {
     paths: pages.map((page) => ({

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -173,6 +173,7 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "madge": "^6.0.0",
+    "msw": "^2.3.1",
     "next": "14.1.0",
     "prettier": "^2.5.1",
     "react": "18.2.0",

--- a/packages/runtime/src/next/tests/client.get-pages.test.ts
+++ b/packages/runtime/src/next/tests/client.get-pages.test.ts
@@ -1,0 +1,159 @@
+import { Makeswift } from '../client'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { randomUUID } from 'crypto'
+
+function createRandomPageV4() {
+  const id = randomUUID()
+  return {
+    id,
+    path: `/${id}`,
+    title: null,
+    description: null,
+    canonicalUrl: null,
+    socialImageUrl: null,
+    sitemapPriority: null,
+    sitemapFrequency: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    publishedAt: new Date().toISOString(),
+    isOnline: true,
+    excludedFromSearch: false,
+    locale: 'en-US',
+    localizedVariants: [],
+  }
+}
+
+const TEST_API_KEY = 'xxx'
+const apiOrigin = 'https://api.fakeswift.com'
+const baseUrl = `${apiOrigin}/v4/pages`
+
+const handlers = [
+  http.get(baseUrl, () => HttpResponse.json({ data: [], hasMore: false }), { once: true }),
+]
+
+const server = setupServer(...handlers)
+
+beforeAll(() => {
+  server.resetHandlers()
+  server.listen()
+})
+
+// Reset any request handlers that we may add during the tests,
+// so they don't affect other tests.
+afterEach(() => server.resetHandlers())
+
+// Clean up after the tests are finished.
+afterAll(() => server.close())
+
+describe('getPages v4', () => {
+  test('empty', async () => {
+    // Arrange
+    const client = new Makeswift(TEST_API_KEY, { apiOrigin })
+
+    // Act
+    const pageResults = await client.getPages()
+
+    // Assert
+    expect(pageResults).toEqual({
+      data: [],
+      hasMore: false,
+    })
+  })
+
+  test('throws on unexpected data', async () => {
+    // Arrange
+    const client = new Makeswift(TEST_API_KEY, { apiOrigin })
+
+    server.use(
+      http.get(baseUrl, () => HttpResponse.json({ data: { test: 'test' }, hasMore: false }), {
+        once: true,
+      }),
+    )
+
+    // Act
+    const getPagesPromise = client.getPages()
+
+    // Assert
+    expect(getPagesPromise).rejects.toThrow('Failed to parse getPages response')
+  })
+
+  test('can get many pages', async () => {
+    // Arrange
+    const client = new Makeswift(TEST_API_KEY, { apiOrigin })
+    const mockPages = Array.from({ length: 10 }, createRandomPageV4)
+    server.use(
+      http.get(baseUrl, () => HttpResponse.json({ data: mockPages, hasMore: false }), {
+        once: true,
+      }),
+    )
+
+    // Act
+    const pageResults = await client.getPages()
+
+    // Assert
+    expect(pageResults).toEqual({
+      data: mockPages,
+      hasMore: false,
+    })
+  })
+
+  test('toArray gets all pages', async () => {
+    // Arrange
+    const client = new Makeswift(TEST_API_KEY, { apiOrigin })
+    const [page1, page2, page3] = Array.from({ length: 3 }, createRandomPageV4)
+    server.use(
+      http.get(baseUrl, () => HttpResponse.json({ data: [page1], hasMore: true }), { once: true }),
+      http.get(baseUrl, () => HttpResponse.json({ data: [page2], hasMore: true }), { once: true }),
+      http.get(baseUrl, () => HttpResponse.json({ data: [page3], hasMore: false }), { once: true }),
+    )
+
+    // Act
+    const pageResults = await client.getPages().toArray()
+    expect(pageResults).toHaveLength(3)
+    expect(pageResults).toEqual([page1, page2, page3])
+    expect(server.listHandlers().every(handler => handler.isUsed)).toBe(true)
+  })
+
+  test('async iterable gets all pages', async () => {
+    // Arrange
+    const client = new Makeswift(TEST_API_KEY, { apiOrigin })
+    const [page1, page2, page3] = Array.from({ length: 3 }, createRandomPageV4)
+    server.use(
+      http.get(baseUrl, () => HttpResponse.json({ data: [page1], hasMore: true }), { once: true }),
+      http.get(baseUrl, () => HttpResponse.json({ data: [page2], hasMore: true }), { once: true }),
+      http.get(baseUrl, () => HttpResponse.json({ data: [page3], hasMore: false }), { once: true }),
+    )
+
+    // Act
+    const pageResults = []
+    for await (const page of client.getPages()) {
+      pageResults.push(page)
+    }
+
+    expect(pageResults).toHaveLength(3)
+    expect(pageResults).toEqual([page1, page2, page3])
+    expect(server.listHandlers().every(handler => handler.isUsed)).toBe(true)
+  })
+
+  test('async iterable methods are chainable', async () => {
+    // Arrange
+    const client = new Makeswift(TEST_API_KEY, { apiOrigin })
+    const [page1, page2, page3] = Array.from({ length: 3 }, createRandomPageV4)
+    server.use(
+      http.get(baseUrl, () => HttpResponse.json({ data: [page1, page2, page3], hasMore: false }), {
+        once: true,
+      }),
+    )
+
+    // Act
+    const mappedAndFilteredPages = await client
+      .getPages()
+      .map(page => page.id)
+      .filter(id => id === page1.id)
+      .toArray()
+
+    //Assert
+    expect(mappedAndFilteredPages).toEqual([page1.id])
+  })
+})

--- a/packages/runtime/src/next/utils/async-iterable.ts
+++ b/packages/runtime/src/next/utils/async-iterable.ts
@@ -1,0 +1,41 @@
+export class AsyncIterableExt<T> implements AsyncIterable<T> {
+  constructor(public readonly iterable: AsyncIterable<T>) {}
+
+  async *[Symbol.asyncIterator]() {
+    for await (const value of this.iterable) {
+      yield value
+    }
+  }
+
+  map<U>(callback: (arg: T) => U) {
+    const iterable = this.iterable
+    return makeAsyncIterableExt<U>(async function* () {
+      for await (const value of iterable) {
+        yield callback(value)
+      }
+    })
+  }
+
+  filter(predicate: (arg: T) => Boolean) {
+    const iterable = this.iterable
+    return makeAsyncIterableExt<T>(async function* () {
+      for await (const value of iterable) {
+        if (predicate(value)) yield value
+      }
+    })
+  }
+
+  async toArray() {
+    const result: T[] = []
+    for await (const item of this) {
+      result.push(item)
+    }
+    return result
+  }
+}
+
+export function makeAsyncIterableExt<T>(generator: () => AsyncIterator<T>) {
+  return new AsyncIterableExt<T>({
+    [Symbol.asyncIterator]: generator,
+  })
+}

--- a/packages/runtime/src/next/utils/pagination.ts
+++ b/packages/runtime/src/next/utils/pagination.ts
@@ -1,0 +1,52 @@
+import { AsyncIterableExt } from './async-iterable'
+
+type PaginationResult<T> = { data: T[]; hasMore: boolean }
+type IterablePaginationResult<T> = Promise<PaginationResult<T>> & AsyncIterableExt<T>
+
+type PaginationFunction<Options, R extends { id: any }> = Options extends {
+  after?: string
+}
+  ? (options: Options) => Promise<PaginationResult<R>>
+  : never
+
+type IterableMethod<Options, R> = Partial<Options> extends Options
+  ? (options?: Options) => IterablePaginationResult<R>
+  : (options: Options) => IterablePaginationResult<R>
+
+export function toIterablePaginationResult<Options, R extends { id: string }>(
+  fn: PaginationFunction<Options, R>,
+): IterableMethod<Options, R> {
+  return (options?: Options): IterablePaginationResult<R> => {
+    let __promise: Promise<PaginationResult<R>>
+
+    function getPromise() {
+      if (__promise) return __promise
+      __promise = fn(options ?? ({} as Options))
+      return __promise
+    }
+
+    async function* generator() {
+      let hasMore = true
+      let after: string | undefined = undefined
+
+      while (hasMore) {
+        const pages: PaginationResult<R> = await fn({ ...options, after } as Options)
+        const { data, hasMore: hasMoreNext } = pages
+        hasMore = hasMoreNext
+        after = data.at(-1)?.id
+        for (const item of data) {
+          yield item
+        }
+      }
+    }
+
+    const result: Partial<IterablePaginationResult<R>> = new AsyncIterableExt<R>({
+      [Symbol.asyncIterator]: generator,
+    })
+
+    result.then = (onfulfilled?, onrejected?) => getPromise().then(onfulfilled, onrejected)
+    result.catch = onrejected => getPromise().catch(onrejected)
+    result.finally = onfinally => getPromise().finally(onfinally)
+    return result as IterablePaginationResult<R>
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,7 +271,7 @@ importers:
         version: 8.2.2
       jest:
         specifier: ^29.0.1
-        version: 29.0.1
+        version: 29.0.1(@types/node@20.11.11)
       tsup:
         specifier: ^8.0.2
         version: 8.0.2(@swc/core@1.4.17)(typescript@5.1.6)
@@ -465,6 +465,9 @@ importers:
       madge:
         specifier: ^6.0.0
         version: 6.0.0
+      msw:
+        specifier: ^2.3.1
+        version: 2.3.1(typescript@5.1.6)
       next:
         specifier: 14.1.0
         version: 14.1.0(@babel/core@7.24.5)(react-dom@18.2.0)(react@18.2.0)
@@ -1656,6 +1659,18 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
+  /@bundled-es-modules/cookie@2.0.0:
+    resolution: {integrity: sha512-Or6YHg/kamKHpxULAdSqhGqnWFneIXu1NKvvfBBzKGwpVsYuFIQ5aBPHDnnoR3ghW1nvSkALd+EF9iMtY7Vjxw==}
+    dependencies:
+      cookie: 0.5.0
+    dev: true
+
+  /@bundled-es-modules/statuses@1.0.1:
+    resolution: {integrity: sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==}
+    dependencies:
+      statuses: 2.0.1
+    dev: true
+
   /@changesets/apply-release-plan@7.0.0:
     resolution: {integrity: sha512-vfi69JR416qC9hWmFGSxj7N6wA5J222XNBmezSVATPWDVPIF7gkd4d8CpbEbXmRWbVrkoli3oerGS6dcL/BGsQ==}
     dependencies:
@@ -2803,6 +2818,43 @@ packages:
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
     dev: true
 
+  /@inquirer/confirm@3.1.9:
+    resolution: {integrity: sha512-UF09aejxCi4Xqm6N/jJAiFXArXfi9al52AFaSD+2uIHnhZGtd1d6lIGTRMPouVSJxbGEi+HkOWSYaiEY/+szUw==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@inquirer/core': 8.2.2
+      '@inquirer/type': 1.3.3
+    dev: true
+
+  /@inquirer/core@8.2.2:
+    resolution: {integrity: sha512-K8SuNX45jEFlX3EBJpu9B+S2TISzMPGXZIuJ9ME924SqbdW6Pt6fIkKvXg7mOEOKJ4WxpQsxj0UTfcL/A434Ww==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@inquirer/figures': 1.0.3
+      '@inquirer/type': 1.3.3
+      '@types/mute-stream': 0.0.4
+      '@types/node': 20.14.4
+      '@types/wrap-ansi': 3.0.0
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      cli-spinners: 2.9.2
+      cli-width: 4.1.0
+      mute-stream: 1.0.0
+      signal-exit: 4.1.0
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
+    dev: true
+
+  /@inquirer/figures@1.0.3:
+    resolution: {integrity: sha512-ErXXzENMH5pJt5/ssXV0DfWUZqly8nGzf0UcBV9xTnP+KyffE2mqyxIMBrZ8ijQck2nU0TQm40EQB53YreyWHw==}
+    engines: {node: '>=18'}
+    dev: true
+
+  /@inquirer/type@1.3.3:
+    resolution: {integrity: sha512-xTUt0NulylX27/zMx04ZYar/kr1raaiFTVvQ5feljQsiAgdm0WPj4S73/ye0fbslh+15QrIuDvfCXTek7pMY5A==}
+    engines: {node: '>=18'}
+    dev: true
+
   /@isaacs/cliui@8.0.2:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -3320,6 +3372,23 @@ packages:
       read-yaml-file: 1.1.0
     dev: true
 
+  /@mswjs/cookies@1.1.1:
+    resolution: {integrity: sha512-W68qOHEjx1iD+4VjQudlx26CPIoxmIAtK4ZCexU0/UJBG6jYhcuyzKJx+Iw8uhBIGd9eba64XgWVgo20it1qwA==}
+    engines: {node: '>=18'}
+    dev: true
+
+  /@mswjs/interceptors@0.29.1:
+    resolution: {integrity: sha512-3rDakgJZ77+RiQUuSK69t1F0m8BQKA8Vh5DCS5V0DWvNY67zob2JhhQrhCO0AKLGINTRSFd1tBaHcJTkhefoSw==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.2
+      strict-event-emitter: 0.5.1
+    dev: true
+
   /@n1ru4l/graphql-live-query@0.9.0(graphql@16.3.0):
     resolution: {integrity: sha512-BTpWy1e+FxN82RnLz4x1+JcEewVdfmUhV1C6/XYD5AjS7PQp9QFF7K8bCD6gzPTr2l+prvqOyVueQhFJxB1vfg==}
     peerDependencies:
@@ -3428,6 +3497,21 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.13.0
+    dev: true
+
+  /@open-draft/deferred-promise@2.2.0:
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+    dev: true
+
+  /@open-draft/logger@0.3.0:
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.2
+    dev: true
+
+  /@open-draft/until@2.1.0:
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
     dev: true
 
   /@pkgjs/parseargs@0.11.0:
@@ -4109,6 +4193,10 @@ packages:
       '@types/color-convert': 2.0.0
     dev: true
 
+  /@types/cookie@0.6.0:
+    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
+    dev: true
+
   /@types/cors@2.8.12:
     resolution: {integrity: sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==}
     dev: true
@@ -4234,6 +4322,12 @@ packages:
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
     dev: true
 
+  /@types/mute-stream@0.0.4:
+    resolution: {integrity: sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==}
+    dependencies:
+      '@types/node': 20.14.4
+    dev: true
+
   /@types/negotiator@0.6.3:
     resolution: {integrity: sha512-JkXTOdKs5MF086b/pt8C3+yVp3iDUwG635L7oCH6HvJvvr6lSUU5oe/gLXnPEfYRROHjJIPgCV6cuAg8gGkntQ==}
     dev: true
@@ -4248,6 +4342,12 @@ packages:
 
   /@types/node@20.11.11:
     resolution: {integrity: sha512-PlJCXfb57Jrman0H1BxO2+Q7qwih2Mwk7T6Gvixj+SK4mqs4RWOGMMoP6p/LFa3UrP2CZOO6ai6otd7J/TB6Ug==}
+    dependencies:
+      undici-types: 5.26.5
+    dev: true
+
+  /@types/node@20.14.4:
+    resolution: {integrity: sha512-1ChboN+57suCT2t/f8lwtPY/k3qTpuD/qnqQuYoBg6OQOcPyaw7PiZVdGpaZYAvhDDtqrt0oAaM8+oSu1xsUGw==}
     dependencies:
       undici-types: 5.26.5
     dev: true
@@ -4295,6 +4395,10 @@ packages:
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
     dev: true
 
+  /@types/statuses@2.0.5:
+    resolution: {integrity: sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A==}
+    dev: true
+
   /@types/through@0.0.30:
     resolution: {integrity: sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==}
     dependencies:
@@ -4317,6 +4421,10 @@ packages:
     resolution: {integrity: sha512-NbsqiNX9CnEfC1Z0Vf4mE1SgAJ07JnRYcNex7AJ9zAVzmiGHmjKFEk7O4TJIsgv2B1sLEb6owKFZrACwdYngsQ==}
     dependencies:
       '@types/node': 20.11.11
+    dev: true
+
+  /@types/wrap-ansi@3.0.0:
+    resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
     dev: true
 
   /@types/ws@8.5.3:
@@ -5341,6 +5449,11 @@ packages:
     resolution: {integrity: sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==}
     engines: {node: '>=6'}
 
+  /cli-spinners@2.9.2:
+    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
+    engines: {node: '>=6'}
+    dev: true
+
   /cli-truncate@0.2.1:
     resolution: {integrity: sha512-f4r4yJnbT++qUPI9NR4XLDLq41gQ+uqnPItWG0F5ZkehuNiTTa3EY0S4AqTSUOeJ7/zU41oWPQSNkW5BqPL9bg==}
     engines: {node: '>=0.10.0'}
@@ -5352,6 +5465,11 @@ packages:
   /cli-width@3.0.0:
     resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
     engines: {node: '>= 10'}
+
+  /cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+    dev: true
 
   /client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -5533,6 +5651,11 @@ packages:
 
   /convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  /cookie@0.5.0:
+    resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
+    engines: {node: '>= 0.6'}
+    dev: true
 
   /core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -7397,6 +7520,11 @@ packages:
     resolution: {integrity: sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A==}
     engines: {node: ^12.22.0 || ^14.16.0 || >=16.0.0}
 
+  /graphql@16.8.2:
+    resolution: {integrity: sha512-cvVIBILwuoSyD54U4cF/UXDh5yAobhNV/tPygI4lZhgOIJQE/WLWC4waBRb4I6bDVYb3OVx3lfHbaQOEoUD5sg==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+    dev: true
+
   /hard-rejection@2.1.0:
     resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
     engines: {node: '>=6'}
@@ -7462,6 +7590,10 @@ packages:
     dependencies:
       capital-case: 1.0.4
       tslib: 2.6.2
+    dev: true
+
+  /headers-polyfill@4.0.3:
+    resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
     dev: true
 
   /hey-listen@1.0.8:
@@ -7846,6 +7978,10 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
+  /is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
+    dev: true
+
   /is-number-object@1.0.7:
     resolution: {integrity: sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==}
     engines: {node: '>= 0.4'}
@@ -8205,34 +8341,6 @@ packages:
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
-    dev: true
-
-  /jest-cli@29.0.1:
-    resolution: {integrity: sha512-XozBHtoJCS6mnjCxNESyGm47Y4xSWzNlBJj4tix9nGrG6m068B83lrTWKtjYAenYSfOqyYVpQCkyqUp35IT+qA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 29.0.1
-      '@jest/test-result': 29.0.1
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      import-local: 3.1.0
-      jest-config: 29.0.1(@types/node@20.11.11)
-      jest-util: 29.7.0
-      jest-validate: 29.0.1
-      prompts: 2.4.2
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - supports-color
-      - ts-node
     dev: true
 
   /jest-cli@29.0.1(@types/node@20.11.11):
@@ -8999,26 +9107,6 @@ packages:
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
-    dev: true
-
-  /jest@29.0.1:
-    resolution: {integrity: sha512-liHkwzaW6iwQyhRBFj0A4ZYKcsQ7ers1s62CCT95fPeNzoxT/vQRWwjTT4e7jpSCwrvPP2t1VESuy7GrXcr2ug==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 29.0.1
-      '@jest/types': 29.5.0
-      import-local: 3.1.0
-      jest-cli: 29.0.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - supports-color
-      - ts-node
     dev: true
 
   /jest@29.0.1(@types/node@20.11.11):
@@ -9818,6 +9906,37 @@ packages:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
     dev: true
 
+  /msw@2.3.1(typescript@5.1.6):
+    resolution: {integrity: sha512-ocgvBCLn/5l3jpl1lssIb3cniuACJLoOfZu01e3n5dbJrpA5PeeWn28jCLgQDNt6d7QT8tF2fYRzm9JoEHtiig==}
+    engines: {node: '>=18'}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      typescript: '>= 4.7.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@bundled-es-modules/cookie': 2.0.0
+      '@bundled-es-modules/statuses': 1.0.1
+      '@inquirer/confirm': 3.1.9
+      '@mswjs/cookies': 1.1.1
+      '@mswjs/interceptors': 0.29.1
+      '@open-draft/until': 2.1.0
+      '@types/cookie': 0.6.0
+      '@types/statuses': 2.0.5
+      chalk: 4.1.2
+      graphql: 16.8.2
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.2
+      path-to-regexp: 6.2.1
+      strict-event-emitter: 0.5.1
+      type-fest: 4.20.1
+      typescript: 5.1.6
+      yargs: 17.7.2
+    dev: true
+
   /multipipe@1.0.2:
     resolution: {integrity: sha512-6uiC9OvY71vzSGX8lZvSqscE7ft9nPupJ8fMjrCNRAUy2LREUW42UL+V/NTrogr6rFgRydUrCX4ZitfpSNkSCQ==}
     dependencies:
@@ -9827,6 +9946,11 @@ packages:
 
   /mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
+
+  /mute-stream@1.0.0:
+    resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    dev: true
 
   /mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
@@ -10146,6 +10270,10 @@ packages:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
     dev: true
 
+  /outvariant@1.4.2:
+    resolution: {integrity: sha512-Ou3dJ6bA/UJ5GVHxah4LnqDwZRwAmWxrG3wtrHrbGnP4RnLCtA64A4F+ae7Y8ww660JaddSoArUR5HjipWSHAQ==}
+    dev: true
+
   /p-cancelable@1.1.0:
     resolution: {integrity: sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==}
     engines: {node: '>=6'}
@@ -10320,7 +10448,6 @@ packages:
 
   /path-to-regexp@6.2.1:
     resolution: {integrity: sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==}
-    dev: false
 
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -10408,22 +10535,6 @@ packages:
     dependencies:
       camelcase-css: 2.0.1
       postcss: 8.4.33
-    dev: true
-
-  /postcss-load-config@4.0.2:
-    resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
-    engines: {node: '>= 14'}
-    peerDependencies:
-      postcss: '>=8.0.9'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      postcss:
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      lilconfig: 3.0.0
-      yaml: 2.3.4
     dev: true
 
   /postcss-load-config@4.0.2(postcss@8.4.33):
@@ -11452,6 +11563,11 @@ packages:
       escape-string-regexp: 2.0.0
     dev: true
 
+  /statuses@2.0.1:
+    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
+    dev: true
+
   /stream-to-array@2.3.0:
     resolution: {integrity: sha512-UsZtOYEn4tWU2RGLOXr/o/xjRBftZRlG3dEWoaHr8j4GuypJ3isitGbVyjQKAuMu+xbiop8q224TjiZWc4XTZA==}
     dependencies:
@@ -11467,6 +11583,10 @@ packages:
   /streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
+
+  /strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
+    dev: true
 
   /string-env-interpolation@1.0.1:
     resolution: {integrity: sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg==}
@@ -12151,7 +12271,7 @@ packages:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.2
+      postcss-load-config: 4.0.2(postcss@8.4.33)
       resolve-from: 5.0.0
       rollup: 4.13.0
       source-map: 0.8.0-beta.0
@@ -12298,6 +12418,11 @@ packages:
   /type-fest@0.8.1:
     resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
     engines: {node: '>=8'}
+    dev: true
+
+  /type-fest@4.20.1:
+    resolution: {integrity: sha512-R6wDsVsoS9xYOpy8vgeBlqpdOyzJ12HNfQhC/aAKWM3YoCV9TtunJzh/QpkMgeDhkoynDcw5f1y+qF9yc/HHyg==}
+    engines: {node: '>=16'}
     dev: true
 
   /typed-array-buffer@1.0.0:


### PR DESCRIPTION
Updates the sample applications to use the new paginated v4 `getPages` endpoint. Also adds a deprecation notice to `getSitemap`.