### PR TITLE
chore: add automation for publishing release candidates

### DIFF
--- a/.github/workflows/rc-release.yml
+++ b/.github/workflows/rc-release.yml
@@ -1,0 +1,82 @@
+name: Release Candidate Release
+
+on:
+  pull_request:
+    # Run when PR opened and when subsequent commits are made https://github.com/orgs/community/discussions/25161 
+    # Will further restrict to only rc branches targeting the main branch below (in the 'if' under the job)
+    types: [opened, synchronize]
+
+concurrency: ${{ github.workflow}}-${{ github.ref }}
+
+jobs:
+  release_candidate_release:
+    if: contains(github.head_ref, '-rc-') && github.base_ref == 'main'
+    name: Release Candidate Release
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+
+      # Setup steps
+      - name: Check out git repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up pnpm 8.x
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - name: Set up Node.js 18.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --ignore-scripts --frozen-lockfile
+
+        # Prerelease-related steps
+        # output of the action used below is named 'files_exists', see: https://github.com/andstor/file-existence-action
+      - name: Check if Already in Prerelease Mode
+        id: is_in_prerelease_mode
+        uses: andstor/file-existence-action@v3
+        with:
+          files: '.changeset/pre.json'
+      # See: https://github.com/changesets/changesets/blob/main/docs/prereleases.md 
+      - name: Enter Prerelease Mode
+        if: steps.is_in_prerelease_mode.outputs.files_exists == 'false'
+        run: pnpm exec changeset pre enter rc
+        # increment version in pre.json and store new version in a .txt file to be used in a PR comment
+        # ubuntu-latest includes jq, see 'Included Software' for ubuntu-latest: https://github.com/actions/runner-images
+      - name: Version 
+        run: | 
+          pnpm exec changeset version
+
+          cat .changeset/pre.json | jq -r .version >> version.txt
+
+        # Commit change to version in pre.json and push to remote
+      - name: Commit Change to Prerelease Version
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'chore: version release candidate'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish 
+        run: pnpm exec changeset publish --tag rc
+      - name: Comment on PR
+        run: |
+          cat << EOF > message.txt
+          # Candidate Release
+          > $(date +"Updated at %B %d, %Y, %H:%M:%S.")
+
+          I've published a prerelease for your commit, ${GITHUB_SHA:0:7}. To use it, go to a Next.js app with \`@makeswift/runtime\` installed and run:
+          \`\`\`bash
+          pnpm up @makeswift/runtime@$(cat version.txt)
+          \`\`\`
+          EOF
+      - uses: mshick/add-pr-comment@v2
+        with:
+          message-path: message.txt
+      - name: Push Tag to Remote
+        run: git push --follow-tags
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install --ignore-scripts --frozen-lockfile
 
+      # output of the action used below is named 'files_exists', see: https://github.com/andstor/file-existence-action
+      - name: Check if in Prerelease Mode
+        id: is_in_prerelease_mode
+        uses: andstor/file-existence-action@v3
+        with:
+          files: '.changeset/pre.json'
+      # This step itself does not exit prerelease mode, but rather will "set an intent" to exit prerelease mode in 'pre.json' (see: https://github.com/changesets/changesets/blob/main/docs/prereleases.md)
+      # As a result, when the subsequent use of changesets/action@v1 (in a step below) runs 'changeset version', prerelease mode will be exited and versioning/release will proceed as normal.
+      - name: Prepare to Exit Prerelease Mode if Needed
+        if: steps.is_in_prerelease_mode.outputs.files_exists == 'true'
+        run: pnpm exec changeset pre exit
       - name: Create release pull request or publish to NPM
         uses: changesets/action@v1
         with:

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -8,6 +8,7 @@ concurrency: ${{ github.workflow}}-${{ github.ref }}
 
 jobs:
   snapshot_release:
+    if: ${{ !contains(github.head_ref, '-rc-') }}
     name: Snapshot Release
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
ENG-6796

For something like https://github.com/makeswift/makeswift/pull/838, we want people to be able to use @makeswift/runtime@rc instead of asking them to find a snapshot. 

What I'm trying to do here:
- create a prerelease with the distribution tag 'rc' when either (A) a PR is opened to merge a branch with '-rc-' in its name into main or (B) a commit is made to a branch with '-rc-' in the name that already has an open PR to be merged into main
- prevent the existing snapshot release process from picking up branches with '-rc-' in their name
- update the main release process (release.yml) so that it exits prerelease mode if necessary before versioning/publishing (i.e., if we merge a PR from a release candidate into main without having manually exited prerelease mode)

A few thoughts:
- I wonder if there is a branch name pattern we'd prefer over '-rc-'? We've talked about including the dist tag in the branch name (i.e., having 'release/alpha' or similar as a branch naming pattern), but right now I'm concerned about the amount of time I might spend trying to get the parsing/validation working and whether we'd get enough value out of having multiple prerelease stages for that to be worthwhile. 
- Being new to both GitHub actions and changesets, I am concerned about tinkering with the release process. I'm not sure how to test something like this and have peace of mind prior to merging. 
- I would understand if we want to handle rc publishes manually for now versus trying this out.
