### PR TITLE
fix: `Shape` iterates through definition instead of data/value keys

### DIFF
--- a/.changeset/khaki-squids-play.md
+++ b/.changeset/khaki-squids-play.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/controls": patch
+---
+
+fix: `Shape` control iterates through definition instead of data/value keys

--- a/packages/controls/jest.config.json
+++ b/packages/controls/jest.config.json
@@ -2,5 +2,6 @@
   "testRegex": "(\\./__tests__/.*|(\\.|/)(test|spec))\\.(types\\.)?[jt]sx?$",
   "transform": {
     "^.+\\.(t|j)sx?$": "@swc/jest"
-  }
+  },
+  "setupFilesAfterEnv": ["<rootDir>/src/jest-setup.ts"]
 }

--- a/packages/controls/src/controls/shape/__snapshots__/shape.test.ts.snap
+++ b/packages/controls/src/controls/shape/__snapshots__/shape.test.ts.snap
@@ -19,6 +19,82 @@ ShapeDefinition {
 }
 `;
 
+exports[`Shape gracefully handles missing/extra props copyData 1`] = `
+{
+  "color": {
+    "alpha": 1,
+    "swatchId": "[swatch-id]",
+  },
+  "link": undefined,
+  "list": undefined,
+  "text": "Hello world",
+}
+`;
+
+exports[`Shape gracefully handles missing/extra props fromData 1`] = `
+{
+  "color": {
+    "alpha": 1,
+    "swatchId": "[swatch-id]",
+  },
+  "link": undefined,
+  "list": undefined,
+  "text": "Hello world",
+}
+`;
+
+exports[`Shape gracefully handles missing/extra props getTranslatableData 1`] = `
+{
+  "color": null,
+  "link": null,
+  "list": null,
+  "text": "Hello world",
+}
+`;
+
+exports[`Shape gracefully handles missing/extra props mergeTranslatedData 1`] = `
+{
+  "color": {
+    "alpha": 1,
+    "swatchId": "[swatch-id]",
+  },
+  "link": undefined,
+  "list": undefined,
+  "text": "Hello world",
+}
+`;
+
+exports[`Shape gracefully handles missing/extra props toData 1`] = `
+{
+  "color": {
+    "@@makeswift/type": "color::v1",
+    "alpha": 1,
+    "swatchId": "[swatch-id]",
+  },
+  "link": {
+    "payload": {
+      "openInNewTab": false,
+      "pageId": "[page-id]",
+    },
+    "type": "OPEN_PAGE",
+  },
+  "list": [
+    {
+      "id": "xxxxxxxx-xxxx-xxxx-xxxx-100000000000",
+      "type": "makeswift::controls::number",
+      "value": {
+        "@@makeswift/type": "number::v1",
+        "value": 17,
+      },
+    },
+  ],
+  "text": {
+    "@@makeswift/type": "text-area::v1",
+    "value": "Hello world",
+  },
+}
+`;
+
 exports[`Shape serialization serialize/deserialize composable shape of controls 1`] = `
 {
   "config": {

--- a/packages/controls/src/controls/shape/shape.test.ts
+++ b/packages/controls/src/controls/shape/shape.test.ts
@@ -1,13 +1,16 @@
+import { createReplacementContext } from '../../context'
 import { Targets } from '../../introspection'
 import { deserializeRecord, type DeserializedRecord } from '../../serialization'
 
-import { type DataType } from '../associated-types'
+import { type DataType, type ValueType } from '../associated-types'
 import { Checkbox, CheckboxDefinition } from '../checkbox'
 import { Color, ColorDefinition } from '../color'
 import { Combobox } from '../combobox'
 import { ControlDefinition } from '../definition'
 import { Image } from '../image'
 import { GenericLink as Link } from '../link'
+import { List } from '../list'
+import { Number } from '../number'
 import { TextArea } from '../text-area'
 import { TextInput } from '../text-input'
 
@@ -159,28 +162,6 @@ describe('Shape', () => {
       const fileIds = shape.introspect(shapeData, Targets.File)
       expect(fileIds).toEqual(['file-id'])
     })
-
-    test('gracefully handles missing/extra props', () => {
-      const shape = Shape({
-        type: {
-          color: Color({ defaultValue: 'red' }),
-          link: Link(),
-          image: Image(),
-        },
-      })
-
-      const shapeData = {
-        // missing props + extra prop that should be ignored
-        extraProp: 'extra',
-      }
-
-      expect(
-        shape.introspect(
-          shapeData as DataType<typeof shape>,
-          Targets.ChildrenElement,
-        ),
-      ).toStrictEqual([])
-    })
   })
 
   describe('getTranslatableData', () => {
@@ -209,5 +190,63 @@ describe('Shape', () => {
         color: null,
       })
     })
