### PR TITLE
chore: update example apps with new `getPages` method

### DIFF
--- a/examples/basic-typescript-pages/package.json
+++ b/examples/basic-typescript-pages/package.json
@@ -8,7 +8,7 @@
     "icons": "npx @svgr/cli --typescript --replace-attr-values \"#000=currentColor\" --out-dir generated/icons -- public/icons"
   },
   "dependencies": {
-    "@makeswift/runtime": "^0.18.0",
+    "@makeswift/runtime": "^0.19.0",
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-tabs": "^1.0.4",
     "clsx": "^2.0.0",

--- a/examples/basic-typescript-pages/pages/[[...path]].tsx
+++ b/examples/basic-typescript-pages/pages/[[...path]].tsx
@@ -5,14 +5,15 @@ import { Makeswift, Page as MakeswiftPage, PageProps } from '@makeswift/runtime/
 import { client } from '@/lib/makeswift/client'
 
 export const getStaticPaths = (async () => {
-  const pages = await client.getPages()
-
   return {
-    paths: pages.map(page => ({
-      params: {
-        path: page.path.split('/').filter(segment => segment !== ''),
-      },
-    })),
+    paths: await client
+      .getPages()
+      .map(page => ({
+        params: {
+          path: page.path.split('/').filter(segment => segment !== ''),
+        },
+      }))
+      .toArray(),
     fallback: 'blocking',
   }
 }) satisfies GetStaticPaths

--- a/examples/basic-typescript/app/[[...path]]/page.tsx
+++ b/examples/basic-typescript/app/[[...path]]/page.tsx
@@ -8,11 +8,12 @@ import { client } from '@/lib/makeswift/client'
 type ParsedUrlQuery = { path?: string[] }
 
 export async function generateStaticParams() {
-  const pages = await client.getPages()
-
-  return pages.map(page => ({
-    path: page.path.split('/').filter(segment => segment !== ''),
-  }))
+  return await client
+    .getPages()
+    .map(page => ({
+      path: page.path.split('/').filter(segment => segment !== ''),
+    }))
+    .toArray()
 }
 
 export default async function Page({ params }: { params: ParsedUrlQuery }) {

--- a/examples/basic-typescript/package.json
+++ b/examples/basic-typescript/package.json
@@ -8,7 +8,7 @@
     "icons": "npx @svgr/cli --typescript --replace-attr-values \"#000=currentColor\" --out-dir generated/icons -- public/icons"
   },
   "dependencies": {
-    "@makeswift/runtime": "^0.18.0",
+    "@makeswift/runtime": "^0.19.0",
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-tabs": "^1.0.4",
     "clsx": "^2.0.0",

--- a/examples/bigcommerce-catalyst/app/(default)/[...path]/page.tsx
+++ b/examples/bigcommerce-catalyst/app/(default)/[...path]/page.tsx
@@ -1,28 +1,28 @@
-import { getSiteVersion } from '@makeswift/runtime/next/server'
-import { notFound } from 'next/navigation'
-import { Page as MakeswiftPage } from '@makeswift/runtime/next'
+import { getSiteVersion } from '@makeswift/runtime/next/server';
+import { notFound } from 'next/navigation';
+import { Page as MakeswiftPage } from '@makeswift/runtime/next';
 
-import { client } from '~/lib/makeswift/client'
-import '~/lib/makeswift/components'
+import { client } from '~/lib/makeswift/client';
+import '~/lib/makeswift/components';
 
-type ParsedUrlQuery = { path?: string[] }
+type ParsedUrlQuery = { path?: string[] };
 
 export async function generateStaticParams() {
-  const pages = await client.getPages()
-
-  return pages.flatMap((page) => ({
+  return await client
+    .getPages()
+    .map((page) => ({
       path: page.path.split('/').filter((segment) => segment !== ''),
-    }),
-  )
+    }))
+    .toArray();
 }
 
 export default async function Page({ params }: { params: ParsedUrlQuery }) {
-  const path = '/' + (params?.path ?? []).join('/')
+  const path = '/' + (params?.path ?? []).join('/');
   const snapshot = await client.getPageSnapshot(path, {
     siteVersion: getSiteVersion(),
-  })
+  });
 
-  if (snapshot == null) return notFound()
+  if (snapshot == null) return notFound();
 
-  return <MakeswiftPage snapshot={snapshot} />
+  return <MakeswiftPage snapshot={snapshot} />;
 }

--- a/examples/bigcommerce-catalyst/package-lock.json
+++ b/examples/bigcommerce-catalyst/package-lock.json
@@ -11,7 +11,7 @@
         "@bigcommerce/catalyst-client": "^0.1.1",
         "@graphql-typed-document-node/core": "^3.2.0",
         "@icons-pack/react-simple-icons": "^9.3.0",
-        "@makeswift/runtime": "^0.18.0",
+        "@makeswift/runtime": "^0.19.0",
         "@radix-ui/react-accordion": "^1.1.2",
         "@radix-ui/react-checkbox": "^1.0.4",
         "@radix-ui/react-dialog": "^1.0.5",
