### PR TITLE
refactor(runtime): pass initial root element directly

### DIFF
--- a/packages/runtime/src/next/client.ts
+++ b/packages/runtime/src/next/client.ts
@@ -173,19 +173,22 @@ export function componentDocumentToRootEmbeddedDocument({
   name: string
   type: string
 }): EmbeddedDocument {
-  const { data, locale, id } = document
+  const { data: rootElement, locale, id } = document
 
-  if (data != null && data.type !== type) {
+  if (rootElement != null && rootElement.type !== type) {
     throw new Error(
-      `Type "${data.type}" does not match the expected type "${type}" from the snapshot`,
+      `Type "${rootElement.type}" does not match the expected type "${type}" from the snapshot`,
     )
   }
 
-  const rootElement = data ?? {
+  const initialRootElement = {
     // Fallback rootElement
     // Create a stable uuid so two different clients will have the same empty element data.
     // This is needed to make presence feature work for an element that is not yet created.
-    key: deterministicUUID({ id, locale, seed: document.seed }),
+    key:
+      rootElement != null
+        ? rootElement.key
+        : deterministicUUID({ id, locale, seed: document.seed }),
     type,
     props: {},
   }
@@ -193,6 +196,7 @@ export function componentDocumentToRootEmbeddedDocument({
   const rootDocument: EmbeddedDocument = {
     key: uuid(),
     rootElement,
+    initialRootElement,
     locale,
     id,
     type,

--- a/packages/runtime/src/runtimes/react/components/Document.tsx
+++ b/packages/runtime/src/runtimes/react/components/Document.tsx
@@ -3,6 +3,7 @@ import { type Document as ReactPageDocument } from '../../../state/react-page'
 import { ElementImperativeHandle } from '../element-imperative-handle'
 import { DocumentContext } from '../hooks/use-document-context'
 import { Element } from './Element'
+import { getRootElementFromDocument } from '../../../state/utils/get-root-element-from-document'
 
 type DocumentProps = {
   document: ReactPageDocument
@@ -13,9 +14,11 @@ export const Document = memo(
     { document }: DocumentProps,
     ref: Ref<ElementImperativeHandle>,
   ): JSX.Element {
+    const rootElement = getRootElementFromDocument(document)
+
     return (
       <DocumentContext.Provider value={document}>
-        <Element ref={ref} element={document.rootElement} />
+        <Element ref={ref} element={rootElement} />
       </DocumentContext.Provider>
     )
   }),

--- a/packages/runtime/src/state/actions.ts
+++ b/packages/runtime/src/state/actions.ts
@@ -2,7 +2,7 @@ import type { Operation } from 'ot-json0'
 
 import { ControlInstance } from '@makeswift/controls'
 
-import type { Element, Document, EMBEDDED_DOCUMENT_TYPE } from './modules/read-only-documents'
+import { type Element, type Document, EMBEDDED_DOCUMENT_TYPE } from './modules/read-only-documents'
 import type { ComponentType } from './modules/react-components'
 import type { Measurable, BoxModel } from './modules/box-models'
 import type { ThunkAction } from 'redux-thunk'
@@ -99,10 +99,14 @@ type DocumentPayloadBaseDocument = {
   locale?: string | null // older versions of the runtime may not provide this field
 }
 
-type DocumentPayloadEmbeddedDocument = DocumentPayloadBaseDocument & {
+type DocumentPayloadEmbeddedDocument = {
+  key: string
+  locale: string | null
   id: string
   type: string
   name: string
+  rootElement: Element | null
+  initialRootElement: Element
   __type: typeof EMBEDDED_DOCUMENT_TYPE
 }
 

--- a/packages/runtime/src/state/modules/read-only-documents.ts
+++ b/packages/runtime/src/state/modules/read-only-documents.ts
@@ -25,10 +25,14 @@ type BaseDocument = {
 
 export const EMBEDDED_DOCUMENT_TYPE = 'EMBEDDED_DOCUMENT' as const
 
-export type EmbeddedDocument = BaseDocument & {
+export type EmbeddedDocument = {
+  key: string
+  locale: string | null
   id: string
   type: string
   name: string
+  rootElement: Element | null
+  initialRootElement: Element
   __type: typeof EMBEDDED_DOCUMENT_TYPE
 }
 

--- a/packages/runtime/src/state/modules/read-write-documents.ts
+++ b/packages/runtime/src/state/modules/read-write-documents.ts
@@ -3,6 +3,7 @@ import { removeIn, setIn } from 'immutable'
 
 import * as ReadOnlyDocuments from './read-only-documents'
 import { Action, ActionTypes } from '../actions'
+import { getRootElementFromDocument } from '../utils/get-root-element-from-document'
 
 export type { Document, Element, ElementData, ElementReference } from './read-only-documents'
 export { isElementReference } from './read-only-documents'
@@ -56,7 +57,7 @@ export function reducer(state: State = getInitialState(), action: Action): State
       const document = getDocument(nextState, action.payload.documentKey)
       if (document == null) return nextState
 
-      const currentRootElement = document.rootElement
+      const currentRootElement = getRootElementFromDocument(document)
 
       const nextRootElement = apply(currentRootElement, action.payload.operation)
 

--- a/packages/runtime/src/state/react-page.ts
+++ b/packages/runtime/src/state/react-page.ts
@@ -39,6 +39,7 @@ import {
   merge,
   mergeTranslatedData,
 } from '../controls/control'
+import { getRootElementFromDocument } from './utils/get-root-element-from-document'
 
 import { type SetupTeardownMixin, withSetupTeardown } from './mixins/setup-teardown'
 
@@ -158,7 +159,7 @@ function getDocumentElements(state: State, documentKey: string): Map<string, Doc
 
   if (document == null) return new Map()
 
-  return normalizeElement(document.rootElement, descriptors)
+  return normalizeElement(getRootElementFromDocument(document), descriptors)
 }
 
 /**

--- a/packages/runtime/src/state/utils/get-root-element-from-document.test.ts
+++ b/packages/runtime/src/state/utils/get-root-element-from-document.test.ts
@@ -1,0 +1,75 @@
+import { getRootElementFromDocument } from './get-root-element-from-document'
+import { Document } from '../react-page'
+
+describe('getRootElementFromDocument', () => {
+  test('returns rootElement for base documents', () => {
+    const document: Document = {
+      key: 'document-key',
+      locale: null,
+      rootElement: {
+        key: 'root-element',
+        type: 'DIV',
+        props: {},
+      },
+    }
+
+    const root = getRootElementFromDocument(document)
+    expect(root).toMatchObject({
+      key: 'root-element',
+      type: 'DIV',
+      props: {},
+    })
+  })
+
+  test('returns root element if defined for embedded document', () => {
+    const document: Document = {
+      id: 'document-id',
+      key: 'document-key',
+      type: 'DOCUMENT',
+      name: 'Document',
+      locale: null,
+      initialRootElement: {
+        key: 'initial-root-element',
+        type: 'DIV',
+        props: {},
+      },
+      rootElement: {
+        key: 'root-element',
+        type: 'DIV',
+        props: {},
+      },
+      __type: 'EMBEDDED_DOCUMENT',
+    }
+
+    const root = getRootElementFromDocument(document)
+    expect(root).toMatchObject({
+      key: 'root-element',
+      type: 'DIV',
+      props: {},
+    })
+  })
+
+  test('returns initial root element if root element is null', () => {
+    const document: Document = {
+      id: 'document-id',
+      key: 'document-key',
+      type: 'DOCUMENT',
+      name: 'Document',
+      locale: null,
+      initialRootElement: {
+        key: 'initial-root-element',
+        type: 'DIV',
+        props: {},
+      },
+      rootElement: null,
+      __type: 'EMBEDDED_DOCUMENT',
+    }
+
+    const root = getRootElementFromDocument(document)
+    expect(root).toMatchObject({
+      key: 'initial-root-element',
+      type: 'DIV',
+      props: {},
+    })
+  })
+})

--- a/packages/runtime/src/state/utils/get-root-element-from-document.ts
+++ b/packages/runtime/src/state/utils/get-root-element-from-document.ts
@@ -1,0 +1,10 @@
+import { match } from 'ts-pattern'
+import { type Document } from '../react-page'
+import { type Element } from '@makeswift/controls'
+import { EMBEDDED_DOCUMENT_TYPE } from '../modules/read-only-documents'
+
+export function getRootElementFromDocument(document: Document): Element {
+  return match(document)
+    .with({ __type: EMBEDDED_DOCUMENT_TYPE }, doc => doc.rootElement ?? doc.initialRootElement)
+    .otherwise(doc => doc.rootElement)
+}


### PR DESCRIPTION
Rather than passing metadata about whether the root element exists or not, we now allow the root element to be null, and also pass an initial root element field. This allows us to derive whether the root exists, as well as use this initial root to reset the data later.