### PR TITLE
runtime: forward ref only if the component supports it

### DIFF
--- a/.changeset/eight-ears-smile.md
+++ b/.changeset/eight-ears-smile.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Only forward a ref if the component supports it, with the exception of lazy components, which continue to receive a ref unconditionally.

--- a/packages/runtime/src/runtimes/react/components/ElementData.tsx
+++ b/packages/runtime/src/runtimes/react/components/ElementData.tsx
@@ -1,7 +1,7 @@
 import { Ref, Suspense, forwardRef, memo } from 'react'
 import { ElementData as ReactPageElementData } from '../../../state/react-page'
 import { useComponent } from '../hooks/use-component'
-import { suppressRefWarning } from '../utils/suppress-ref-warning'
+import { canAcceptRef } from '../utils/can-accept-ref'
 import { FallbackComponent } from '../../../components/shared/FallbackComponent'
 import { PropsValue } from '../controls'
 
@@ -16,16 +16,22 @@ export const ElementData = memo(
   ): JSX.Element {
     const Component = useComponent(elementData.type)
 
-    suppressRefWarning(`\`ForwardRef(${ElementData.name})\``)
-
     if (Component == null) {
       return <FallbackComponent ref={ref as Ref<HTMLDivElement>} text="Component not found" />
     }
 
+    const forwardRef = canAcceptRef(Component)
+
     return (
       <Suspense>
         <PropsValue element={elementData}>
-          {props => <Component {...props} key={elementData.key} ref={ref} />}
+          {props =>
+            forwardRef ? (
+              <Component {...props} key={elementData.key} ref={ref} />
+            ) : (
+              <Component {...props} key={elementData.key} />
+            )
+          }
         </PropsValue>
       </Suspense>
     )

--- a/packages/runtime/src/runtimes/react/utils/can-accept-ref.test.tsx
+++ b/packages/runtime/src/runtimes/react/utils/can-accept-ref.test.tsx
@@ -1,0 +1,27 @@
+import { Component, forwardRef, memo, lazy } from 'react'
+
+import { canAcceptRef } from './can-accept-ref'
+
+class Greeting extends Component {
+  render() {
+    return <h1>Hello, world!</h1>
+  }
+}
+
+describe('canAcceptRef', () => {
+  test.each([
+    [false, 'function component', () => <div />],
+    [
+      true,
+      'function component wrapped in `forwardRef',
+      forwardRef<HTMLDivElement>((_, ref) => <div ref={ref} />),
+    ],
+    [true, 'class component', Greeting],
+    // we try to pass a ref to all lazy components since we can't know if they accept refs without loading them
+    [true, 'lazy function component', lazy(async () => ({ default: () => <div /> }))],
+    [true, 'lazy class component', lazy(async () => ({ default: Greeting }))],
+  ])('returns %s for a %s', (expected, _, c) => {
+    expect(canAcceptRef(c)).toBe(expected)
+    expect(canAcceptRef(memo(c))).toBe(expected)
+  })
+})

--- a/packages/runtime/src/runtimes/react/utils/can-accept-ref.ts
+++ b/packages/runtime/src/runtimes/react/utils/can-accept-ref.ts
@@ -1,0 +1,56 @@
+import type { Component, PropsWithoutRef, RefAttributes } from 'react'
+import { type ComponentType } from '../../../state/react-page'
+
+type WrapperComponent = {
+  $$typeof: string
+  new (props: PropsWithoutRef<any> & RefAttributes<any>, context?: any): Component<any>
+}
+
+type MemoComponent = WrapperComponent & {
+  type: ComponentType
+}
+
+// See https://github.com/facebook/react/blob/main/packages/shared/ReactSymbols.js
+const REACT_MEMO_TYPE: symbol = Symbol.for('react.memo')
+const REACT_LAZY_TYPE: symbol = Symbol.for('react.lazy')
+const REACT_FORWARD_REF_TYPE: symbol = Symbol.for('react.forward_ref')
+
+function hasTypeofSymbol(c: ComponentType, type: symbol): c is WrapperComponent {
+  // React uses `$$typeof` field on its wrapper components to identify them,
+  // see https://github.com/facebook/react/blob/main/packages/shared/ReactElementType.js
+  // and https://github.com/search?q=repo%3Afacebook%2Freact%20%24%24typeof&type=code
+  return c != null && '$$typeof' in c && c.$$typeof === type
+}
+
+function isMemoComponent(c: ComponentType): c is MemoComponent {
+  return hasTypeofSymbol(c, REACT_MEMO_TYPE)
+}
+
+function isLazyComponent(c: ComponentType) {
+  return hasTypeofSymbol(c, REACT_LAZY_TYPE)
+}
+
+function isForwardRef(c: ComponentType) {
+  return hasTypeofSymbol(c, REACT_FORWARD_REF_TYPE)
+}
+
+function unwrapIfMemo(c: ComponentType): ComponentType {
+  return isMemoComponent(c) ? c.type : c
+}
+
+function isClassComponent(c: ComponentType) {
+  return typeof c === 'function' && c.prototype && Boolean(c.prototype.isReactComponent)
+}
+
+function canAcceptRefImpl(c: ComponentType) {
+  return (
+    isClassComponent(c) ||
+    isForwardRef(c) ||
+    // will try to pass a ref to all lazy components since we can't know if they accept refs without loading them
+    isLazyComponent(c)
+  )
+}
+
+export function canAcceptRef(c: ComponentType) {
+  return canAcceptRefImpl(unwrapIfMemo(c))
+}


### PR DESCRIPTION
We still always attempt to forward to lazy components since we can't know if they accept refs without loading them.

Partially resolves https://linear.app/makeswift/issue/ENG-1609/solve-forwardref-warnings-coming-from-renderhook-components