### PR TITLE
fix: create stricter checkbox controls tests

### DIFF
--- a/packages/runtime/src/next/components/tests/controls/__snapshots__/checkbox-control.test.tsx.snap
+++ b/packages/runtime/src/next/components/tests/controls/__snapshots__/checkbox-control.test.tsx.snap
@@ -52,6 +52,58 @@ exports[`Page can render CheckboxControl v0 data 1`] = `
 }
 `;
 
+exports[`Page can render CheckboxControl v0 data 2`] = `
+{
+  "apiOrigin": "https://test-api-origin.com",
+  "cacheData": {},
+  "document": {
+    "data": {
+      "key": "00000000-0000-0000-0000-000000000000",
+      "props": {
+        "children": {
+          "columns": [
+            {
+              "deviceId": "desktop",
+              "value": {
+                "count": 12,
+                "spans": [
+                  [
+                    12,
+                  ],
+                ],
+              },
+            },
+          ],
+          "elements": [
+            {
+              "key": "11111111-1111-1111-1111-111111111111",
+              "props": {
+                "checkbox": false,
+              },
+              "type": "TestComponent",
+            },
+          ],
+        },
+      },
+      "type": "./components/Root/index.js",
+    },
+    "fonts": [],
+    "id": "test-page-id",
+    "locale": null,
+    "localizedPages": [],
+    "meta": {},
+    "seo": {},
+    "site": {
+      "id": "test-site-id",
+    },
+    "snippets": [],
+  },
+  "locale": null,
+  "localizedResourcesMap": {},
+  "preview": false,
+}
+`;
+
 exports[`Page can render CheckboxControl v1 data 1`] = `
 {
   "apiOrigin": "https://test-api-origin.com",
@@ -81,6 +133,61 @@ exports[`Page can render CheckboxControl v1 data 1`] = `
                 "checkbox": {
                   "@@makeswift/type": "checkbox::v1",
                   "value": true,
+                },
+              },
+              "type": "TestComponent",
+            },
+          ],
+        },
+      },
+      "type": "./components/Root/index.js",
+    },
+    "fonts": [],
+    "id": "test-page-id",
+    "locale": null,
+    "localizedPages": [],
+    "meta": {},
+    "seo": {},
+    "site": {
+      "id": "test-site-id",
+    },
+    "snippets": [],
+  },
+  "locale": null,
+  "localizedResourcesMap": {},
+  "preview": false,
+}
+`;
+
+exports[`Page can render CheckboxControl v1 data 2`] = `
+{
+  "apiOrigin": "https://test-api-origin.com",
+  "cacheData": {},
+  "document": {
+    "data": {
+      "key": "00000000-0000-0000-0000-000000000000",
+      "props": {
+        "children": {
+          "columns": [
+            {
+              "deviceId": "desktop",
+              "value": {
+                "count": 12,
+                "spans": [
+                  [
+                    12,
+                  ],
+                ],
+              },
+            },
+          ],
+          "elements": [
+            {
+              "key": "11111111-1111-1111-1111-111111111111",
+              "props": {
+                "checkbox": {
+                  "@@makeswift/type": "checkbox::v1",
+                  "value": false,
                 },
               },
               "type": "TestComponent",

--- a/packages/runtime/src/next/components/tests/controls/checkbox-control.test.tsx
+++ b/packages/runtime/src/next/components/tests/controls/checkbox-control.test.tsx
@@ -26,9 +26,9 @@ const ROOT_ID = '00000000-0000-0000-0000-000000000000'
 const ELEMENT_ID = '11111111-1111-1111-1111-111111111111'
 
 describe('Page', () => {
-  test('can render CheckboxControl v0 data', async () => {
+  test.each([true, false])('can render CheckboxControl v0 data', async bool => {
     // Arrange
-    const checkboxControlData: CheckboxControlDataV0 = true
+    const checkboxControlData: CheckboxControlDataV0 = bool
     const TestComponentType = 'TestComponent'
     const testId = 'test-id'
     const elementData: ElementData = createRootComponent(
@@ -51,7 +51,7 @@ describe('Page', () => {
       forwardRef<HTMLDivElement, { checkbox?: CheckboxControlData }>(({ checkbox }, ref) => {
         return (
           <div ref={ref} data-testid={testId}>
-            {checkbox ? 'alpha' : 'beta'}
+            {JSON.stringify(checkbox)}
           </div>
         )
       }),
@@ -74,14 +74,14 @@ describe('Page', () => {
     )
 
     expect(snapshot).toMatchSnapshot()
-    expect(screen.getByTestId(testId)).toHaveTextContent('alpha')
+    expect(JSON.parse(screen.getByTestId(testId).textContent ?? '')).toBe(bool)
   })
 
-  test('can render CheckboxControl v1 data', async () => {
+  test.each([true, false])('can render CheckboxControl v1 data', async bool => {
     // Arrange
     const checkboxControlData: CheckboxControlDataV1 = {
       [CheckboxControlDataTypeKey]: CheckboxControlDataTypeValueV1,
-      value: true,
+      value: bool,
     }
 
     const TestComponentType = 'TestComponent'
@@ -106,7 +106,7 @@ describe('Page', () => {
       forwardRef<HTMLDivElement, { checkbox?: CheckboxControlData }>(({ checkbox }, ref) => {
         return (
           <div ref={ref} data-testid={testId}>
-            {checkbox ? 'alpha' : 'beta'}
+            {JSON.stringify(checkbox)}
           </div>
         )
       }),
@@ -129,6 +129,6 @@ describe('Page', () => {
     )
 
     expect(snapshot).toMatchSnapshot()
-    expect(screen.getByTestId(testId)).toHaveTextContent('alpha')
+    expect(JSON.parse(screen.getByTestId(testId).textContent ?? '')).toBe(bool)
   })
 })


### PR DESCRIPTION
Rewrites the checkbox control tests to check exact DOM node contents rather than ternary based text inclusions. Also uses data-driven unit tests to check all boolean values.