### PR TITLE
Send an event during initialize() to inform the builder which document/element tree to subscribe to

### DIFF
--- a/.changeset/quick-eagles-sort.md
+++ b/.changeset/quick-eagles-sort.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Send the `REGISTER_BUILDER_DOCUMENT` event during `initialize()`. This is used to inform the builder which document or element tree to subscribe to.

--- a/packages/runtime/src/components/page/Page.tsx
+++ b/packages/runtime/src/components/page/Page.tsx
@@ -9,14 +9,12 @@ import { usePageSnippets } from '../hooks/usePageSnippets'
 import { PageHead } from './PageHead'
 
 type Props = {
-  document: MakeswiftPageDocument
+  pageDocument: MakeswiftPageDocument
+  documentKey: string
 }
 
-export function Page({ document: page }: Props): JSX.Element {
+export function Page({ pageDocument: page, documentKey }: Props): JSX.Element {
   const { bodySnippets } = usePageSnippets({ page })
-
-  const baseLocalizedPage = page.localizedPages.find(({ parentId }) => parentId == null)
-  const documentId = baseLocalizedPage?.elementTreeId ?? page.id
 
   useRouterLocaleSync()
 
@@ -24,7 +22,7 @@ export function Page({ document: page }: Props): JSX.Element {
     <>
       <PageHead document={page} />
 
-      <DocumentReference documentReference={createDocumentReference(documentId)} />
+      <DocumentReference documentReference={createDocumentReference(documentKey)} />
 
       {bodySnippets.map(snippet => (
         <BodySnippet key={snippet.id} code={snippet.code} cleanup={snippet.cleanup} />

--- a/packages/runtime/src/next/components/page.tsx
+++ b/packages/runtime/src/next/components/page.tsx
@@ -28,17 +28,23 @@ See our docs for more information on what's changed and instructions to migrate:
       }),
     [snapshot],
   )
-  const rootElements = new Map([[snapshot.document.id, snapshot.document.data]])
 
-  snapshot.document.localizedPages.forEach(localizedPage => {
-    rootElements.set(localizedPage.elementTreeId, localizedPage.data)
-  })
+  const localizedPage = snapshot.document.localizedPages.find(({ parentId }) => parentId == null)
+  const rootElement = localizedPage
+    ? { key: localizedPage.elementTreeId, data: localizedPage.data }
+    : { key: snapshot.document.id, data: snapshot.document.data }
+
+  const rootElements = new Map([[rootElement.key, rootElement.data]])
 
   return (
     <Suspense>
       <RuntimeProvider client={client} rootElements={rootElements} preview={snapshot.preview}>
         {/* We use a key here to reset the Snippets state in the PageMeta component */}
-        <PageMeta key={snapshot.document.data.key} document={snapshot.document} />
+        <PageMeta
+          key={snapshot.document.data.key}
+          pageDocument={snapshot.document}
+          documentKey={rootElement.key}
+        />
       </RuntimeProvider>
     </Suspense>
   )

--- a/packages/runtime/src/state/actions.ts
+++ b/packages/runtime/src/state/actions.ts
@@ -27,6 +27,9 @@ export const ActionTypes = {
 
   CHANGE_DOCUMENT: 'CHANGE_DOCUMENT',
 
+  REGISTER_BUILDER_DOCUMENT: 'REGISTER_BUILDER_DOCUMENT',
+  UNREGISTER_BUILDER_DOCUMENT: 'UNREGISTER_BUILDER_DOCUMENT',
+
   REGISTER_COMPONENT: 'REGISTER_COMPONENT',
   UNREGISTER_COMPONENT: 'UNREGISTER_COMPONENT',
 
@@ -93,6 +96,16 @@ type RegisterDocumentAction = {
 
 type UnregisterDocumentAction = {
   type: typeof ActionTypes.UNREGISTER_DOCUMENT
+  payload: { documentKey: string }
+}
+
+type RegisterBuilderDocumentAction = {
+  type: typeof ActionTypes.REGISTER_BUILDER_DOCUMENT
+  payload: { documentKey: string; document: Document }
+}
+
+type UnregisterBuilderDocumentAction = {
+  type: typeof ActionTypes.UNREGISTER_BUILDER_DOCUMENT
   payload: { documentKey: string }
 }
 
@@ -289,6 +302,8 @@ export type Action =
   | ChangeDocumentAction
   | RegisterDocumentAction
   | UnregisterDocumentAction
+  | RegisterBuilderDocumentAction
+  | UnregisterBuilderDocumentAction
   | RegisterComponentAction
   | UnregisterComponentAction
   | RegisterBuilderComponentAction
@@ -338,6 +353,17 @@ export function registerDocument(document: Document): RegisterDocumentAction {
 
 export function unregisterDocument(documentKey: string): UnregisterDocumentAction {
   return { type: ActionTypes.UNREGISTER_DOCUMENT, payload: { documentKey } }
+}
+
+export function registerBuilderDocument(document: Document): RegisterBuilderDocumentAction {
+  return {
+    type: ActionTypes.REGISTER_BUILDER_DOCUMENT,
+    payload: { documentKey: document.key, document },
+  }
+}
+
+export function unregisterBuilderDocument(documentKey: string): UnregisterBuilderDocumentAction {
+  return { type: ActionTypes.UNREGISTER_BUILDER_DOCUMENT, payload: { documentKey } }
 }
 
 export function registerDocumentEffect(

--- a/packages/runtime/src/state/modules/read-write-documents.ts
+++ b/packages/runtime/src/state/modules/read-write-documents.ts
@@ -46,6 +46,10 @@ export function getDocument(state: State, documentKey: string): ReadOnlyDocument
   return ReadOnlyDocuments.getDocument(getReadOnlyDocumentsStateSlice(state), documentKey)
 }
 
+export function getDocuments(state: State): ReadOnlyDocuments.State {
+  return ReadOnlyDocuments.getDocuments(getReadOnlyDocumentsStateSlice(state))
+}
+
 export function reducer(state: State = getInitialState(), action: Action): State {
   const nextState = ReadOnlyDocuments.reducer(state, action)
 


### PR DESCRIPTION
This is required for "Host-driven navigation". Right now the builder gets the `elementTreeId` from the `pageId` in the builder.

We want to inverse this control and let the host drive the builder.