@@ -3800,9 +3800,9 @@
       }
     },
     "node_modules/@makeswift/runtime": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@makeswift/runtime/-/runtime-0.18.0.tgz",
-      "integrity": "sha512-H7GLaZ3/rEiOdmCRph0zku+cCzGcAkJQpvTYA/6gfUEZOF5CDesebmNlmi72moXv6R/ZPAfpKiQ3Kl3cgvkDNg==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@makeswift/runtime/-/runtime-0.19.0.tgz",
+      "integrity": "sha512-vnh7VR5RvVvUwtYSg/1mQ0huReNcKpinq89yBhCURnnIkPHv2Q920HxkktcufKUekrixl2QCVZZpo8xJBPkqkA==",
       "dependencies": {
         "@emotion/cache": "^11.11.0",
         "@emotion/css": "^11.9.0",

--- a/examples/bigcommerce-catalyst/package.json
+++ b/examples/bigcommerce-catalyst/package.json
@@ -17,7 +17,7 @@
     "@bigcommerce/catalyst-client": "^0.1.1",
     "@graphql-typed-document-node/core": "^3.2.0",
     "@icons-pack/react-simple-icons": "^9.3.0",
-    "@makeswift/runtime": "^0.18.0",
+    "@makeswift/runtime": "^0.19.0",
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-dialog": "^1.0.5",

--- a/examples/bigcommerce/package.json
+++ b/examples/bigcommerce/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@headlessui/react": "1.6.6",
-    "@makeswift/runtime": "^0.18.0",
+    "@makeswift/runtime": "^0.19.0",
     "i18next": "22.1.4",
     "next": "^14.2.3",
     "next-i18next": "13.0.0",

--- a/examples/bigcommerce/pages/[[...path]].tsx
+++ b/examples/bigcommerce/pages/[[...path]].tsx
@@ -19,7 +19,7 @@ type Props = MakeswiftPageProps & PageProps
 export async function getStaticPaths(ctx: GetStaticPathsContext) {
   const config = getConfig()
   const makeswift = new Makeswift(config.makeswift.siteApiKey)
-  const pages = await makeswift.getPages()
+  const pages = await makeswift.getPages().toArray()
   const pagesWithLocale = pages.flatMap(page => {
     if (ctx.locales == null) return { page, locale: ctx.defaultLocale }
 

--- a/examples/shopify/package.json
+++ b/examples/shopify/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@headlessui/react": "1.6.6",
-    "@makeswift/runtime": "^0.18.0",
+    "@makeswift/runtime": "^0.19.0",
     "next": "^14.2.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/examples/shopify/pages/[[...path]].tsx
+++ b/examples/shopify/pages/[[...path]].tsx
@@ -17,14 +17,16 @@ type Props = MakeswiftPageProps & PageProps
 export async function getStaticPaths() {
   const config = getConfig()
   const makeswift = new Makeswift(config.makeswift.siteApiKey)
-  const pages = await makeswift.getPages()
 
   return {
-    paths: pages.map(page => ({
-      params: {
-        path: page.path.split('/').filter(segment => segment !== ''),
-      },
-    })),
+    paths: await makeswift
+      .getPages()
+      .map(page => ({
+        params: {
+          path: page.path.split('/').filter(segment => segment !== ''),
+        },
+      }))
+      .toArray(),
     fallback: 'blocking',
   }
 }

--- a/examples/thirdweb/package.json
+++ b/examples/thirdweb/package.json
@@ -13,7 +13,7 @@
     "@chakra-ui/react": "^2.5.5",
     "@emotion/react": "11",
     "@emotion/styled": "11",
-    "@makeswift/runtime": "^0.18.0",
+    "@makeswift/runtime": "^0.19.0",
     "@thirdweb-dev/react": "^3.14.20",
     "@thirdweb-dev/sdk": "^3.10.40",
     "classnames": "2.3.1",

--- a/examples/thirdweb/pages/[[...path]].tsx
+++ b/examples/thirdweb/pages/[[...path]].tsx
@@ -11,14 +11,16 @@ import { GetStaticPropsContext } from 'next'
 export async function getStaticPaths() {
   const config = getConfig()
   const makeswift = new Makeswift(config.makeswiftSiteApiKey)
-  const pages = await makeswift.getPages()
 
   return {
-    paths: pages.map((page) => ({
-      params: {
-        path: page.path.split('/').filter((segment) => segment !== ''),
-      },
-    })),
+    paths: await makeswift
+      .getPages()
+      .map((page) => ({
+        params: {
+          path: page.path.split('/').filter((segment) => segment !== ''),
+        },
+      }))
+      .toArray(),
     fallback: 'blocking',
   }
 }


### PR DESCRIPTION
Currently using the snapshot version of the runtime to test everything. Will modify this PR when the new version of the runtime is released.