### PR TITLE
refactor(runtime): remove fallback prop

### DIFF
--- a/packages/runtime/src/next/client.ts
+++ b/packages/runtime/src/next/client.ts
@@ -168,12 +168,10 @@ export function componentDocumentToRootEmbeddedDocument({
   document,
   name,
   type,
-  hasFallback = false,
 }: {
   document: MakeswiftComponentDocument | MakeswiftComponentDocumentFallback
   name: string
   type: string
-  hasFallback?: boolean
 }): EmbeddedDocument {
   const { data, locale, id } = document
 
@@ -200,10 +198,6 @@ export function componentDocumentToRootEmbeddedDocument({
     type,
     name,
     __type: EMBEDDED_DOCUMENT_TYPE,
-    meta: {
-      isInitialData: data == null,
-      hasFallback,
-    },
   }
 
   return rootDocument

--- a/packages/runtime/src/next/components/MakeswiftComponent.tsx
+++ b/packages/runtime/src/next/components/MakeswiftComponent.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { memo, ReactNode, Suspense, useMemo } from 'react'
+import { memo, Suspense, useMemo } from 'react'
 import { componentDocumentToRootEmbeddedDocument, MakeswiftComponentSnapshot } from '../client'
 import { DocumentRoot } from '../../runtimes/react/components/DocumentRoot'
 import { useSyncCacheData } from '../hooks/use-sync-cache-data'
@@ -10,10 +10,9 @@ type Props = {
   snapshot: MakeswiftComponentSnapshot
   label: string
   type: string
-  fallback?: ReactNode
 }
 
-export const MakeswiftComponent = memo(({ snapshot, label, type, fallback }: Props) => {
+export const MakeswiftComponent = memo(({ snapshot, label, type }: Props) => {
   useSyncCacheData(snapshot.cacheData)
 
   const rootDocument = useMemo(
@@ -22,7 +21,6 @@ export const MakeswiftComponent = memo(({ snapshot, label, type, fallback }: Pro
         document: snapshot.document,
         name: label,
         type,
-        hasFallback: fallback != null,
       }),
     [snapshot, label, type],
   )
@@ -31,7 +29,7 @@ export const MakeswiftComponent = memo(({ snapshot, label, type, fallback }: Pro
 
   return (
     <Suspense>
-      <DocumentRoot rootDocument={rootDocument} fallback={fallback} />
+      <DocumentRoot rootDocument={rootDocument} />
     </Suspense>
   )
 })

--- a/packages/runtime/src/next/components/tests/makeswift-component-rendering.test.tsx
+++ b/packages/runtime/src/next/components/tests/makeswift-component-rendering.test.tsx
@@ -12,13 +12,7 @@ import {
   type MakeswiftComponentSnapshot,
 } from '../../client'
 import { type CacheData } from '../../../api/react'
-import { type ReactNode } from 'react'
 import { TextInput } from '@makeswift/controls'
-
-const fallbackTestId = 'fallback'
-function FallbackNode() {
-  return <div data-testid={fallbackTestId}>Fallback Node</div>
-}
 
 const CustomComponentType = 'CustomComponent'
 const customComponentContentTestId = 'custom'
@@ -60,10 +54,7 @@ function createMakeswiftComponentSnapshot(
   }
 }
 
-async function testMakeswiftComponentRendering(
-  snapshot: MakeswiftComponentSnapshot,
-  fallback?: ReactNode,
-) {
+async function testMakeswiftComponentRendering(snapshot: MakeswiftComponentSnapshot) {
   const runtime = new ReactRuntime()
 
   runtime.registerComponent(CustomComponent, {
@@ -81,7 +72,6 @@ async function testMakeswiftComponentRendering(
           label="Embedded Component"
           type={CustomComponentType}
           snapshot={snapshot}
-          fallback={fallback}
         />
       </ReactRuntimeProvider>,
     ),
@@ -89,39 +79,17 @@ async function testMakeswiftComponentRendering(
 }
 
 describe('MakeswiftComponent', () => {
-  describe('without fallback', () => {
-    test('empty snapshot renders component with default props', async () => {
-      const snapshot = createMakeswiftComponentSnapshot(emptyDocumentFixture)
-      await testMakeswiftComponentRendering(snapshot)
+  test('empty snapshot renders component with default props', async () => {
+    const snapshot = createMakeswiftComponentSnapshot(emptyDocumentFixture)
+    await testMakeswiftComponentRendering(snapshot)
 
-      expect(screen.queryByTestId(customComponentContentTestId)).toHaveTextContent('Default Text')
-      expect(screen.queryByTestId(fallbackTestId)).not.toBeInTheDocument()
-    })
-
-    test('existing snapshot renders component with saved props', async () => {
-      const snapshot = createMakeswiftComponentSnapshot(existingDocumentFixture)
-      await testMakeswiftComponentRendering(snapshot)
-
-      expect(screen.queryByTestId(customComponentContentTestId)).toHaveTextContent('Hello World')
-      expect(screen.queryByTestId(fallbackTestId)).not.toBeInTheDocument()
-    })
+    expect(screen.queryByTestId(customComponentContentTestId)).toHaveTextContent('Default Text')
   })
 
-  describe('with fallback', () => {
-    test('empty snapshot renders fallback component', async () => {
-      const snapshot = createMakeswiftComponentSnapshot(emptyDocumentFixture)
-      await testMakeswiftComponentRendering(snapshot, <FallbackNode />)
+  test('existing snapshot renders component with saved props', async () => {
+    const snapshot = createMakeswiftComponentSnapshot(existingDocumentFixture)
+    await testMakeswiftComponentRendering(snapshot)
 
-      expect(screen.queryByTestId(customComponentContentTestId)).not.toBeInTheDocument()
-      expect(screen.queryByTestId(fallbackTestId)).toHaveTextContent('Fallback Node')
-    })
-
-    test('existing snapshot renders component with saved props', async () => {
-      const snapshot = createMakeswiftComponentSnapshot(existingDocumentFixture)
-      await testMakeswiftComponentRendering(snapshot, <FallbackNode />)
-
-      expect(screen.queryByTestId(customComponentContentTestId)).toHaveTextContent('Hello World')
-      expect(screen.queryByTestId(fallbackTestId)).not.toBeInTheDocument()
-    })
+    expect(screen.queryByTestId(customComponentContentTestId)).toHaveTextContent('Hello World')
   })
 })

--- a/packages/runtime/src/runtimes/react/components/Document.tsx
+++ b/packages/runtime/src/runtimes/react/components/Document.tsx
@@ -1,32 +1,21 @@
-import { ReactNode, Ref, forwardRef, memo } from 'react'
+import { Ref, forwardRef, memo } from 'react'
 import { type Document as ReactPageDocument } from '../../../state/react-page'
 import { ElementImperativeHandle } from '../element-imperative-handle'
 import { DocumentContext } from '../hooks/use-document-context'
-import { ElementWithFallback } from './Element'
-import { match } from 'ts-pattern'
+import { Element } from './Element'
 
 type DocumentProps = {
   document: ReactPageDocument
-  fallback?: ReactNode
 }
 
 export const Document = memo(
   forwardRef(function Document(
-    { document, fallback }: DocumentProps,
+    { document }: DocumentProps,
     ref: Ref<ElementImperativeHandle>,
   ): JSX.Element {
-    const isInitialData = match(document)
-      .with({ meta: { isInitialData: true } }, () => true)
-      .otherwise(() => false)
-
     return (
       <DocumentContext.Provider value={document}>
-        <ElementWithFallback
-          ref={ref}
-          element={document.rootElement}
-          fallback={fallback}
-          isInitialData={isInitialData}
-        />
+        <Element ref={ref} element={document.rootElement} />
       </DocumentContext.Provider>
     )
   }),

--- a/packages/runtime/src/runtimes/react/components/DocumentRoot.tsx
+++ b/packages/runtime/src/runtimes/react/components/DocumentRoot.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, Ref, forwardRef, memo } from 'react'
+import { Ref, forwardRef, memo } from 'react'
 import { type Document } from '../../../state/react-page'
 import { ElementImperativeHandle } from '../element-imperative-handle'
 import { useDocument } from '../hooks/use-document'
@@ -7,12 +7,11 @@ import { Document as DocumentComponent } from './Document'
 
 type Props = {
   rootDocument: Document
-  fallback?: ReactNode
 }
 
 export const DocumentRoot = memo(
   forwardRef(function DocumentRoot(
-    { rootDocument, fallback }: Props,
+    { rootDocument }: Props,
     ref: Ref<ElementImperativeHandle>,
   ): JSX.Element {
     const document = useDocument(rootDocument.key) ?? rootDocument
@@ -21,6 +20,6 @@ export const DocumentRoot = memo(
       return <FallbackComponent ref={ref as Ref<HTMLDivElement>} text="Document not found" />
     }
 
-    return <DocumentComponent ref={ref} document={document} fallback={fallback} />
+    return <DocumentComponent ref={ref} document={document} />
   }),
 )

--- a/packages/runtime/src/runtimes/react/components/Element.tsx
+++ b/packages/runtime/src/runtimes/react/components/Element.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { forwardRef, memo, ReactNode, Ref, useCallback, useImperativeHandle, useRef } from 'react'
+import { forwardRef, memo, Ref, useCallback, useImperativeHandle, useRef } from 'react'
 import { isElementReference, type Element as ElementDataOrRef } from '../../../state/react-page'
 import { ElementRegistration } from './ElementRegistration'
 import { ElementReference } from './ElementReference'
@@ -8,25 +8,17 @@ import { ElementData } from './ElementData'
 import { ElementImperativeHandle } from '../element-imperative-handle'
 import { FindDomNode } from '../find-dom-node'
 
-type ElementWithFallbackProps = {
+type Props = {
   element: ElementDataOrRef
-  fallback?: ReactNode
-  isInitialData?: boolean
 }
 
-export const ElementWithFallback = memo(
+export const Element = memo(
   forwardRef(function Element(
-    { element, fallback, isInitialData = false }: ElementWithFallbackProps,
+    { element }: Props,
     ref: Ref<ElementImperativeHandle>,
   ): JSX.Element | null {
-    const showFallback = fallback != null && isInitialData
-
     const useFindDomNodeRef = useRef(true)
     const imperativeHandleRef = useRef(new ElementImperativeHandle())
-
-    const fallbackCallbackRef = useCallback((current: (() => Element | Text | null) | null) => {
-      imperativeHandleRef.current.callback(() => current?.() ?? null)
-    }, [])
 
     const findDomNodeCallbackRef = useCallback((current: (() => Element | Text | null) | null) => {
       if (useFindDomNodeRef.current === true) {
@@ -44,35 +36,18 @@ export const ElementWithFallback = memo(
 
     return (
       <ElementRegistration componentHandle={imperativeHandleRef.current} elementKey={element.key}>
-        {showFallback ? (
-          <FindDomNode ref={fallbackCallbackRef}>{fallback}</FindDomNode>
-        ) : (
-          <FindDomNode ref={findDomNodeCallbackRef}>
-            {isElementReference(element) ? (
-              <ElementReference
-                key={element.key}
-                ref={elementCallbackRef}
-                elementReference={element}
-              />
-            ) : (
-              <ElementData key={element.key} ref={elementCallbackRef} elementData={element} />
-            )}
-          </FindDomNode>
-        )}
+        <FindDomNode ref={findDomNodeCallbackRef}>
+          {isElementReference(element) ? (
+            <ElementReference
+              key={element.key}
+              ref={elementCallbackRef}
+              elementReference={element}
+            />
+          ) : (
+            <ElementData key={element.key} ref={elementCallbackRef} elementData={element} />
+          )}
+        </FindDomNode>
       </ElementRegistration>
     )
-  }),
-)
-
-type ElementProps = {
-  element: ElementDataOrRef
-}
-
-export const Element = memo(
-  forwardRef(function Element(
-    { element }: ElementProps,
-    ref: Ref<ElementImperativeHandle>,
-  ): JSX.Element | null {
-    return <ElementWithFallback element={element} ref={ref} />
   }),
 )

--- a/packages/runtime/src/state/modules/read-only-documents.ts
+++ b/packages/runtime/src/state/modules/read-only-documents.ts
@@ -29,10 +29,6 @@ export type EmbeddedDocument = BaseDocument & {
   id: string
   type: string
   name: string
-  meta?: {
-    isInitialData?: boolean
-    hasFallback?: boolean
-  }
   __type: typeof EMBEDDED_DOCUMENT_TYPE
 }
 


### PR DESCRIPTION
Remove support for passing a fallback to the `MakeswiftComponent` component.