### PR TITLE
fix: gracefully deserialize controls

### DIFF
--- a/.changeset/late-wolves-vanish.md
+++ b/.changeset/late-wolves-vanish.md
@@ -1,8 +1,9 @@
 ---
-"@makeswift/runtime": patch
+'@makeswift/runtime': patch
 ---
 
-Gracefully deserialize controls - if an invalid control definition is provided,
-a helpful console error message is shown and the remaining controls will still
-be deserialized. In the builder, the panel for the invalid control will be
-unavailable.
+- Relax `Select` options schema to allow values that can be coerced to a string.
+
+- `deserializeControls` now handles deserialization issues more gracefully:
+  the function attempts to deserialize all of the controls, reporting
+  deserialization errors through an optional error callback.

--- a/.changeset/late-wolves-vanish.md
+++ b/.changeset/late-wolves-vanish.md
@@ -1,0 +1,8 @@
+---
+"@makeswift/runtime": patch
+---
+
+Gracefully deserialize controls - if an invalid control definition is provided,
+a helpful console error message is shown and the remaining controls will still
+be deserialized. In the builder, the panel for the invalid control will be
+unavailable.

--- a/.changeset/tall-coins-compare.md
+++ b/.changeset/tall-coins-compare.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/controls': patch
+---
+
+Relax `Select` options schema to allow values that can be coerced to a string.

--- a/packages/controls/src/controls/select/__snapshots__/select.test.js.snap
+++ b/packages/controls/src/controls/select/__snapshots__/select.test.js.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Select deserialize correctly coerces numeric values to string 1`] = `
+SelectDefinition {
+  "config": {
+    "defaultValue": "12",
+    "label": "Text size",
+    "options": [
+      {
+        "label": "sm",
+        "value": "8",
+      },
+      {
+        "label": "md",
+        "value": "12",
+      },
+      {
+        "label": "lg",
+        "value": "16",
+      },
+    ],
+  },
+}
+`;
+
+exports[`Select deserialize string values 1`] = `
+SelectDefinition {
+  "config": {
+    "defaultValue": "p",
+    "label": "Block type",
+    "labelOrientation": "horizontal",
+    "options": [
+      {
+        "label": "Paragraph",
+        "value": "p",
+      },
+      {
+        "label": "Heading 1",
+        "value": "h1",
+      },
+    ],
+  },
+}
+`;

--- a/packages/controls/src/controls/select/select.test.js
+++ b/packages/controls/src/controls/select/select.test.js
@@ -1,0 +1,39 @@
+import { SelectDefinition } from './select'
+
+describe('Select', () => {
+  describe('deserialize', () => {
+    test('string values', () => {
+      expect(
+        SelectDefinition.deserialize({
+          type: SelectDefinition.type,
+          config: {
+            label: 'Block type',
+            labelOrientation: 'horizontal',
+            options: [
+              { value: 'p', label: 'Paragraph' },
+              { value: 'h1', label: 'Heading 1' },
+            ],
+            defaultValue: 'p',
+          },
+        }),
+      ).toMatchSnapshot()
+    })
+
+    test('correctly coerces numeric values to string', () => {
+      expect(
+        SelectDefinition.deserialize({
+          type: SelectDefinition.type,
+          config: {
+            label: 'Text size',
+            options: [
+              { value: 8, label: 'sm' },
+              { value: 12, label: 'md' },
+              { value: 16, label: 'lg' },
+            ],
+            defaultValue: 12,
+          },
+        }),
+      ).toMatchSnapshot()
+    })
+  })
+})

--- a/packages/controls/src/controls/select/select.ts
+++ b/packages/controls/src/controls/select/select.ts
@@ -81,9 +81,9 @@ class Definition<C extends Config> extends ControlDefinition<
     }
 
     const { config: configSchema } = Definition.schema(
-      z.string(),
-      z.string().optional(),
-      z.string().optional(),
+      z.coerce.string(),
+      z.coerce.string().optional(),
+      z.coerce.string().optional(),
     )
 
     const def = z.object({

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -8,6 +8,12 @@
   `@makeswift/controls`. As part of this update, this package is no longer
   exposing internal data types and functions associated with our controls.
 
+  Controls and their options are now verified at runtime. If you were previously
+  using our controls without TypeScript, you may have been able to pass invalid
+  options to controls without seeing an error. This will now result in an error
+  being thrown in the builder console and the associated control panel not
+  appearing.
+
   ## BREAKING:
 
   1. Attempting to create a control with arbitrary configuration options will

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -8,12 +8,6 @@
   `@makeswift/controls`. As part of this update, this package is no longer
   exposing internal data types and functions associated with our controls.
 
-  Controls and their options are now verified at runtime. If you were previously
-  using our controls without TypeScript, you may have been able to pass invalid
-  options to controls without seeing an error. This will now result in an error
-  being thrown in the builder console and the associated control panel not
-  appearing.
-
   ## BREAKING:
 
   1. Attempting to create a control with arbitrary configuration options will
@@ -41,6 +35,13 @@
      ```
 
      Previously, the `options` array was allowed to be empty.
