### PR TITLE
fix: verify serialized controls during deserialization

### DIFF
--- a/.changeset/new-cows-flow.md
+++ b/.changeset/new-cows-flow.md
@@ -1,0 +1,6 @@
+---
+'@makeswift/runtime': patch
+---
+
+Performs runtime verification of incoming data during control deserialization.
+Also adds new fields to the `deserializeControls` error callback.

--- a/packages/runtime/src/builder/serialization/control-serialization.test.ts
+++ b/packages/runtime/src/builder/serialization/control-serialization.test.ts
@@ -1,4 +1,10 @@
-import { serializeControls, deserializeControls } from './control-serialization'
+import { Grid, Image, Width } from '@makeswift/prop-controllers'
+import {
+  serializeControls,
+  deserializeControls,
+  isSerializedControl,
+  serializeControl,
+} from './control-serialization'
 import { Checkbox, Number, Select } from '@makeswift/controls'
 
 describe('deserializeControls', () => {
@@ -50,4 +56,31 @@ describe('deserializeControls', () => {
 
     transferables.forEach((port: any) => port.close())
   })
+})
+
+describe('isSerializedControl', () => {
+  test.each([serializeControl(Grid()), serializeControl(Width()), serializeControl(Image())])(
+    `returns true for serialized prop-controllers: %p`,
+    value => {
+      // Assert
+      expect(isSerializedControl(value)).toBe(true)
+    },
+  )
+
+  test.each([
+    Checkbox({ label: 'Checkbox', defaultValue: true }).serialize(),
+    Number({ label: 'Number', defaultValue: 42 }).serialize(),
+    Select({ label: 'Select', options: [{ value: 'red', label: 'Red' }] }).serialize(),
+  ])(`returns true for serialized controls: %p`, value => {
+    // Assert
+    expect(isSerializedControl(value)).toBe(true)
+  })
+
+  test.each(['string', 1, true, null, undefined, { key: 'value' }, [{ key: 'value' }]])(
+    'returns false for invalid serialized data: %p',
+    value => {
+      // Assert
+      expect(isSerializedControl(value)).toBe(false)
+    },
+  )
 })


### PR DESCRIPTION
Modify the deserializeControls function to accept unknown data, which is checked to be a serialized control at runtime. Also expand the error callback to return the erroring key/serialized data that failed during deserialization.