### PR TITLE
fix: stop default rules from overriding props

### DIFF
--- a/packages/runtime/src/components/shared/BackgroundsContainer/index.tsx
+++ b/packages/runtime/src/components/shared/BackgroundsContainer/index.tsx
@@ -25,6 +25,11 @@ export default forwardRef<HTMLDivElement | null, Props>(function BackgroundsCont
   { backgrounds, children, className, ...restOfProps }: Props,
   ref: Ref<HTMLDivElement>,
 ) {
+  const widthAndMarginStyle = useStyle({
+    width: '100%',
+    margin: '0 auto',
+  })
+
   return (
     <div
       {...restOfProps}
@@ -32,8 +37,6 @@ export default forwardRef<HTMLDivElement | null, Props>(function BackgroundsCont
       className={cx(
         useStyle({
           position: 'relative',
-          width: '100%',
-          margin: '0 auto',
           '> *': {
             borderRadius: 'inherit',
             height: 'inherit',
@@ -42,7 +45,7 @@ export default forwardRef<HTMLDivElement | null, Props>(function BackgroundsCont
             position: 'relative',
           },
         }),
-        className,
+        className ? className : widthAndMarginStyle,
       )}
     >
       <Backgrounds backgrounds={useBackgrounds(backgrounds)} />


### PR DESCRIPTION

When using a Box as the root for an embedded component, the width/margin prop panels do not apply to the Box as expected, even though the data is saved correctly from the panels. The reason for this is that the CSS class being generated via the prop data is injected earlier in the stylesheet than the class for the default styles, resulting in only the latter being applied. This is not true for when the page root is present around the box, which will result in the defaults getting injected first, followed by the props class.

Since responsive styles for width/margin are always passed to the BackgroundsContainer, this fix addresses the problem by only applying the generated classname for default width/margin if a classname was not passed.

Below is an example with two pages. The one on the left has a Box as a root, with the only non-default prop being a `margin-bottom` of `100px`. The one on the right has a Root as a root, containing a Box, with the same margin settings are the first. In both cases, the Box has identical classnames. The only difference is the injection order of the CSS classes in the main style tag.

Before:

![CleanShot 2024-10-24 at 18 10 25](https://github.com/user-attachments/assets/975fe412-9ffe-4990-b292-e8e345d8d1df)

After:

![CleanShot 2024-10-24 at 18 07 00](https://github.com/user-attachments/assets/eaa4bc14-c6e3-4b33-a8d0-b5c07035f620)