+
+  3. In addition to stricter compile-time checks, control definitions are now
+     validated at runtime when you load your site in the Makeswift builder.
+     Previously, if you were using vanilla JavaScript, you might have been
+     able to pass invalid or unsupported options to controls without
+     encountering an error. Now, such issues will trigger an error entry in the
+     browser console, and the related control panel will not appear.
 
 ### Patch Changes
 

--- a/packages/runtime/src/builder/serialization/__snapshots__/control-serialization.test.ts.snap
+++ b/packages/runtime/src/builder/serialization/__snapshots__/control-serialization.test.ts.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`deserializeControls gracefully deserializes record of serialized controls when invalid config is provided 1`] = `
+[
+  [Error: Could not deserialize control for "faultyNumber": [
+  {
+    "code": "invalid_type",
+    "expected": "number",
+    "received": "string",
+    "path": [
+      "config",
+      "defaultValue"
+    ],
+    "message": "Expected number, received string"
+  }
+]],
+  [Error: Could not deserialize control for "faultySelect": [
+  {
+    "code": "invalid_type",
+    "expected": "string",
+    "received": "number",
+    "path": [
+      "config",
+      "options",
+      0,
+      "value"
+    ],
+    "message": "Expected string, received number"
+  }
+]],
+]
+`;

--- a/packages/runtime/src/builder/serialization/__snapshots__/control-serialization.test.ts.snap
+++ b/packages/runtime/src/builder/serialization/__snapshots__/control-serialization.test.ts.snap
@@ -2,6 +2,18 @@
 
 exports[`deserializeControls gracefully deserializes record of serialized controls when invalid config is provided 1`] = `
 [
+  [Error: Could not deserialize control for "faultyCheckbox": [
+  {
+    "code": "invalid_type",
+    "expected": "boolean",
+    "received": "number",
+    "path": [
+      "config",
+      "defaultValue"
+    ],
+    "message": "Expected boolean, received number"
+  }
+]],
   [Error: Could not deserialize control for "faultyNumber": [
   {
     "code": "invalid_type",
@@ -12,20 +24,6 @@ exports[`deserializeControls gracefully deserializes record of serialized contro
       "defaultValue"
     ],
     "message": "Expected number, received string"
-  }
-]],
-  [Error: Could not deserialize control for "faultySelect": [
-  {
-    "code": "invalid_type",
-    "expected": "string",
-    "received": "number",
-    "path": [
-      "config",
-      "options",
-      0,
-      "value"
-    ],
-    "message": "Expected string, received number"
   }
 ]],
 ]

