### PR TITLE
fix(runtime): not found localized global components saved as `null`

### DIFF
--- a/.changeset/fuzzy-planes-peel.md
+++ b/.changeset/fuzzy-planes-peel.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+fix: not found localized global components saved as `null` (previouly saved "not found" payload)

--- a/packages/runtime/src/next/api-handler/index.ts
+++ b/packages/runtime/src/next/api-handler/index.ts
@@ -224,15 +224,7 @@ export function MakeswiftApiHandler(
     ) {
       return client
         .getLocalizedGlobalElement(m.params.globalElementId, m.params.locale, siteVersion)
-        .then(resource => {
-          const body = resource === null ? { message: 'Not Found' } : resource
-
-          // We're not returning 404 if it's null because localized global element is nullable.
-          return match(args)
-            .with(routeHandlerPattern, () => NextResponse.json(body))
-            .with(apiRoutePattern, ([, res]) => res.json(body))
-            .exhaustive()
-        })
+        .then(handleResource)
     }
 
     if ((m = matches<{ id: string }>('/page-pathname-slices/:id'))) {


### PR DESCRIPTION
Before:

<img width="904" alt="before" src="https://github.com/user-attachments/assets/23fbe2c9-1f4a-45e7-b5c3-74f02a847e30">

After:

<img width="904" alt="after" src="https://github.com/user-attachments/assets/5c2f20c0-c0cb-4023-8f35-1367db28fa23">