+  })
+
+  describe('gracefully handles missing/extra props', () => {
+    const shape = Shape({
+      type: {
+        color: Color({ defaultValue: 'red' }),
+        list: List({ type: Number() }),
+        link: Link(),
+        text: TextArea(),
+      },
+    })
+
+    const data = {
+      // missing props + extra prop that should be ignored
+      color: { swatchId: '[swatch-id]', alpha: 1 },
+      text: 'Hello world',
+      extraProp: 'extra',
+    } as DataType<typeof shape>
+
+    const value = {
+      color: { swatchId: '[swatch-id]', alpha: 1 },
+      list: [17],
+      link: {
+        type: 'OPEN_PAGE',
+        payload: { pageId: '[page-id]', openInNewTab: false },
+      },
+      text: 'Hello world',
+      // extra prop only, `toData` doesn't handle missing props
+      extraProp: 'extra',
+    } as ValueType<typeof shape>
+
+    test('fromData', () => expect(shape.fromData(data)).toMatchSnapshot())
+    test('toData', () => expect(shape.toData(value)).toMatchSnapshot())
+    test('copyData', () =>
+      expect(
+        shape.copyData(data, {
+          replacementContext: createReplacementContext({}),
+          copyElement: (node) => node,
+        }),
+      ).toMatchSnapshot())
+
+    test('getTranslatableData', () =>
+      expect(shape.getTranslatableData(data)).toMatchSnapshot())
+
+    test('mergeTranslatedData', () =>
+      expect(
+        shape.mergeTranslatedData(
+          data,
+          {},
+          {
+            translatedData: {},
+            mergeTranslatedData: (node) => node,
+          },
+        ),
+      ).toMatchSnapshot())
+
+    test('introspect', () =>
+      expect(shape.introspect(data, Targets.ChildrenElement)).toStrictEqual([]))
   })
 })

--- a/packages/controls/src/controls/shape/shape.ts
+++ b/packages/controls/src/controls/shape/shape.ts
@@ -128,15 +128,11 @@ class Definition<C extends Config> extends ControlDefinition<
 
   fromData(data: DataType<C> | undefined): ValueType<C> | undefined {
     if (data == null) return undefined
-    return mapValues(data, (value, key) =>
-      this.keyDefs[key as string]?.fromData(value),
-    )
+    return mapValues(this.keyDefs, (def, key) => def.fromData(data[key]))
   }
 
   toData(value: ValueType<C>): DataType<C> {
-    return mapValues(value, (value, key) =>
-      this.keyDefs[key as string]?.toData(value),
-    )
+    return mapValues(this.keyDefs, (def, key) => def.toData(value[key]))
   }
 
   copyData(
@@ -144,15 +140,15 @@ class Definition<C extends Config> extends ControlDefinition<
     context: CopyContext,
   ): DataType<C> | undefined {
     if (data == null) return undefined
-    return mapValues(data, (value, key) =>
-      this.keyDefs[key as string]?.copyData(value, context),
+    return mapValues(this.keyDefs, (def, key) =>
+      def.copyData(data[key], context),
     )
   }
 
   getTranslatableData(data: DataType<C>): Data {
     if (data == null) return null
-    return mapValues(data, (value, key) => {
-      return this.keyDefs[key as string]?.getTranslatableData(value)
+    return mapValues(this.keyDefs, (def, key) => {
+      return def.getTranslatableData(data[key])
     })
   }
 
@@ -162,12 +158,8 @@ class Definition<C extends Config> extends ControlDefinition<
     context: MergeTranslatableDataContext,
   ): Data {
     if (translatedData == null) return data
-    return mapValues(data, (value, key) =>
-      this.keyDefs[key as string]?.mergeTranslatedData(
-        value,
-        translatedData[key as string],
-        context,
-      ),
+    return mapValues(this.keyDefs, (def, key) =>
+      def.mergeTranslatedData(data[key], translatedData[key], context),
     )
   }
 
@@ -182,9 +174,9 @@ class Definition<C extends Config> extends ControlDefinition<
   }
 
   introspect<R>(data: DataType<C> | undefined, target: IntrospectionTarget<R>) {
-    return Object.entries(data ?? {}).flatMap(
-      ([key, value]) =>
-        this.keyDefs[key as string]?.introspect(value, target) ?? [],
+    if (data == null) return []
+    return Object.entries(this.keyDefs).flatMap(
+      ([key, def]) => def.introspect(data[key], target) ?? [],
     )
   }
 }

--- a/packages/controls/src/jest-setup.ts
+++ b/packages/controls/src/jest-setup.ts
@@ -1,0 +1,4 @@
+let uidSuffix = 100000000000
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => `xxxxxxxx-xxxx-xxxx-xxxx-${uidSuffix++}`),
+}))


### PR DESCRIPTION
This doesn't help us to gracefully handle property "swaps" along the lines of an example outlined below, but it is more conceptually correct and stops us from erring on stale/abandoned props. The current behavior I'm replacing is a regression introduced in https://github.com/makeswift/makeswift/pull/781.

"Property swap" example (to be tackled later):
1. Define a custom component taking a `Shape` prop with a key `a` mapped to `Number`
2. Add the component to the page
3. Change prop `a` to be a `List({ type: Number() })`