--- a/packages/runtime/src/builder/serialization/control-serialization.test.ts
+++ b/packages/runtime/src/builder/serialization/control-serialization.test.ts
@@ -26,10 +26,12 @@ describe('deserializeControls', () => {
     // Arrange
     const controls = {
       checkbox: Checkbox({ label: 'Checkbox', defaultValue: true }),
+      // @ts-expect-error Semi-valid config for select: at runtime, we allow for values that can be coerced to string
+      select: Select({ label: 'Select', options: [{ value: 1, label: 'Red' }] }),
+      // @ts-expect-error Invalid config for checkbox, we expect a strict boolean value
+      faultyCheckbox: Checkbox({ label: 'Boolean', defaultValue: 1 }),
       // @ts-expect-error Invalid config for number
       faultyNumber: Number({ label: 'Number', defaultValue: 'not a number!' }),
-      // @ts-expect-error Invalid config for select
-      faultySelect: Select({ label: 'Select', options: [{ value: 1, label: 'Red' }] }),
     } as const
 
     const [serialized, transferables] = serializeControls(controls)
@@ -42,7 +44,7 @@ describe('deserializeControls', () => {
     })
 
     // Assert
-    expect(Object.keys(deserializedControls)).toEqual(['checkbox'])
+    expect(Object.keys(deserializedControls)).toEqual(['checkbox', 'select'])
     expect(errorCallback).toHaveBeenCalledTimes(2)
     expect(errors).toMatchSnapshot()
 

--- a/packages/runtime/src/builder/serialization/control-serialization.test.ts
+++ b/packages/runtime/src/builder/serialization/control-serialization.test.ts
@@ -1,0 +1,49 @@
+import { serializeControls, deserializeControls } from './control-serialization'
+import { Checkbox, Number, Select } from '@makeswift/controls'
+
+describe('deserializeControls', () => {
+  test('deserializes record of serialized controls', () => {
+    // Arrange
+    const controls = {
+      checkbox: Checkbox({ label: 'Checkbox', defaultValue: true }),
+      number: Number({ label: 'Number', defaultValue: 42 }),
+      select: Select({ label: 'Select', options: [{ value: 'red', label: 'Red' }] }),
+    } as const
+
+    const [serialized, transferables] = serializeControls(controls)
+
+    // Act
+    const deserializedControls = deserializeControls(serialized)
+
+    // Assert
+    expect(Object.keys(deserializedControls)).toEqual(Object.keys(controls))
+    expect(deserializedControls).toEqual(controls)
+
+    transferables.forEach((port: any) => port.close())
+  })
+
+  test('gracefully deserializes record of serialized controls when invalid config is provided', () => {
+    // Arrange
+    const controls = {
+      checkbox: Checkbox({ label: 'Checkbox', defaultValue: true }),
+      // @ts-expect-error Invalid config for number
+      faultyNumber: Number({ label: 'Number', defaultValue: 'not a number!' }),
+      // @ts-expect-error Invalid config for select
+      faultySelect: Select({ label: 'Select', options: [{ value: 1, label: 'Red' }] }),
+    } as const
+
+    const [serialized, transferables] = serializeControls(controls)
+
+    // Act
+    const errorCallback = jest.fn()
+    const deserializedControls = deserializeControls(serialized, {
+      onError: errorCallback,
+    })
+
+    // Assert
+    expect(Object.keys(deserializedControls)).toEqual(['checkbox'])
+    expect(errorCallback).toHaveBeenCalledTimes(2)
+
+    transferables.forEach((port: any) => port.close())
+  })
+})

--- a/packages/runtime/src/builder/serialization/control-serialization.test.ts
+++ b/packages/runtime/src/builder/serialization/control-serialization.test.ts
@@ -35,7 +35,8 @@ describe('deserializeControls', () => {
     const [serialized, transferables] = serializeControls(controls)
 
     // Act
-    const errorCallback = jest.fn()
+    const errors: Error[] = []
+    const errorCallback = jest.fn().mockImplementation(e => errors.push(e))
     const deserializedControls = deserializeControls(serialized, {
       onError: errorCallback,
     })
@@ -43,6 +44,7 @@ describe('deserializeControls', () => {
     // Assert
     expect(Object.keys(deserializedControls)).toEqual(['checkbox'])
     expect(errorCallback).toHaveBeenCalledTimes(2)
+    expect(errors).toMatchSnapshot()
 
     transferables.forEach((port: any) => port.close())
   })

--- a/packages/runtime/src/builder/serialization/control-serialization.ts
+++ b/packages/runtime/src/builder/serialization/control-serialization.ts
@@ -1041,10 +1041,22 @@ export function serializeControls(
 
 export function deserializeControls(
   serializedControls: Record<string, SerializedControl>,
+  { onError }: { onError?: (err: Error) => void } = {},
 ): Record<string, DeserializedControl> {
   return Object.entries(serializedControls).reduce(
     (deserializedControls, [key, serializedControl]) => {
-      return { ...deserializedControls, [key]: deserializeControl(serializedControl) }
+      try {
+        const deserializedControl = deserializeControl(serializedControl)
+        return { ...deserializedControls, [key]: deserializedControl }
+      } catch (err: unknown) {
+        if (err instanceof Error) {
+          const error = new Error(`Could not deserialize control for "${key}": ${err.message}`, {
+            cause: err,
+          })
+          onError?.(error)
+        }
+        return deserializedControls
+      }
     },
     {} as Record<string, DeserializedControl>,
   )

--- a/packages/runtime/src/builder/serialization/control-serialization.ts
+++ b/packages/runtime/src/builder/serialization/control-serialization.ts
@@ -1049,12 +1049,15 @@ export function deserializeControls(
         const deserializedControl = deserializeControl(serializedControl)
         return { ...deserializedControls, [key]: deserializedControl }
       } catch (err: unknown) {
-        if (err instanceof Error) {
-          const error = new Error(`Could not deserialize control for "${key}": ${err.message}`, {
-            cause: err,
-          })
-          onError?.(error)
-        }
+        const error =
+          err instanceof Error
+            ? new Error(`Could not deserialize control for "${key}": ${err.message}`, {
+                cause: err,
+              })
+            : new Error(`Could not deserialize control for "${key}", unknown error: ${err}`)
+
+        onError?.(error)
+
         return deserializedControls
       }
     },


### PR DESCRIPTION
Modifies controls deserialization to still continue if an invalid config from the user is provided. This allows for the panels of successfully created controls to still appear in the builder. Addresses the case where some users are not passing valid configs during prop registration, but the issue is not surfaced due to them most likely not using TypeScript.

![CleanShot 2024-08-26 at 10 17 02](https://github.com/user-attachments/assets/5f370da8-abc9-4636-92a9-b0d1b4d5edac)
