### PR TITLE
fix(runtime): don't use locale to partition non-localized resources

### DIFF
--- a/apps/nextjs-pages-router/next.config.mjs
+++ b/apps/nextjs-pages-router/next.config.mjs
@@ -6,8 +6,8 @@ const withMakeswift = createWithMakeswift()
 const nextConfig = {
   reactStrictMode: true,
   i18n: {
-    locales: ["en-US", "fr-FR"],
-    defaultLocale: "en-US",
+    locales: ['en-US', 'fr-FR', 'it-IT'],
+    defaultLocale: 'en-US',
   },
 }
 

--- a/packages/runtime/src/next/client.ts
+++ b/packages/runtime/src/next/client.ts
@@ -422,12 +422,11 @@ export class Makeswift {
             siteVersion,
           )
 
-          localizedResourcesMap.set(globalElementId, localizedGlobalElement?.id ?? null)
-
           if (localizedGlobalElement) {
             // Update the logic here when we can merge element trees
             elementData = localizedGlobalElement.data
 
+            localizedResourcesMap.set(globalElementId, localizedGlobalElement.id)
             localizedGlobalElements.set(localizedGlobalElement.id, localizedGlobalElement)
           }
         }

--- a/packages/runtime/src/state/modules/__tests__/api-resources.test.ts
+++ b/packages/runtime/src/state/modules/__tests__/api-resources.test.ts
@@ -163,17 +163,17 @@ describe('state / APIResources', () => {
   test('`Actions.apiResourceFulfilled` correctly populates the store', () => {
     const state = (
       [
-        [swatch, null],
+        [swatch, 'en-US'], // locale on non-localizable resources should be ignored
         [file, null],
         [typography, null],
         [pagePathnameSlice, null],
         [localizedPagePathnameSlice_fr_FR, 'fr-FR'],
-        [globalElement, null],
+        [globalElement, 'en-US'], // see above
         [localizedGlobalElement_fr_FR, 'fr-FR'],
         [localizedGlobalElement_it_IT, 'it-IT'],
         [table, null],
         [snippet, null],
-        [page, null],
+        [page, 'fr-FR'], // see above
         [site, null],
       ] as [APIResource, string][]
     ).reduce(
@@ -210,7 +210,7 @@ describe('state / APIResources', () => {
 
     const updatedState = (
       [
-        [{ ...swatch, hue: 17 }, null],
+        [{ ...swatch, hue: 17 }, 'en-US'], // locale on non-localizable resources should be ignored
         [{ ...pagePathnameSlice, pathname: 'test/new-pathname' }, null],
         [
           {
@@ -253,7 +253,7 @@ describe('state / APIResources', () => {
 
     const updatedState = (
       [
-        [`${APIResourceType.Swatch}:${swatch.id}`, null],
+        [`${APIResourceType.Swatch}:${swatch.id}`, 'en-US'], // locale on non-localizable resources should be ignored
         [`${APIResourceType.PagePathnameSlice}:${localizedPagePathnameSlice_fr_FR.id}`, 'fr-FR'],
         [`${APIResourceType.LocalizedGlobalElement}:${localizedGlobalElement_it_IT.id}`, 'it-IT'],
       ] as [string, string][]


### PR DESCRIPTION
... plus updated tests.

`getAPIResource` and other API resource functions already enforce at compile-time whether we should pass `locale` to access an API resource of a specific type, but actions do not. However, we don't want to place the burden of conditionally passing the locale on action creators, as actions are often dispatched from a context that handles all resource types. Instead, we make it okay to pass a locale in all resource action payloads and have the reducer use the locale for scoping only if we are operating on a localized resource.