### PR TITLE
fix: gracefully handle the mismatch between `Shape` definition vs data when introspecting

### DIFF
--- a/.changeset/big-bats-retire.md
+++ b/.changeset/big-bats-retire.md
@@ -1,0 +1,6 @@
+---
+"@makeswift/controls": patch
+"@makeswift/runtime": patch
+---
+
+fixes `Shape` introspection and copying to properly handle non-existent/orphaned props.

--- a/packages/controls/src/controls/shape/shape.test.ts
+++ b/packages/controls/src/controls/shape/shape.test.ts
@@ -1,6 +1,7 @@
 import { Targets } from '../../introspection'
 import { deserializeRecord, type DeserializedRecord } from '../../serialization'
 
+import { type DataType } from '../associated-types'
 import { Checkbox, CheckboxDefinition } from '../checkbox'
 import { Color, ColorDefinition } from '../color'
 import { Combobox } from '../combobox'
@@ -157,6 +158,28 @@ describe('Shape', () => {
 
       const fileIds = shape.introspect(shapeData, Targets.File)
       expect(fileIds).toEqual(['file-id'])
+    })
+
+    test('gracefully handles missing/extra props', () => {
+      const shape = Shape({
+        type: {
+          color: Color({ defaultValue: 'red' }),
+          link: Link(),
+          image: Image(),
+        },
+      })
+
+      const shapeData = {
+        // missing props + extra prop that should be ignored
+        extraProp: 'extra',
+      }
+
+      expect(
+        shape.introspect(
+          shapeData as DataType<typeof shape>,
+          Targets.ChildrenElement,
+        ),
+      ).toStrictEqual([])
     })
   })
 

--- a/packages/controls/src/controls/shape/shape.ts
+++ b/packages/controls/src/controls/shape/shape.ts
@@ -145,7 +145,7 @@ class Definition<C extends Config> extends ControlDefinition<
   ): DataType<C> | undefined {
     if (data == null) return undefined
     return mapValues(data, (value, key) =>
-      this.keyDefs[key as string].copyData(value, context),
+      this.keyDefs[key as string]?.copyData(value, context),
     )
   }
 
@@ -182,8 +182,9 @@ class Definition<C extends Config> extends ControlDefinition<
   }
 
   introspect<R>(data: DataType<C> | undefined, target: IntrospectionTarget<R>) {
-    return Object.entries(data ?? {}).flatMap(([key, value]) =>
-      this.keyDefs[key as string]?.introspect(value, target),
+    return Object.entries(data ?? {}).flatMap(
+      ([key, value]) =>
+        this.keyDefs[key as string]?.introspect(value, target) ?? [],
     )
   }
 }


### PR DESCRIPTION
`introspect` should never return `undefined`.