### PR TITLE
fix(runtime): `registerComponent` fails to correctly deduce resolved value type

### DIFF
--- a/.changeset/heavy-trainers-dress.md
+++ b/.changeset/heavy-trainers-dress.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+fix: `registerComponent` fails to correctly deduce resolved value type in some cases

--- a/packages/runtime/src/runtimes/react/__tests__/react-runtime.test.tsx
+++ b/packages/runtime/src/runtimes/react/__tests__/react-runtime.test.tsx
@@ -1,0 +1,104 @@
+/** @jest-environment jsdom */
+import { type MouseEvent } from 'react'
+import {
+  Checkbox,
+  Combobox,
+  Color,
+  Image,
+  Link,
+  List,
+  Number,
+  Select,
+  Shape,
+  TextArea,
+  TextInput,
+} from '../../../controls'
+
+import { ReactRuntime } from '../react-runtime'
+
+type Card = {
+  imageSrc?: string
+  imageAlt: string
+  title: string
+  text: string
+  link: {
+    href: string
+    onClick: (event: MouseEvent) => void
+  }
+}
+
+type Entity = {
+  id: number
+  name: string
+}
+
+function Sandbox(props: {
+  cards: Card[]
+  entityId?: Entity['id']
+  theme: 'light' | 'dark'
+  background: string
+  boolean: boolean
+  number?: number
+}) {
+  return <div>{JSON.stringify(props)}</div>
+}
+
+describe('registerComponent', () => {
+  test("correctly deduces control definitions' resolved value types", () => {
+    ReactRuntime.registerComponent(Sandbox, {
+      type: 'sandbox',
+      label: 'Sandbox',
+      props: {
+        cards: List({
+          label: 'Cards',
+          type: Shape({
+            type: {
+              imageSrc: Image({ label: 'Image' }),
+              imageAlt: TextInput({
+                label: 'Alt text',
+                defaultValue: 'Image',
+              }),
+              title: TextInput({
+                label: 'Title',
+                defaultValue: 'This is a title',
+              }),
+              text: TextArea({
+                label: 'Text',
+                defaultValue: 'Lorem ipsum',
+              }),
+              link: Link({ label: 'On click' }),
+            },
+          }),
+          getItemLabel(item) {
+            return item?.title ?? 'This is a title'
+          },
+        }),
+        entityId: Combobox({
+          async getOptions() {
+            return fetch(`/api/entities`)
+              .then(r => r.json())
+              .then((entities: Entity[]) =>
+                entities.map(entity => ({
+                  id: entity.id.toString(),
+                  label: entity.name,
+                  value: entity.id,
+                })),
+              )
+          },
+          label: 'Entity',
+        }),
+        theme: Select({
+          label: 'Text color',
+          options: [
+            { value: 'light', label: 'Light' },
+            { value: 'dark', label: 'Dark' },
+          ],
+          defaultValue: 'light',
+        }),
+        background: Color({ label: 'Background color', defaultValue: '#fff' }),
+        boolean: Checkbox({ label: 'Boolean', defaultValue: true }),
+        number: Number({ label: 'Number' }),
+      },
+    })
+  })
+})

--- a/packages/runtime/src/runtimes/react/react-runtime.ts
+++ b/packages/runtime/src/runtimes/react/react-runtime.ts
@@ -1,6 +1,7 @@
 import { registerBuiltinComponents } from '../../components/builtin/register'
+import { ControlDefinition as UnifiedControlDefinition } from '@makeswift/controls'
 
-import { type Descriptor, type DescriptorValueType } from '../../prop-controllers/descriptors'
+import { type LegacyDescriptor, type DescriptorValueType } from '../../prop-controllers/descriptors'
 
 import { registerComponentEffect, registerReactComponentEffect } from '../../state/actions'
 import { BreakpointsInput } from '../../state/modules/breakpoints'
@@ -23,7 +24,8 @@ export class ReactRuntime extends RuntimeCore {
   // We will remove them when we release a new breaking change.
   // ------------------ Deprecated API ------------------ //
   static registerComponent<
-    P extends Record<string, Descriptor>,
+    ControlDef extends UnifiedControlDefinition,
+    P extends Record<string, LegacyDescriptor | ControlDef>,
     C extends ComponentType<{ [K in keyof P]: DescriptorValueType<P[K]> }>,
   >(
     component: C,
@@ -54,7 +56,8 @@ export class ReactRuntime extends RuntimeCore {
   // ------------------ Deprecated API ends here ------------------ //
 
   registerComponent<
-    P extends Record<string, Descriptor>,
+    ControlDef extends UnifiedControlDefinition,
+    P extends Record<string, LegacyDescriptor | ControlDef>,
     C extends ComponentType<{ [K in keyof P]: DescriptorValueType<P[K]> }>,
   >(
     component: C,


### PR DESCRIPTION
Fixes regression introduced in 0.20.0 ("unified controls interface" release), includes a test reproducing the issue.
