### PR TITLE
feat(runtime): utilize v2 endpoint for fetching element trees

### DIFF
--- a/.changeset/dry-jokes-juggle.md
+++ b/.changeset/dry-jokes-juggle.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+feat(runtime): utilize v2 endpoint for fetching element trees

--- a/packages/runtime/src/next/client.ts
+++ b/packages/runtime/src/next/client.ts
@@ -149,15 +149,11 @@ const makeswiftComponentDocumentSchemaV2 = z.object({
 
 export type MakeswiftComponentDocumentSchemaV2 = z.infer<typeof makeswiftComponentDocumentSchemaV2>
 
-const getMakeswiftComponentDocumentSchemaV2 = z.object({
-  elementTree: makeswiftComponentDocumentSchemaV2.nullable(),
-  parentLocaleElementTree: makeswiftComponentDocumentSchemaV2.nullable()
-})
-.and(z.union([
+const getMakeswiftComponentDocumentSchemaV2 = z.union([
   z.object({ elementTree: z.null(), parentLocaleElementTree: makeswiftComponentDocumentSchemaV2 }),
   z.object({ elementTree: makeswiftComponentDocumentSchemaV2, parentLocaleElementTree: z.null()}),
   z.object({ elementTree: makeswiftComponentDocumentSchemaV2, parentLocaleElementTree: makeswiftComponentDocumentSchemaV2 }),
-], {errorMap: (_issue, _ctx) => ({message: "One or both of 'elementTree' and 'parentLocaleElementTree' must be present."})}))
+], {errorMap: (_issue, _ctx) => ({message: "One or both of 'elementTree' and 'parentLocaleElementTree' must be present."})})
 
 const makeswiftComponentDocumentSchema = z.object({
   id: z.string(),

--- a/packages/runtime/src/next/client.ts
+++ b/packages/runtime/src/next/client.ts
@@ -683,7 +683,7 @@ export class Makeswift {
 
     // If the element tree is not found, we generate a document with null data
     if (response.status === 404) {
-      return this.getDummyDocument(id, locale)
+      return this.getSnapshotWithFallbackDocument(id, locale)
     }
 
     const json = await response.json()
@@ -700,7 +700,7 @@ export class Makeswift {
 
     // This case should never be reached (response was an http 200, but neither the element tree nor the parent locale element tree were provided in the response)
     if (document == null) {
-      return this.getDummyDocument(id, locale)
+      return this.getSnapshotWithFallbackDocument(id, locale)
     }
 
     const cacheData = await this.introspect(document.data, siteVersion, locale)
@@ -888,7 +888,7 @@ export class Makeswift {
     return this.runtime.mergeTranslatedData(elementTree, translatedData)
   }
 
-  getDummyDocument(id: string, locale: string | undefined): MakeswiftComponentSnapshot {
+  getSnapshotWithFallbackDocument(id: string, locale: string | undefined): MakeswiftComponentSnapshot {
     const apiKeyPrefix = z.string().parse(this.apiKey.split('-').at(0))
     return {
       document: {

--- a/packages/runtime/src/next/client.ts
+++ b/packages/runtime/src/next/client.ts
@@ -138,6 +138,22 @@ export type MakeswiftPageSnapshot = {
   cacheData: CacheData
 }
 
+const makeswiftComponentDocumentSchemaV2 = z.object({
+  id: z.string(),
+  name: z.string().nullable(),
+  locale: z.string(),
+  data: Schema.element,
+  type: z.string().nullable(),
+  siteId: z.string(),
+})
+
+export type MakeswiftComponentDocumentSchemaV2 = z.infer<typeof makeswiftComponentDocumentSchemaV2>
+
+const getMakeswiftComponentDocumentSchemaV2 = z.object({
+  elementTree: makeswiftComponentDocumentSchemaV2.nullable(),
+  parentLocaleElementTree: makeswiftComponentDocumentSchemaV2.nullable()
+})
+
 const makeswiftComponentDocumentSchema = z.object({
   id: z.string(),
   name: z.string().nullable(),
@@ -652,45 +668,41 @@ export class Makeswift {
   async getComponentSnapshot(
     id: string,
     {
-      siteVersion = MakeswiftSiteVersion.Working,
+      siteVersion: siteVersionPromise,
       locale,
-    }: {
-      siteVersion?: MakeswiftSiteVersion
-      locale?: string
-    } = {},
+    }: { siteVersion: MakeswiftSiteVersion | Promise<MakeswiftSiteVersion>; locale?: string},
   ): Promise<MakeswiftComponentSnapshot> {
     const searchParams = new URLSearchParams()
     if (locale) searchParams.set('locale', locale)
 
+    const siteVersion = await siteVersionPromise
     const response = await this.fetch(
-      `v1/element-trees/${id}?${searchParams.toString()}`,
+      `v2/element-trees/${id}?${searchParams.toString()}`,
       siteVersion,
     )
 
     // If the element tree is not found, we generate a document with null data
     if (response.status === 404) {
-      const apiKeyPrefix = z.string().parse(this.apiKey.split('-').at(0))
-
-      return {
-        document: {
-          id,
-          locale: locale ?? null,
-          data: null,
-          // We pass the seed to generate the elementKey to make sure it's unique for each site.
-          seed: apiKeyPrefix,
-        },
-        cacheData: CacheData.empty(),
-      }
+      return this.getDummyDocument(id, locale)
     }
 
     const json = await response.json()
 
     if (!response.ok) {
-      console.error('Failed to get page snapshot', json)
-      throw new Error(`Failed to get page snapshot with error: "${response.statusText}"`)
+      console.error('Failed to get component snapshot', json)
+      throw new Error(`Failed to get component snapshot with error: "${response.statusText}"`)
     }
 
-    const document = makeswiftComponentDocumentSchema.parse(json)
+    const elementTreeResponse = getMakeswiftComponentDocumentSchemaV2.parse(json)
+
+    // favor picking 'elementTree' if it is available.
+    const document = elementTreeResponse.elementTree ?? elementTreeResponse.parentLocaleElementTree
+
+    // This case should never be reached (response was an http 200, but neither the element tree nor the parent locale element tree were provided in the response)
+    if (document == null) {
+      return this.getDummyDocument(id, locale)
+    }
+
     const cacheData = await this.introspect(document.data, siteVersion, locale)
 
     return { document, cacheData }
@@ -874,5 +886,19 @@ export class Makeswift {
 
   mergeTranslatedData(elementTree: ElementData, translatedData: Record<string, Data>): Element {
     return this.runtime.mergeTranslatedData(elementTree, translatedData)
+  }
+
+  getDummyDocument(id: string, locale: string | undefined): MakeswiftComponentSnapshot {
+    const apiKeyPrefix = z.string().parse(this.apiKey.split('-').at(0))
+    return {
+      document: {
+        id,
+        locale: locale ?? null,
+        data: null,
+        // We pass the seed to generate the elementKey to make sure it's unique for each site.
+        seed: apiKeyPrefix,
+      },
+      cacheData: CacheData.empty(),
+    }
   }
 }

--- a/packages/runtime/src/next/client.ts
+++ b/packages/runtime/src/next/client.ts
@@ -682,7 +682,6 @@ export class Makeswift {
       siteVersion,
     )
 
-    // If the element tree is not found, we generate a document with null data
     if (response.status === 404) {
       return this.getSnapshotWithFallbackDocument(id, locale)
     }
@@ -696,7 +695,6 @@ export class Makeswift {
 
     const elementTreeResponse = getMakeswiftComponentDocumentSchemaV2.parse(json)
 
-    // favor picking 'elementTree' if it is available.
     const document = elementTreeResponse.elementTree ?? elementTreeResponse.parentLocaleElementTree
 
     const cacheData = await this.introspect(document.data, siteVersion, locale)

--- a/packages/runtime/src/next/client.ts
+++ b/packages/runtime/src/next/client.ts
@@ -153,6 +153,11 @@ const getMakeswiftComponentDocumentSchemaV2 = z.object({
   elementTree: makeswiftComponentDocumentSchemaV2.nullable(),
   parentLocaleElementTree: makeswiftComponentDocumentSchemaV2.nullable()
 })
+.and(z.union([
+  z.object({ elementTree: z.null(), parentLocaleElementTree: makeswiftComponentDocumentSchemaV2 }),
+  z.object({ elementTree: makeswiftComponentDocumentSchemaV2, parentLocaleElementTree: z.null()}),
+  z.object({ elementTree: makeswiftComponentDocumentSchemaV2, parentLocaleElementTree: makeswiftComponentDocumentSchemaV2 }),
+], {errorMap: (_issue, _ctx) => ({message: "One or both of 'elementTree' and 'parentLocaleElementTree' must be present."})}))
 
 const makeswiftComponentDocumentSchema = z.object({
   id: z.string(),
@@ -697,11 +702,6 @@ export class Makeswift {
 
     // favor picking 'elementTree' if it is available.
     const document = elementTreeResponse.elementTree ?? elementTreeResponse.parentLocaleElementTree
-
-    // This case should never be reached (response was an http 200, but neither the element tree nor the parent locale element tree were provided in the response)
-    if (document == null) {
-      return this.getSnapshotWithFallbackDocument(id, locale)
-    }
 
     const cacheData = await this.introspect(document.data, siteVersion, locale)
 

--- a/packages/runtime/src/next/tests/client.get-component-snapshot.test.ts
+++ b/packages/runtime/src/next/tests/client.get-component-snapshot.test.ts
@@ -1,0 +1,167 @@
+import { Makeswift, MakeswiftComponentDocumentSchemaV2 } from '../client'
+import { http, HttpResponse, graphql } from 'msw'
+
+import { server } from '../../mocks/server'
+import { MakeswiftSiteVersion } from '../preview-mode'
+import { ZodError } from 'zod'
+
+const TEST_API_KEY = 'xxx'
+const apiOrigin = 'https://api.fakeswift.com'
+const baseUrl = `${apiOrigin}/v2/element-trees`
+
+describe('getComponentSnapshot using v2 element tree endpoint', () => {
+    test('return fallback document on 404', async () => {
+        // Arrange
+        const client = new Makeswift(TEST_API_KEY, { apiOrigin })
+        const treeId = 'myTree'
+        server.use(
+            http.get(`${baseUrl}/${treeId}`, () => HttpResponse.text('', { status: 404 }),{ once: true })
+        )
+
+        // Act
+        const result = await client.getComponentSnapshot(treeId, { siteVersion: MakeswiftSiteVersion.Working })
+
+        // Assert
+        expect(result.document).not.toBeNull()
+        expect(result.document.id).toBe(treeId)
+        expect(result.document.data).toBeNull()
+        expect(result.cacheData).not.toBeNull()
+        expect(result.cacheData.apiResources).toStrictEqual({})
+        expect(result.cacheData.localizedResourcesMap).toStrictEqual({})
+    })
+
+    test('throws if response is 200 but element tree results are null', async () => {
+        // Arrange
+        const client = new Makeswift(TEST_API_KEY, { apiOrigin })
+        const treeId = 'myTree'
+        server.use(
+            http.get(`${baseUrl}/${treeId}`, () => HttpResponse.json({ elementTree: null, parentLocaleElementTree: null}, { status: 200}), { once: true})
+        )
+
+        // Act
+        const getResult = async () => {
+            return client.getComponentSnapshot(treeId, { siteVersion: MakeswiftSiteVersion.Working })
+        }
+
+        // Assert
+        expect(getResult).rejects.toThrow(ZodError)
+    })
+
+    test('throws on unexpected format for element tree', async () => {
+        // Arrange
+        const client = new Makeswift(TEST_API_KEY, { apiOrigin })
+        const treeId = 'myTree'
+        server.use(
+            http.get(`${baseUrl}/${treeId}`, () => HttpResponse.json({ elementTree: {}, parentLocaleElementTree: null}, { status: 200}), { once: true })
+        )
+
+        // Act
+        const getResult = async () => {
+            return client.getComponentSnapshot(treeId, { siteVersion: MakeswiftSiteVersion.Working })
+        }
+
+        // Assert
+        expect(getResult).rejects.toThrow(ZodError)
+    })
+
+    test('favors returning elementTree over parentLocaleElementTree if both are present', async () => {
+        // Arrange
+        const client = new Makeswift(TEST_API_KEY, { apiOrigin })
+
+        // These fields don't need to correspond to any existing resource for the test - they are just being used to form a valid MakeswiftComponentDocumentSchemaV2 object
+        const treeId = 'myTree123'
+        const elementTreeName = 'myElementTree'
+        const elementTreeKey = "abc123"
+
+        const elementTree: MakeswiftComponentDocumentSchemaV2 = {
+            id: treeId,
+            type: './components/Box/index.js',
+            name: elementTreeName,
+            data: {
+                type: './components/Box/index.js',
+                key: elementTreeKey,
+                props: {}
+            },
+            locale: 'fr-FR',
+            siteId: 'mySiteId'
+        }
+
+        const parentLocaleElementTree: MakeswiftComponentDocumentSchemaV2 = {
+            id: treeId,
+            type: './components/Box/index.js',
+            name: 'parentLocaleElementTreeName',
+            data: {
+                type: './components/Box/index.js',
+                key: 'def123',
+                props: {}
+            },
+            locale: 'en-US',
+            siteId: 'mySiteId'
+        }
+
+        const testResponse = {
+            elementTree,
+            parentLocaleElementTree
+        }
+
+        server.use(
+            http.get(`${baseUrl}/${treeId}`, () => HttpResponse.json(testResponse, { status: 200}), { once: true }),
+            graphql.operation(() => {
+                return HttpResponse.json({})
+            })
+        )
+
+        // Act
+        const result = await client.getComponentSnapshot(treeId, { siteVersion: MakeswiftSiteVersion.Working })
+
+        // Assert
+        expect(result).not.toBeNull()
+        expect(result.document).not.toBeNull()
+        expect(result.document.data).not.toBeNull()
+        expect(result.document.data?.key).toBe(elementTreeKey)
+    })
+
+    test('returns parentLocaleElementTree when elementTree is not present', async () => {
+        // Arrange
+        const client = new Makeswift(TEST_API_KEY, { apiOrigin })
+
+        // These fields don't need to correspond to any existing resource for the test - they are just being used to form a valid MakeswiftComponentDocumentSchemaV2 object
+        const treeId = 'myTree123'
+        const parentLocaleElementTreeName = 'myElementTree'
+        const elementTreeKey = 'def123'
+
+        const parentLocaleElementTree: MakeswiftComponentDocumentSchemaV2 = {
+            id: treeId,
+            type: './components/Box/index.js',
+            name: parentLocaleElementTreeName,
+            data: {
+                type: './components/Box/index.js',
+                key: elementTreeKey,
+                props: {}
+            },
+            locale: 'en-US',
+            siteId: 'mySiteId'
+        }
+
+        const testResponse = {
+            elementTree: null,
+            parentLocaleElementTree
+        }
+
+        server.use(
+            http.get(`${baseUrl}/${treeId}`, () => HttpResponse.json(testResponse, { status: 200 }), { once: true }),
+            graphql.operation(() => {
+                return HttpResponse.json({})
+            })
+        )
+
+        // Act
+        const result = await client.getComponentSnapshot(treeId, { siteVersion: MakeswiftSiteVersion.Working })
+
+        // Assert
+        expect(result).not.toBeNull()
+        expect(result.document).not.toBeNull()
+        expect(result.document.data).not.toBeNull()
+        expect(result.document.data?.key).toBe(elementTreeKey)
+    })
+})


### PR DESCRIPTION
eng-7065

Updating the runtime to use the new v2 endpoint for fetching element trees that was added in eng-6954

Here we decided on making the siteVersion param mandatory: https://makeswifthq.slack.com/archives/C080BNSNEG7/p1733744344493169 