### PR TITLE
refactor: continuous builder document registration

### DIFF
--- a/packages/runtime/src/next/components/MakeswiftComponent.tsx
+++ b/packages/runtime/src/next/components/MakeswiftComponent.tsx
@@ -1,11 +1,10 @@
 'use client'
 
-import { memo, ReactNode, Suspense, useEffect, useMemo } from 'react'
+import { memo, ReactNode, Suspense, useMemo } from 'react'
 import { componentDocumentToRootEmbeddedDocument, MakeswiftComponentSnapshot } from '../client'
 import { DocumentRoot } from '../../runtimes/react/components/DocumentRoot'
 import { useSyncCacheData } from '../hooks/use-sync-cache-data'
-import { useDispatch } from '../../runtimes/react/hooks/use-dispatch'
-import { registerDocumentsEffect } from '../../state/actions'
+import { useRegisterDocument } from '../../runtimes/react/hooks/use-register-document'
 
 type Props = {
   snapshot: MakeswiftComponentSnapshot
@@ -15,8 +14,6 @@ type Props = {
 }
 
 export const MakeswiftComponent = memo(({ snapshot, name, type, fallback }: Props) => {
-  const dispatch = useDispatch()
-
   useSyncCacheData(snapshot.cacheData)
 
   const rootDocument = useMemo(
@@ -30,7 +27,7 @@ export const MakeswiftComponent = memo(({ snapshot, name, type, fallback }: Prop
     [snapshot, name, type],
   )
 
-  useEffect(() => dispatch(registerDocumentsEffect([rootDocument])), [rootDocument])
+  useRegisterDocument(rootDocument)
 
   return (
     <Suspense>

--- a/packages/runtime/src/runtimes/react/hooks/use-register-document.ts
+++ b/packages/runtime/src/runtimes/react/hooks/use-register-document.ts
@@ -1,0 +1,22 @@
+import { useEffect } from 'react'
+import { type Document } from '../../../state/react-page'
+import { useDispatch } from './use-dispatch'
+import { useIsInBuilder } from './use-is-in-builder'
+import { registerBuilderDocumentsEffect, registerDocumentsEffect } from '../../../state/actions'
+
+/**
+ * @param document Document to register
+ */
+export function useRegisterDocument(document: Document): void {
+  const isInBuilder = useIsInBuilder()
+  const dispatch = useDispatch()
+
+  useEffect(() => dispatch(registerDocumentsEffect([document])), [document])
+
+  // TODO: Decide whether to do this via middleware or via explicit action (like
+  // what we're doing below)
+  useEffect(() => {
+    if (!isInBuilder) return
+    return dispatch(registerBuilderDocumentsEffect([document]))
+  }, [isInBuilder, document])
+}

--- a/packages/runtime/src/state/actions.ts
+++ b/packages/runtime/src/state/actions.ts
@@ -409,6 +409,18 @@ export function registerDocumentsEffect(
   }
 }
 
+export function registerBuilderDocumentsEffect(
+  documents: Document[],
+): ThunkAction<() => void, unknown, unknown, Action> {
+  return dispatch => {
+    documents.forEach(document => dispatch(registerBuilderDocument(document)))
+
+    return () => {
+      documents.forEach(document => dispatch(unregisterBuilderDocument(document.key)))
+    }
+  }
+}
+
 export function changeDocument(documentKey: string, operation: Operation): ChangeDocumentAction {
   return { type: ActionTypes.CHANGE_DOCUMENT, payload: { documentKey, operation } }
 }


### PR DESCRIPTION
Currently, the runtime only sends builder documents during the initialization
of the builder <-> host connection. This means that any functionality that could
rely on a remount of a document after the connection has already been
established will not work, since the registration will not be communicated to
the builder.

This change addresses this by adding a document registration hook for embedded
components that sends a builder registration action on mount.

https://github.com/user-attachments/assets/d0c7a560-b3a0-4f94-92ae-f4a02fda36bc

