### PR TITLE
fix(runtime): use separate finddomnode for fallbacks

### DIFF
--- a/packages/runtime/src/runtimes/react/components/Element.tsx
+++ b/packages/runtime/src/runtimes/react/components/Element.tsx
@@ -24,6 +24,10 @@ export const ElementWithFallback = memo(
     const useFindDomNodeRef = useRef(true)
     const imperativeHandleRef = useRef(new ElementImperativeHandle())
 
+    const fallbackCallbackRef = useCallback((current: (() => Element | Text | null) | null) => {
+      imperativeHandleRef.current.callback(() => current?.() ?? null)
+    }, [])
+
     const findDomNodeCallbackRef = useCallback((current: (() => Element | Text | null) | null) => {
       if (useFindDomNodeRef.current === true) {
         imperativeHandleRef.current.callback(() => current?.() ?? null)
@@ -39,21 +43,23 @@ export const ElementWithFallback = memo(
     useImperativeHandle(ref, () => imperativeHandleRef.current, [])
 
     return (
-      <FindDomNode ref={findDomNodeCallbackRef}>
-        <ElementRegistration componentHandle={imperativeHandleRef.current} elementKey={element.key}>
-          {showFallback ? (
-            fallback
-          ) : isElementReference(element) ? (
-            <ElementReference
-              key={element.key}
-              ref={elementCallbackRef}
-              elementReference={element}
-            />
-          ) : (
-            <ElementData key={element.key} ref={elementCallbackRef} elementData={element} />
-          )}
-        </ElementRegistration>
-      </FindDomNode>
+      <ElementRegistration componentHandle={imperativeHandleRef.current} elementKey={element.key}>
+        {showFallback ? (
+          <FindDomNode ref={fallbackCallbackRef}>{fallback}</FindDomNode>
+        ) : (
+          <FindDomNode ref={findDomNodeCallbackRef}>
+            {isElementReference(element) ? (
+              <ElementReference
+                key={element.key}
+                ref={elementCallbackRef}
+                elementReference={element}
+              />
+            ) : (
+              <ElementData key={element.key} ref={elementCallbackRef} elementData={element} />
+            )}
+          </FindDomNode>
+        )}
+      </ElementRegistration>
     )
   }),
 )


### PR DESCRIPTION
Use a separate `FindDomNode` for rendering the fallback which won't be overruled by the element callback ref.

Before:

https://github.com/user-attachments/assets/39c61206-7868-4e1f-a519-73b7882f34cc

After:

https://github.com/user-attachments/assets/298ea89d-16bb-4da4-b9b9-9ff90e6656b7
