### PR TITLE
refactor: create control test helper

### DIFF
--- a/packages/controls/package.json
+++ b/packages/controls/package.json
@@ -12,7 +12,8 @@
     "dev": "concurrently -k 'tsc --watch --preserveWatchOutput' 'tsup src/index.ts --watch'",
     "build": "tsc && tsup src/index.ts",
     "prepublishOnly": "turbo run build",
-    "test": "jest --passWithNoTests"
+    "test": "jest --passWithNoTests",
+    "clean": "rm -rf dist"
   },
   "dependencies": {
     "ts-pattern": "^5.0.8",

--- a/packages/prop-controllers/package.json
+++ b/packages/prop-controllers/package.json
@@ -10,6 +10,7 @@
   "types": "./dist/types/index.d.ts",
   "scripts": {
     "dev": "concurrently -k 'tsc --watch --preserveWatchOutput' 'tsup src/index.ts --watch'",
+    "clean": "rm -rf dist",
     "build": "tsc && tsup src/index.ts",
     "prepublishOnly": "turbo run build",
     "test": "jest"

--- a/packages/runtime/jest.config.ts
+++ b/packages/runtime/jest.config.ts
@@ -7,8 +7,11 @@ const config: Config = {
     // "**/__tests__/**/*.[jt]s?(x)",
     '**/?(*.)+(spec|test).[tj]s?(x)',
   ],
+  setupFiles: ['./jest.polyfills.js'],
   setupFilesAfterEnv: ['<rootDir>/src/jest-setup.ts'],
+  resolver: `${__dirname}/jest.resolver.js`,
   transform: {
+    '^.+\\.(t|j)s?$': '@swc/jest',
     '^.+\\.(t|j)sx?$': [
       '@swc/jest',
       {

--- a/packages/runtime/jest.polyfills.js
+++ b/packages/runtime/jest.polyfills.js
@@ -1,0 +1,36 @@
+/**
+ * @note The block below contains polyfills for Node.js globals
+ * required for Jest to function when running JSDOM tests.
+ * These HAVE to be require's and HAVE to be in this exact
+ * order, since "undici" depends on the "TextEncoder" global API.
+ *
+ * Consider migrating to a more modern test runner if
+ * you don't want to deal with this.
+ */
+
+const { TextDecoder, TextEncoder } = require('node:util')
+const { ReadableStream, TransformStream } = require('node:stream/web')
+const { clearImmediate } = require('node:timers')
+const { performance } = require('node:perf_hooks')
+
+Object.defineProperties(globalThis, {
+  TextDecoder: { value: TextDecoder },
+  TextEncoder: { value: TextEncoder },
+  ReadableStream: { value: ReadableStream },
+  TransformStream: { value: TransformStream },
+  clearImmediate: { value: clearImmediate },
+  performance: { value: performance },
+})
+
+const { Blob, File } = require('node:buffer')
+const { fetch, Headers, FormData, Request, Response } = require('undici')
+
+Object.defineProperties(globalThis, {
+  fetch: { value: fetch, writable: true },
+  Blob: { value: Blob },
+  File: { value: File },
+  Headers: { value: Headers },
+  FormData: { value: FormData },
+  Request: { value: Request },
+  Response: { value: Response },
+})

--- a/packages/runtime/jest.resolver.js
+++ b/packages/runtime/jest.resolver.js
@@ -1,0 +1,19 @@
+// Based on https://github.com/microsoft/accessibility-insights-web/pull/5421#issuecomment-1109168149
+module.exports = (path, options) => {
+  // Call the defaultResolver, so we leverage its cache, error handling, etc.
+  return options.defaultResolver(path, {
+    ...options,
+    // Use packageFilter to process parsed `package.json` before the resolution
+    // (see https://www.npmjs.com/package/resolve#resolveid-opts-cb)
+    packageFilter: pkg => {
+      if (pkg.name === 'msw') {
+        delete pkg.exports['./node'].browser
+      }
+      if (pkg.name === '@mswjs/interceptors') {
+        delete pkg.exports
+      }
+
+      return pkg
+    },
+  })
+}

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -182,6 +182,7 @@
     "slate-hyperscript": "^0.77.0",
     "slate-react": "^0.91.7",
     "tsup": "^8.0.1",
-    "typescript": "^5.1.6"
+    "typescript": "^5.1.6",
+    "undici": "^6.19.2"
   }
 }

--- a/packages/runtime/src/jest-setup.ts
+++ b/packages/runtime/src/jest-setup.ts
@@ -1,5 +1,10 @@
 import '@testing-library/jest-dom'
 import { matchers } from '@emotion/jest'
+import { server } from './mocks/server'
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
 
 expect.extend(matchers)
 

--- a/packages/runtime/src/mocks/server.ts
+++ b/packages/runtime/src/mocks/server.ts
@@ -1,0 +1,3 @@
+import { setupServer } from 'msw/node'
+
+export const server = setupServer()

--- a/packages/runtime/src/next/components/tests/controls/__snapshots__/checkbox-control.test.tsx.snap
+++ b/packages/runtime/src/next/components/tests/controls/__snapshots__/checkbox-control.test.tsx.snap
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Page can render CheckboxControl v0 data 1`] = `
+exports[`Page Checkbox control data v0 when value is false: resolvedValue 1`] = `false`;
+
+exports[`Page Checkbox control data v0 when value is false: snapshot 1`] = `
 {
   "apiOrigin": "https://test-api-origin.com",
   "cacheData": {},
@@ -26,7 +28,7 @@ exports[`Page can render CheckboxControl v0 data 1`] = `
             {
               "key": "11111111-1111-1111-1111-111111111111",
               "props": {
-                "checkbox": true,
+                "propKey": false,
               },
               "type": "TestComponent",
             },
@@ -52,7 +54,9 @@ exports[`Page can render CheckboxControl v0 data 1`] = `
 }
 `;
 
-exports[`Page can render CheckboxControl v0 data 2`] = `
+exports[`Page Checkbox control data v0 when value is true: resolvedValue 1`] = `true`;
+
+exports[`Page Checkbox control data v0 when value is true: snapshot 1`] = `
 {
   "apiOrigin": "https://test-api-origin.com",
   "cacheData": {},
@@ -78,7 +82,7 @@ exports[`Page can render CheckboxControl v0 data 2`] = `
             {
               "key": "11111111-1111-1111-1111-111111111111",
               "props": {
-                "checkbox": false,
+                "propKey": true,
               },
               "type": "TestComponent",
             },
@@ -104,7 +108,9 @@ exports[`Page can render CheckboxControl v0 data 2`] = `
 }
 `;
 
-exports[`Page can render CheckboxControl v1 data 1`] = `
+exports[`Page Checkbox control data v1 when value is false: resolvedValue 1`] = `false`;
+
+exports[`Page Checkbox control data v1 when value is false: snapshot 1`] = `
 {
   "apiOrigin": "https://test-api-origin.com",
   "cacheData": {},
@@ -130,9 +136,9 @@ exports[`Page can render CheckboxControl v1 data 1`] = `
             {
               "key": "11111111-1111-1111-1111-111111111111",
               "props": {
-                "checkbox": {
+                "propKey": {
                   "@@makeswift/type": "checkbox::v1",
-                  "value": true,
+                  "value": false,
                 },
               },
               "type": "TestComponent",
@@ -159,7 +165,9 @@ exports[`Page can render CheckboxControl v1 data 1`] = `
 }
 `;
 
-exports[`Page can render CheckboxControl v1 data 2`] = `
+exports[`Page Checkbox control data v1 when value is true: resolvedValue 1`] = `true`;
+
+exports[`Page Checkbox control data v1 when value is true: snapshot 1`] = `
 {
   "apiOrigin": "https://test-api-origin.com",
   "cacheData": {},
@@ -185,9 +193,9 @@ exports[`Page can render CheckboxControl v1 data 2`] = `
             {
               "key": "11111111-1111-1111-1111-111111111111",
               "props": {
-                "checkbox": {
+                "propKey": {
                   "@@makeswift/type": "checkbox::v1",
-                  "value": false,
+                  "value": true,
                 },
               },
               "type": "TestComponent",

--- a/packages/runtime/src/next/components/tests/controls/__snapshots__/color-control.test.tsx.snap
+++ b/packages/runtime/src/next/components/tests/controls/__snapshots__/color-control.test.tsx.snap
@@ -1,0 +1,501 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Page Color control data v0 with value: {"alpha": 0.5, "swatchId": "[swatch-test-id]"}, swatch: {"__typename": "Swatch", "hue": 238, "lightness": 49, "saturation": 87}, default value: rgb(255,0,0) fetching swatch: resolvedValue 1`] = `"rgba(16, 24, 234, 0.5)"`;
+
+exports[`Page Color control data v0 with value: {"alpha": 0.5, "swatchId": "[swatch-test-id]"}, swatch: {"__typename": "Swatch", "hue": 238, "lightness": 49, "saturation": 87}, default value: rgb(255,0,0) fetching swatch: snapshot 1`] = `
+{
+  "apiOrigin": "https://test-api-origin.com",
+  "cacheData": {},
+  "document": {
+    "data": {
+      "key": "00000000-0000-0000-0000-000000000000",
+      "props": {
+        "children": {
+          "columns": [
+            {
+              "deviceId": "desktop",
+              "value": {
+                "count": 12,
+                "spans": [
+                  [
+                    12,
+                  ],
+                ],
+              },
+            },
+          ],
+          "elements": [
+            {
+              "key": "11111111-1111-1111-1111-111111111111",
+              "props": {
+                "propKey": {
+                  "alpha": 0.5,
+                  "swatchId": "[swatch-test-id]",
+                },
+              },
+              "type": "TestComponent",
+            },
+          ],
+        },
+      },
+      "type": "./components/Root/index.js",
+    },
+    "fonts": [],
+    "id": "test-page-id",
+    "locale": null,
+    "localizedPages": [],
+    "meta": {},
+    "seo": {},
+    "site": {
+      "id": "test-site-id",
+    },
+    "snippets": [],
+  },
+  "locale": null,
+  "localizedResourcesMap": {},
+  "preview": false,
+}
+`;
+
+exports[`Page Color control data v0 with value: {"alpha": 0.5, "swatchId": "[swatch-test-id]"}, swatch: {"__typename": "Swatch", "hue": 238, "lightness": 49, "saturation": 87}, default value: rgb(255,0,0) reading swatch from cache: resolvedValue 1`] = `"rgba(16, 24, 234, 0.5)"`;
+
+exports[`Page Color control data v0 with value: {"alpha": 0.5, "swatchId": "[swatch-test-id]"}, swatch: {"__typename": "Swatch", "hue": 238, "lightness": 49, "saturation": 87}, default value: rgb(255,0,0) reading swatch from cache: snapshot 1`] = `
+{
+  "apiOrigin": "https://test-api-origin.com",
+  "cacheData": {
+    "Swatch": [
+      {
+        "id": "[swatch-test-id]",
+        "value": {
+          "__typename": "Swatch",
+          "hue": 238,
+          "id": "[swatch-test-id]",
+          "lightness": 49,
+          "saturation": 87,
+        },
+      },
+    ],
+  },
+  "document": {
+    "data": {
+      "key": "00000000-0000-0000-0000-000000000000",
+      "props": {
+        "children": {
+          "columns": [
+            {
+              "deviceId": "desktop",
+              "value": {
+                "count": 12,
+                "spans": [
+                  [
+                    12,
+                  ],
+                ],
+              },
+            },
+          ],
+          "elements": [
+            {
+              "key": "11111111-1111-1111-1111-111111111111",
+              "props": {
+                "propKey": {
+                  "alpha": 0.5,
+                  "swatchId": "[swatch-test-id]",
+                },
+              },
+              "type": "TestComponent",
+            },
+          ],
+        },
+      },
+      "type": "./components/Root/index.js",
+    },
+    "fonts": [],
+    "id": "test-page-id",
+    "locale": null,
+    "localizedPages": [],
+    "meta": {},
+    "seo": {},
+    "site": {
+      "id": "test-site-id",
+    },
+    "snippets": [],
+  },
+  "locale": null,
+  "localizedResourcesMap": {},
+  "preview": false,
+}
+`;
+
+exports[`Page Color control data v0 with value: {"alpha": 0.5, "swatchId": "[swatch-test-id]"}, swatch: null, default value: rgb(255,0,0) fetching swatch: resolvedValue 1`] = `"rgb(255, 0, 0)"`;
+
+exports[`Page Color control data v0 with value: {"alpha": 0.5, "swatchId": "[swatch-test-id]"}, swatch: null, default value: rgb(255,0,0) fetching swatch: snapshot 1`] = `
+{
+  "apiOrigin": "https://test-api-origin.com",
+  "cacheData": {},
+  "document": {
+    "data": {
+      "key": "00000000-0000-0000-0000-000000000000",
+      "props": {
+        "children": {
+          "columns": [
+            {
+              "deviceId": "desktop",
+              "value": {
+                "count": 12,
+                "spans": [
+                  [
+                    12,
+                  ],
+                ],
+              },
+            },
+          ],
+          "elements": [
+            {
+              "key": "11111111-1111-1111-1111-111111111111",
+              "props": {
+                "propKey": {
+                  "alpha": 0.5,
+                  "swatchId": "[swatch-test-id]",
+                },
+              },
+              "type": "TestComponent",
+            },
+          ],
+        },
+      },
+      "type": "./components/Root/index.js",
+    },
+    "fonts": [],
+    "id": "test-page-id",
+    "locale": null,
+    "localizedPages": [],
+    "meta": {},
+    "seo": {},
+    "site": {
+      "id": "test-site-id",
+    },
+    "snippets": [],
+  },
+  "locale": null,
+  "localizedResourcesMap": {},
+  "preview": false,
+}
+`;
+
+exports[`Page Color control data v0 with value: {"alpha": 0.5, "swatchId": "[swatch-test-id]"}, swatch: null, default value: rgb(255,0,0) reading swatch from cache: resolvedValue 1`] = `"rgb(255, 0, 0)"`;
+
+exports[`Page Color control data v0 with value: {"alpha": 0.5, "swatchId": "[swatch-test-id]"}, swatch: null, default value: rgb(255,0,0) reading swatch from cache: snapshot 1`] = `
+{
+  "apiOrigin": "https://test-api-origin.com",
+  "cacheData": {
+    "Swatch": [
+      {
+        "id": "[swatch-test-id]",
+        "value": null,
+      },
+    ],
+  },
+  "document": {
+    "data": {
+      "key": "00000000-0000-0000-0000-000000000000",
+      "props": {
+        "children": {
+          "columns": [
+            {
+              "deviceId": "desktop",
+              "value": {
+                "count": 12,
+                "spans": [
+                  [
+                    12,
+                  ],
+                ],
+              },
+            },
+          ],
+          "elements": [
+            {
+              "key": "11111111-1111-1111-1111-111111111111",
+              "props": {
+                "propKey": {
+                  "alpha": 0.5,
+                  "swatchId": "[swatch-test-id]",
+                },
+              },
+              "type": "TestComponent",
+            },
+          ],
+        },
+      },
+      "type": "./components/Root/index.js",
+    },
+    "fonts": [],
+    "id": "test-page-id",
+    "locale": null,
+    "localizedPages": [],
+    "meta": {},
+    "seo": {},
+    "site": {
+      "id": "test-site-id",
+    },
+    "snippets": [],
+  },
+  "locale": null,
+  "localizedResourcesMap": {},
+  "preview": false,
+}
+`;
+
+exports[`Page Color control data v1 with value: {"alpha": 0.5, "swatchId": "[swatch-test-id]"}, swatch: {"__typename": "Swatch", "hue": 238, "lightness": 49, "saturation": 87}, default value: rgb(255,0,0) fetching swatch: resolvedValue 1`] = `"rgba(16, 24, 234, 0.5)"`;
+
+exports[`Page Color control data v1 with value: {"alpha": 0.5, "swatchId": "[swatch-test-id]"}, swatch: {"__typename": "Swatch", "hue": 238, "lightness": 49, "saturation": 87}, default value: rgb(255,0,0) fetching swatch: snapshot 1`] = `
+{
+  "apiOrigin": "https://test-api-origin.com",
+  "cacheData": {},
+  "document": {
+    "data": {
+      "key": "00000000-0000-0000-0000-000000000000",
+      "props": {
+        "children": {
+          "columns": [
+            {
+              "deviceId": "desktop",
+              "value": {
+                "count": 12,
+                "spans": [
+                  [
+                    12,
+                  ],
+                ],
+              },
+            },
+          ],
+          "elements": [
+            {
+              "key": "11111111-1111-1111-1111-111111111111",
+              "props": {
+                "propKey": {
+                  "@@makeswift/type": "color::v1",
+                  "alpha": 0.5,
+                  "swatchId": "[swatch-test-id]",
+                },
+              },
+              "type": "TestComponent",
+            },
+          ],
+        },
+      },
+      "type": "./components/Root/index.js",
+    },
+    "fonts": [],
+    "id": "test-page-id",
+    "locale": null,
+    "localizedPages": [],
+    "meta": {},
+    "seo": {},
+    "site": {
+      "id": "test-site-id",
+    },
+    "snippets": [],
+  },
+  "locale": null,
+  "localizedResourcesMap": {},
+  "preview": false,
+}
+`;
+
+exports[`Page Color control data v1 with value: {"alpha": 0.5, "swatchId": "[swatch-test-id]"}, swatch: {"__typename": "Swatch", "hue": 238, "lightness": 49, "saturation": 87}, default value: rgb(255,0,0) reading swatch from cache: resolvedValue 1`] = `"rgba(16, 24, 234, 0.5)"`;
+
+exports[`Page Color control data v1 with value: {"alpha": 0.5, "swatchId": "[swatch-test-id]"}, swatch: {"__typename": "Swatch", "hue": 238, "lightness": 49, "saturation": 87}, default value: rgb(255,0,0) reading swatch from cache: snapshot 1`] = `
+{
+  "apiOrigin": "https://test-api-origin.com",
+  "cacheData": {
+    "Swatch": [
+      {
+        "id": "[swatch-test-id]",
+        "value": {
+          "__typename": "Swatch",
+          "hue": 238,
+          "id": "[swatch-test-id]",
+          "lightness": 49,
+          "saturation": 87,
+        },
+      },
+    ],
+  },
+  "document": {
+    "data": {
+      "key": "00000000-0000-0000-0000-000000000000",
+      "props": {
+        "children": {
+          "columns": [
+            {
+              "deviceId": "desktop",
+              "value": {
+                "count": 12,
+                "spans": [
+                  [
+                    12,
+                  ],
+                ],
+              },
+            },
+          ],
+          "elements": [
+            {
+              "key": "11111111-1111-1111-1111-111111111111",
+              "props": {
+                "propKey": {
+                  "@@makeswift/type": "color::v1",
+                  "alpha": 0.5,
+                  "swatchId": "[swatch-test-id]",
+                },
+              },
+              "type": "TestComponent",
+            },
+          ],
+        },
+      },
+      "type": "./components/Root/index.js",
+    },
+    "fonts": [],
+    "id": "test-page-id",
+    "locale": null,
+    "localizedPages": [],
+    "meta": {},
+    "seo": {},
+    "site": {
+      "id": "test-site-id",
+    },
+    "snippets": [],
+  },
+  "locale": null,
+  "localizedResourcesMap": {},
+  "preview": false,
+}
+`;
+
+exports[`Page Color control data v1 with value: {"alpha": 0.5, "swatchId": "[swatch-test-id]"}, swatch: null, default value: rgb(255,0,0) fetching swatch: resolvedValue 1`] = `"rgb(255, 0, 0)"`;
+
+exports[`Page Color control data v1 with value: {"alpha": 0.5, "swatchId": "[swatch-test-id]"}, swatch: null, default value: rgb(255,0,0) fetching swatch: snapshot 1`] = `
+{
+  "apiOrigin": "https://test-api-origin.com",
+  "cacheData": {},
+  "document": {
+    "data": {
+      "key": "00000000-0000-0000-0000-000000000000",
+      "props": {
+        "children": {
+          "columns": [
+            {
+              "deviceId": "desktop",
+              "value": {
+                "count": 12,
+                "spans": [
+                  [
+                    12,
+                  ],
+                ],
+              },
+            },
+          ],
+          "elements": [
+            {
+              "key": "11111111-1111-1111-1111-111111111111",
+              "props": {
+                "propKey": {
+                  "@@makeswift/type": "color::v1",
+                  "alpha": 0.5,
+                  "swatchId": "[swatch-test-id]",
+                },
+              },
+              "type": "TestComponent",
+            },
+          ],
+        },
+      },
+      "type": "./components/Root/index.js",
+    },
+    "fonts": [],
+    "id": "test-page-id",
+    "locale": null,
+    "localizedPages": [],
+    "meta": {},
+    "seo": {},
+    "site": {
+      "id": "test-site-id",
+    },
+    "snippets": [],
+  },
+  "locale": null,
+  "localizedResourcesMap": {},
+  "preview": false,
+}
+`;
+
+exports[`Page Color control data v1 with value: {"alpha": 0.5, "swatchId": "[swatch-test-id]"}, swatch: null, default value: rgb(255,0,0) reading swatch from cache: resolvedValue 1`] = `"rgb(255, 0, 0)"`;
+
+exports[`Page Color control data v1 with value: {"alpha": 0.5, "swatchId": "[swatch-test-id]"}, swatch: null, default value: rgb(255,0,0) reading swatch from cache: snapshot 1`] = `
+{
+  "apiOrigin": "https://test-api-origin.com",
+  "cacheData": {
+    "Swatch": [
+      {
+        "id": "[swatch-test-id]",
+        "value": null,
+      },
+    ],
+  },
+  "document": {
+    "data": {
+      "key": "00000000-0000-0000-0000-000000000000",
+      "props": {
+        "children": {
+          "columns": [
+            {
+              "deviceId": "desktop",
+              "value": {
+                "count": 12,
+                "spans": [
+                  [
+                    12,
+                  ],
+                ],
+              },
+            },
+          ],
+          "elements": [
+            {
+              "key": "11111111-1111-1111-1111-111111111111",
+              "props": {
+                "propKey": {
+                  "@@makeswift/type": "color::v1",
+                  "alpha": 0.5,
+                  "swatchId": "[swatch-test-id]",
+                },
+              },
+              "type": "TestComponent",
+            },
+          ],
+        },
+      },
+      "type": "./components/Root/index.js",
+    },
+    "fonts": [],
+    "id": "test-page-id",
+    "locale": null,
+    "localizedPages": [],
+    "meta": {},
+    "seo": {},
+    "site": {
+      "id": "test-site-id",
+    },
+    "snippets": [],
+  },
+  "locale": null,
+  "localizedResourcesMap": {},
+  "preview": false,
+}
+`;

--- a/packages/runtime/src/next/components/tests/controls/checkbox-control.test.tsx
+++ b/packages/runtime/src/next/components/tests/controls/checkbox-control.test.tsx
@@ -1,134 +1,27 @@
 /** @jest-environment jsdom */
-
-import { render, screen } from '@testing-library/react'
-import '@testing-library/jest-dom'
-
-import { ElementData } from '../../../../state/react-page'
-import { Page } from '../../page'
-import { act } from 'react-dom/test-utils'
-import { ReactRuntimeProvider } from '../../../context/react-runtime'
-import { ReactRuntime } from '../../../../react'
-import { forwardRef } from 'react'
-import {
-  createMakeswiftPageSnapshot,
-  createRootComponent,
-} from '../../../../utils/tests/element-data-test-test'
 import {
   Checkbox,
-  CheckboxControlData,
   CheckboxControlDataTypeKey,
   CheckboxControlDataTypeValueV1,
-  CheckboxControlDataV0,
-  CheckboxControlDataV1,
 } from '@makeswift/controls'
-
-const ROOT_ID = '00000000-0000-0000-0000-000000000000'
-const ELEMENT_ID = '11111111-1111-1111-1111-111111111111'
+import { testPageControlPropRendering } from './page-control-prop-rendering'
 
 describe('Page', () => {
-  test.each([true, false])('can render CheckboxControl v0 data', async bool => {
-    // Arrange
-    const checkboxControlData: CheckboxControlDataV0 = bool
-    const TestComponentType = 'TestComponent'
-    const testId = 'test-id'
-    const elementData: ElementData = createRootComponent(
-      [
-        {
-          key: ELEMENT_ID,
-          type: TestComponentType,
-          props: {
-            checkbox: checkboxControlData,
-          },
-        },
-      ],
-      ROOT_ID,
-    )
-    const snapshot = createMakeswiftPageSnapshot(elementData)
-    const runtime = new ReactRuntime()
-
-    // Act
-    runtime.registerComponent(
-      forwardRef<HTMLDivElement, { checkbox?: CheckboxControlData }>(({ checkbox }, ref) => {
-        return (
-          <div ref={ref} data-testid={testId}>
-            {JSON.stringify(checkbox)}
-          </div>
-        )
+  describe.each([
+    {
+      version: 0,
+      toData: (value: boolean | undefined) => value,
+    },
+    {
+      version: 1,
+      toData: (value: boolean | undefined) => ({
+        [CheckboxControlDataTypeKey]: CheckboxControlDataTypeValueV1,
+        value,
       }),
-      {
-        type: TestComponentType,
-        label: 'TestComponent',
-        props: {
-          checkbox: Checkbox(),
-        },
-      },
-    )
-
-    // Assert
-    await act(async () =>
-      render(
-        <ReactRuntimeProvider runtime={runtime}>
-          <Page snapshot={snapshot} />
-        </ReactRuntimeProvider>,
-      ),
-    )
-
-    expect(snapshot).toMatchSnapshot()
-    expect(JSON.parse(screen.getByTestId(testId).textContent ?? '')).toBe(bool)
-  })
-
-  test.each([true, false])('can render CheckboxControl v1 data', async bool => {
-    // Arrange
-    const checkboxControlData: CheckboxControlDataV1 = {
-      [CheckboxControlDataTypeKey]: CheckboxControlDataTypeValueV1,
-      value: bool,
-    }
-
-    const TestComponentType = 'TestComponent'
-    const testId = 'test-id'
-    const elementData: ElementData = createRootComponent(
-      [
-        {
-          key: ELEMENT_ID,
-          type: TestComponentType,
-          props: {
-            checkbox: checkboxControlData,
-          },
-        },
-      ],
-      ROOT_ID,
-    )
-    const snapshot = createMakeswiftPageSnapshot(elementData)
-    const runtime = new ReactRuntime()
-
-    // Act
-    runtime.registerComponent(
-      forwardRef<HTMLDivElement, { checkbox?: CheckboxControlData }>(({ checkbox }, ref) => {
-        return (
-          <div ref={ref} data-testid={testId}>
-            {JSON.stringify(checkbox)}
-          </div>
-        )
-      }),
-      {
-        type: TestComponentType,
-        label: 'TestComponent',
-        props: {
-          checkbox: Checkbox(),
-        },
-      },
-    )
-
-    // Assert
-    await act(async () =>
-      render(
-        <ReactRuntimeProvider runtime={runtime}>
-          <Page snapshot={snapshot} />
-        </ReactRuntimeProvider>,
-      ),
-    )
-
-    expect(snapshot).toMatchSnapshot()
-    expect(JSON.parse(screen.getByTestId(testId).textContent ?? '')).toBe(bool)
+    },
+  ])('Checkbox control data v$version', ({ toData }) => {
+    test.each([true, false])(`when value is %s`, async value => {
+      await testPageControlPropRendering(Checkbox(), { toData: toData as any, value })
+    })
   })
 })

--- a/packages/runtime/src/next/components/tests/controls/color-control.test.tsx
+++ b/packages/runtime/src/next/components/tests/controls/color-control.test.tsx
@@ -1,0 +1,86 @@
+/** @jest-environment jsdom */
+
+import {
+  Color,
+  ColorControlDataTypeKey,
+  ColorControlDataTypeValueV1,
+  ColorData,
+} from '@makeswift/controls'
+import { testPageControlPropRendering } from './page-control-prop-rendering'
+import { http, HttpResponse } from 'msw'
+import { server } from '../../../../mocks/server'
+import { APIResourceType } from '../../../../api'
+
+const swatchesBaseUrl = `/api/makeswift/swatches`
+
+describe('Page', () => {
+  describe.each([
+    {
+      version: 0,
+      toData: (value: ColorData) => value,
+    },
+    {
+      version: 1,
+      toData: (value: ColorData) => ({
+        [ColorControlDataTypeKey]: ColorControlDataTypeValueV1,
+        ...value,
+      }),
+    },
+  ])('Color control data v$version', ({ toData }) => {
+    const swatchId = '[swatch-test-id]'
+
+    describe.each([
+      {
+        value: {
+          swatchId,
+          alpha: 0.5,
+        },
+        swatch: {
+          __typename: APIResourceType.Swatch,
+          hue: 238,
+          saturation: 87,
+          lightness: 49,
+        },
+        defaultValue: 'rgb(255,0,0)',
+      },
+      {
+        value: {
+          swatchId,
+          alpha: 0.5,
+        },
+        swatch: null,
+        defaultValue: 'rgb(255,0,0)',
+      },
+    ])(
+      `with value: $value, swatch: $swatch, default value: $defaultValue`,
+      ({ value, defaultValue, swatch }) => {
+        test(`fetching swatch`, async () => {
+          server.use(
+            http.get(`${swatchesBaseUrl}/${swatchId}`, () =>
+              HttpResponse.json(swatch ? { id: swatchId, ...swatch } : null),
+            ),
+          )
+
+          await testPageControlPropRendering(Color({ defaultValue }), {
+            toData: toData as any,
+            value,
+            expectedRenders: swatch == null ? 1 : 2,
+          })
+        })
+
+        test(`reading swatch from cache`, async () => {
+          await testPageControlPropRendering(Color({ defaultValue }), {
+            toData: toData as any,
+            value,
+            cacheData: {
+              Swatch: [
+                { id: swatchId, value: swatch == null ? null : { id: swatchId, ...swatch } },
+              ],
+            },
+            expectedRenders: 1,
+          })
+        })
+      },
+    )
+  })
+})

--- a/packages/runtime/src/next/components/tests/controls/page-control-prop-rendering.tsx
+++ b/packages/runtime/src/next/components/tests/controls/page-control-prop-rendering.tsx
@@ -1,0 +1,96 @@
+/** @jest-environment jsdom */
+
+import { forwardRef, useRef } from 'react'
+import { act } from 'react-dom/test-utils'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+
+import { Data } from '@makeswift/controls'
+
+import { ElementData } from '../../../../state/react-page'
+import { Page } from '../../page'
+import { ReactRuntimeProvider } from '../../../context/react-runtime'
+import { ReactRuntime } from '../../../../react'
+
+import {
+  createMakeswiftPageSnapshot,
+  createRootComponent,
+} from '../../../../utils/tests/element-data-test-test'
+
+import { type MakeswiftPageSnapshot } from '../../../../next'
+import { ControlDefinition, ControlDefinitionData } from '../../../../controls'
+
+const ROOT_ID = '00000000-0000-0000-0000-000000000000'
+const ELEMENT_ID = '11111111-1111-1111-1111-111111111111'
+
+export async function testPageControlPropRendering<T extends ControlDefinition>(
+  controlDefinition: T,
+  {
+    toData,
+    value,
+    cacheData,
+    expectedRenders,
+  }: {
+    toData: (value: Data) => ControlDefinitionData<T>
+    value: Data
+    cacheData?: MakeswiftPageSnapshot['cacheData']
+    expectedRenders?: number
+  },
+) {
+  // Arrange
+  const controlData = toData(value)
+  const TestComponentType = 'TestComponent'
+  const testId = 'test-id'
+  const renderCountTestId = 'render-count-test-id'
+  const elementData: ElementData = createRootComponent(
+    [
+      {
+        key: ELEMENT_ID,
+        type: TestComponentType,
+        props: {
+          propKey: controlData,
+        },
+      },
+    ],
+    ROOT_ID,
+  )
+  const snapshot = createMakeswiftPageSnapshot(elementData, {}, cacheData)
+  const runtime = new ReactRuntime()
+
+  // Act
+  runtime.registerComponent(
+    forwardRef<HTMLDivElement, { propKey?: any }>(({ propKey }, ref) => {
+      const renderCount = useRef(0)
+      ++renderCount.current
+      return (
+        <div ref={ref}>
+          <div data-testid={renderCountTestId}>{renderCount.current}</div>
+          <div data-testid={testId}>{JSON.stringify(propKey)}</div>
+        </div>
+      )
+    }),
+    {
+      type: TestComponentType,
+      label: 'TestComponent',
+      props: {
+        propKey: controlDefinition,
+      },
+    },
+  )
+
+  // Assert
+  await act(async () =>
+    render(
+      <ReactRuntimeProvider runtime={runtime}>
+        <Page snapshot={snapshot} />
+      </ReactRuntimeProvider>,
+    ),
+  )
+
+  expect(snapshot).toMatchSnapshot('snapshot')
+  expect(JSON.parse(screen.getByTestId(testId).textContent ?? '')).toMatchSnapshot('resolvedValue')
+
+  if (expectedRenders != null) {
+    expect(Number(screen.getByTestId(renderCountTestId).textContent)).toBe(expectedRenders)
+  }
+}

--- a/packages/runtime/src/next/tests/client.get-pages.test.ts
+++ b/packages/runtime/src/next/tests/client.get-pages.test.ts
@@ -1,7 +1,8 @@
 import { Makeswift } from '../client'
 import { http, HttpResponse } from 'msw'
-import { setupServer } from 'msw/node'
 import { randomUUID } from 'crypto'
+
+import { server } from '../../mocks/server'
 
 function createRandomPageV4() {
   const id = randomUUID()
@@ -28,28 +29,13 @@ const TEST_API_KEY = 'xxx'
 const apiOrigin = 'https://api.fakeswift.com'
 const baseUrl = `${apiOrigin}/v4/pages`
 
-const handlers = [
-  http.get(baseUrl, () => HttpResponse.json({ data: [], hasMore: false }), { once: true }),
-]
-
-const server = setupServer(...handlers)
-
-beforeAll(() => {
-  server.resetHandlers()
-  server.listen()
-})
-
-// Reset any request handlers that we may add during the tests,
-// so they don't affect other tests.
-afterEach(() => server.resetHandlers())
-
-// Clean up after the tests are finished.
-afterAll(() => server.close())
-
 describe('getPages v4', () => {
   test('empty', async () => {
     // Arrange
     const client = new Makeswift(TEST_API_KEY, { apiOrigin })
+    server.use(
+      http.get(baseUrl, () => HttpResponse.json({ data: [], hasMore: false }), { once: true }),
+    )
 
     // Act
     const pageResults = await client.getPages()

--- a/packages/runtime/src/utils/tests/element-data-test-test.ts
+++ b/packages/runtime/src/utils/tests/element-data-test-test.ts
@@ -27,6 +27,7 @@ export function createRootComponent(elements: ElementData[], rootId?: string) {
 export function createMakeswiftPageSnapshot(
   elementData: ElementData,
   partialSnapshot: Partial<MakeswiftPageSnapshot> = {},
+  cacheData: MakeswiftPageSnapshot['cacheData'] = {},
 ): MakeswiftPageSnapshot {
   return {
     document: {
@@ -42,7 +43,7 @@ export function createMakeswiftPageSnapshot(
       ...partialSnapshot.document,
     },
     apiOrigin: 'https://test-api-origin.com',
-    cacheData: {},
+    cacheData,
     preview: false,
     localizedResourcesMap: {},
     locale: null,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -486,6 +486,9 @@ importers:
       typescript:
         specifier: ^5.1.6
         version: 5.1.6
+      undici:
+        specifier: ^6.19.2
+        version: 6.19.2
 
   packages/tsconfig: {}
 
@@ -12506,6 +12509,11 @@ packages:
   /undici@4.16.0:
     resolution: {integrity: sha512-tkZSECUYi+/T1i4u+4+lwZmQgLXd4BLGlrc7KZPcLIW7Jpq99+Xpc30ONv7nS6F5UNOxp/HBZSSL9MafUrvJbw==}
     engines: {node: '>=12.18'}
+    dev: true
+
+  /undici@6.19.2:
+    resolution: {integrity: sha512-JfjKqIauur3Q6biAtHJ564e3bWa8VvT+7cSiOJHFbX4Erv6CLGDpg8z+Fmg/1OI/47RA+GI2QZaF48SSaLvyBA==}
+    engines: {node: '>=18.17'}
     dev: true
 
   /uniq@1.0.1:


### PR DESCRIPTION
Adds tests for rendering the color control, while refactoring the existing color control tests to use a shared helper functionality for testing. Also introduces msw for handling swatch retrieval in the color control tests.