### PR TITLE
refactor: move `is`, `deepEqual` and `shallowEqual` predicates to `@makeswift/controls`

### DIFF
--- a/.changeset/two-days-repair.md
+++ b/.changeset/two-days-repair.md
@@ -1,0 +1,6 @@
+---
+"@makeswift/controls": patch
+"@makeswift/runtime": patch
+---
+
+refactor: move `is`, `deepEqual` and `shallowEqual` predicates to the `@makeswift/controls` package

--- a/packages/controls/src/index.ts
+++ b/packages/controls/src/index.ts
@@ -7,3 +7,4 @@ export * from './context'
 export * from './introspection'
 
 export * from './lib/functional'
+export * from './lib/predicates'

--- a/packages/controls/src/lib/predicates/deepEqual.ts
+++ b/packages/controls/src/lib/predicates/deepEqual.ts
@@ -1,0 +1,31 @@
+import { shallowEqual } from './shallowEqual'
+
+const { hasOwnProperty } = Object.prototype
+
+export const deepEqual = (a: unknown, b: unknown): boolean => {
+  if (shallowEqual(a, b)) return true
+
+  if (
+    typeof a !== 'object' ||
+    a === null ||
+    typeof b !== 'object' ||
+    b === null
+  )
+    return false
+
+  const keysA = Object.keys(a)
+  const keysB = Object.keys(b)
+
+  if (keysA.length !== keysB.length) return false
+
+  for (let i = 0; i < keysA.length; i += 1) {
+    if (
+      !hasOwnProperty.call(b, keysA[i]) ||
+      // @ts-expect-error: {}[string] is OK.
+      !deepEqual(a[keysA[i]], b[keysA[i]])
+    )
+      return false
+  }
+
+  return true
+}

--- a/packages/controls/src/lib/predicates/index.ts
+++ b/packages/controls/src/lib/predicates/index.ts
@@ -1,0 +1,3 @@
+export * from './deepEqual'
+export * from './is'
+export * from './shallowEqual'

--- a/packages/controls/src/lib/predicates/is.ts
+++ b/packages/controls/src/lib/predicates/is.ts
@@ -1,0 +1,5 @@
+export function is(x: unknown, y: unknown): boolean {
+  if (x === y) return x !== 0 || y !== 0 || 1 / x === 1 / y
+
+  return x !== x && y !== y
+}

--- a/packages/controls/src/lib/predicates/shallowEqual.ts
+++ b/packages/controls/src/lib/predicates/shallowEqual.ts
@@ -1,0 +1,28 @@
+import { is } from './is'
+
+const { hasOwnProperty } = Object.prototype
+
+export const shallowEqual = (a: unknown, b: unknown): boolean => {
+  if (is(a, b)) return true
+
+  if (
+    typeof a !== 'object' ||
+    a === null ||
+    typeof b !== 'object' ||
+    b === null
+  )
+    return false
+
+  const keysA = Object.keys(a)
+  const keysB = Object.keys(b)
+
+  if (keysA.length !== keysB.length) return false
+
+  for (let i = 0; i < keysA.length; i += 1) {
+    // @ts-expect-error: {}[string] is OK.
+    if (!hasOwnProperty.call(b, keysA[i]) || !is(a[keysA[i]], b[keysA[i]]))
+      return false
+  }
+
+  return true
+}

--- a/packages/runtime/src/utils/deepEqual.ts
+++ b/packages/runtime/src/utils/deepEqual.ts
@@ -1,27 +1,3 @@
-import shallowEqual from './shallowEqual'
-
-const { hasOwnProperty } = Object.prototype
-
-const deepEqual = (a: unknown, b: unknown): boolean => {
-  if (shallowEqual(a, b)) return true
-
-  if (typeof a !== 'object' || a === null || typeof b !== 'object' || b === null) return false
-
-  const keysA = Object.keys(a)
-  const keysB = Object.keys(b)
-
-  if (keysA.length !== keysB.length) return false
-
-  for (let i = 0; i < keysA.length; i += 1) {
-    if (
-      !hasOwnProperty.call(b, keysA[i]) ||
-      // @ts-expect-error: {}[string] is OK.
-      !deepEqual(a[keysA[i]], b[keysA[i]])
-    )
-      return false
-  }
-
-  return true
-}
+import { deepEqual } from '@makeswift/controls'
 
 export default deepEqual

--- a/packages/runtime/src/utils/is.ts
+++ b/packages/runtime/src/utils/is.ts
@@ -1,5 +1,3 @@
-export default function is(x: unknown, y: unknown): boolean {
-  if (x === y) return x !== 0 || y !== 0 || 1 / x === 1 / y
+import { is } from '@makeswift/controls'
 
-  return x !== x && y !== y
-}
+export default is

--- a/packages/runtime/src/utils/shallowEqual.ts
+++ b/packages/runtime/src/utils/shallowEqual.ts
@@ -1,23 +1,3 @@
-import is from './is'
-
-const { hasOwnProperty } = Object.prototype
-
-const shallowEqual = (a: unknown, b: unknown): boolean => {
-  if (is(a, b)) return true
-
-  if (typeof a !== 'object' || a === null || typeof b !== 'object' || b === null) return false
-
-  const keysA = Object.keys(a)
-  const keysB = Object.keys(b)
-
-  if (keysA.length !== keysB.length) return false
-
-  for (let i = 0; i < keysA.length; i += 1) {
-    // @ts-expect-error: {}[string] is OK.
-    if (!hasOwnProperty.call(b, keysA[i]) || !is(a[keysA[i]], b[keysA[i]])) return false
-  }
-
-  return true
-}
+import { shallowEqual } from '@makeswift/controls'
 
 export default shallowEqual


### PR DESCRIPTION
No semantic changes, prep for https://github.com/makeswift/makeswift/pull/814