### PR TITLE
fix: remove `getPages` `publishedAt` sort option

### DIFF
--- a/.changeset/cold-weeks-hang.md
+++ b/.changeset/cold-weeks-hang.md
@@ -1,0 +1,6 @@
+---
+"@makeswift/runtime": patch
+---
+
+Fixes an invalid `"publishedAt"` sort option for `getPages`, which results in a
+400 exception. Replaces this sort option with `"description"`.

--- a/packages/runtime/src/next/client.ts
+++ b/packages/runtime/src/next/client.ts
@@ -74,7 +74,7 @@ const makeswiftGetPagesResultAPISchema = z.object({
 const makeswiftGetPagesParamsSchema = z.object({
   limit: z.number().optional(),
   after: z.string().optional(),
-  sortBy: z.enum(['title', 'path', 'createdAt', 'updatedAt', 'publishedAt']).optional(),
+  sortBy: z.enum(['title', 'path', 'description', 'createdAt', 'updatedAt']).optional(),
   sortDirection: z.enum(['asc', 'desc']).optional(),
   includeOffline: z.boolean().optional(),
   pathPrefix: z.string().optional(),


### PR DESCRIPTION
Removes the `publishedAt` sort option from the `getPages` client method, replacing it with `description`.