### PR TITLE
fix(controls): fix stalled calls/memory leaks on repeated function deserialization

### DIFF
--- a/packages/controls/src/serialization/function-serialization.test.ts
+++ b/packages/controls/src/serialization/function-serialization.test.ts
@@ -1,0 +1,22 @@
+import {
+  deserializeFunction,
+  serializeFunction,
+} from './function-serialization'
+
+describe('function serialization', () => {
+  test('correctly deserializes serialized function', async () => {
+    const getItemLabel = (item: { label: string }) => item.label
+    const serialized = serializeFunction(getItemLabel)
+
+    const deserialized1 = deserializeFunction(serialized)
+    const deserialized2 = deserializeFunction(serialized)
+
+    expect(await deserialized1({ label: 'label 1' })).toBe('label 1')
+    expect(await deserialized1({ label: 'label 2' })).toBe('label 2')
+
+    expect(await deserialized2({ label: 'label 1' })).toBe('label 1')
+    expect(await deserialized2({ label: 'label 2' })).toBe('label 2')
+
+    serialized.close()
+  })
+})

--- a/packages/controls/src/serialization/function-serialization.ts
+++ b/packages/controls/src/serialization/function-serialization.ts
@@ -6,7 +6,16 @@ export function isFunction(value: any): value is AnyFunction {
   return typeof value === 'function'
 }
 
+type ResolveCallPromise<T extends AnyFunction> = (
+  value: SerializedFunctionReturnType<T>,
+) => void
+
+type OnMessageHandler<T extends AnyFunction> = MessagePort['onmessage'] & {
+  newCall?(resolve: ResolveCallPromise<T>): number
+}
+
 export type SerializedFunction<T extends AnyFunction> = MessagePort & {
+  onmessage: OnMessageHandler<T>
   readonly [SerializedFunctionTag]: T
 }
 
@@ -44,30 +53,46 @@ export function serializeFunction<T extends AnyFunction>(
   return messageChannel.port2 as SerializedFunction<T>
 }
 
-export function deserializeFunction<T extends AnyFunction>(
-  serializedFunction: SerializedFunction<T>,
-): DeserializedFunction<T> {
-  type Result = SerializedFunctionReturnType<T>
-  type ResultMessageEvent = MessageEvent<[CallID, Result]>
-  type ResolveCallPromise = (value: Result | PromiseLike<Result>) => void
-
+function onmessageHandler<T extends AnyFunction>(): OnMessageHandler<T> {
+  type ResultMessageEvent = MessageEvent<
+    [CallID, SerializedFunctionReturnType<T>]
+  >
   let nextCallId = 0
-  const calls = new Map<CallID, ResolveCallPromise>()
+  const calls = new Map<CallID, ResolveCallPromise<T>>()
 
-  serializedFunction.onmessage = ({
+  const result: OnMessageHandler<T> = ({
     data: [callId, result],
   }: ResultMessageEvent) => {
     calls.get(callId)?.(result)
-
     calls.delete(callId)
+  }
+
+  result.newCall = (resolve: ResolveCallPromise<T>) => {
+    const callId = nextCallId++
+    calls.set(callId, resolve)
+    return callId
+  }
+
+  return result
+}
+
+export function deserializeFunction<T extends AnyFunction>(
+  serializedFunction: SerializedFunction<T>,
+): DeserializedFunction<T> {
+  if (serializedFunction.onmessage == null) {
+    serializedFunction.onmessage = onmessageHandler<T>()
   }
 
   return function deserializedFunction(...args) {
     return new Promise((resolve) => {
-      const callId = nextCallId++
+      const { newCall } = serializedFunction.onmessage
+      if (newCall == null) {
+        throw new Error(
+          `Deserialized function call failed: 'onmessage' handler is missing 'newCall' method`,
+        )
+      }
 
-      calls.set(callId, resolve)
-
+      const callId = newCall(resolve)
       serializedFunction.postMessage([callId, args])
     })
   }


### PR DESCRIPTION
See the added test for a reproduce:

### Before
<img width="1609" alt="failing test" src="https://github.com/user-attachments/assets/7b1f480c-0fed-4950-af66-a0e83a6d2b03">

### After
<img width="590" alt="passing test" src="https://github.com/user-attachments/assets/5f01499e-94ab-4c0d-89c0-b482bd87f104">

