### PR TITLE
feat: add site.published webhook handler for global revalidation

### DIFF
--- a/.changeset/warm-avocados-bathe.md
+++ b/.changeset/warm-avocados-bathe.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Adds revalidation support for `<MakeswiftComponent />` on App Router.

--- a/packages/runtime/src/next/api-handler/handlers/manifest.ts
+++ b/packages/runtime/src/next/api-handler/handlers/manifest.ts
@@ -14,6 +14,7 @@ export type Manifest = {
   siteVersions: boolean
   unstable_siteVersions: boolean
   localizedPageSSR: boolean
+  webhook: boolean
 }
 
 type ManifestError = { message: string }
@@ -67,6 +68,11 @@ export default async function handler(
     .with(apiRoutePattern, () => false)
     .exhaustive()
 
+  const supportsWebhook = match(args)
+    .with(routeHandlerPattern, () => true)
+    .with(apiRoutePattern, () => false)
+    .exhaustive()
+
   const body = {
     version: PACKAGE_VERSION,
     previewMode: supportsPreviewMode,
@@ -78,6 +84,7 @@ export default async function handler(
     siteVersions: true,
     unstable_siteVersions: true,
     localizedPageSSR: true,
+    webhook: supportsWebhook,
   }
 
   return match(args)

--- a/packages/runtime/src/next/api-handler/handlers/webhook/index.ts
+++ b/packages/runtime/src/next/api-handler/handlers/webhook/index.ts
@@ -1,0 +1,75 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { NextRequest, NextResponse } from 'next/server'
+import { P, match } from 'ts-pattern'
+import { handleSitePublished } from './site-published'
+import {
+  sitePublishedWebhookPayloadSchema,
+  WebhookEventType,
+  WebhookPayloadSchema,
+  WebhookResponseBody,
+} from './types'
+
+type Context = { params: { [key: string]: string | string[] } }
+
+export type WebhookHandlerArgs =
+  | [request: NextRequest, context: Context, params: { apiKey: string }]
+  | [req: NextApiRequest, res: NextApiResponse<WebhookResponseBody>, params: { apiKey: string }]
+
+const routeHandlerPattern = [P.instanceOf(Request), P.any, P.any] as const
+const apiRoutePattern = [P.any, P.any, P.any] as const
+
+function getSecret(args: WebhookHandlerArgs) {
+  return match(args)
+    .with(routeHandlerPattern, ([request]) => request.nextUrl.searchParams.get('secret'))
+    .with(apiRoutePattern, ([req]) => req.query.secret)
+    .exhaustive()
+}
+
+function getRequestBody(args: WebhookHandlerArgs) {
+  return match(args)
+    .with(routeHandlerPattern, ([request]) => request.json())
+    .with(apiRoutePattern, ([req]) => req.body)
+    .exhaustive()
+}
+
+function respond(args: WebhookHandlerArgs, response: WebhookResponseBody, status?: number) {
+  return match(args)
+    .with(routeHandlerPattern, () => NextResponse.json(response, { status }))
+    .with(apiRoutePattern, ([, res]) => res.json(response))
+    .exhaustive()
+}
+
+export default async function handler(
+  request: NextRequest,
+  context: Context,
+  { apiKey }: { apiKey: string },
+): Promise<NextResponse<WebhookResponseBody>>
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WebhookResponseBody>,
+  { apiKey }: { apiKey: string },
+): Promise<void>
+export default async function handler(
+  ...args: WebhookHandlerArgs
+): Promise<NextResponse<WebhookResponseBody> | void> {
+  const [, , { apiKey }] = args
+  const secret = getSecret(args)
+
+  if (secret !== apiKey) return respond(args, { message: 'Unauthorized' }, 401)
+
+  let payload: WebhookPayloadSchema
+
+  try {
+    const body = await getRequestBody(args)
+    payload = sitePublishedWebhookPayloadSchema.parse(body)
+  } catch (error) {
+    console.error(error)
+    return respond(args, { message: 'Invalid request body' }, 400)
+  }
+
+  const result = match(payload.type)
+    .with(WebhookEventType.SITE_PUBLISHED, () => handleSitePublished(payload))
+    .exhaustive()
+
+  return respond(args, result.body, result.status)
+}

--- a/packages/runtime/src/next/api-handler/handlers/webhook/site-published.ts
+++ b/packages/runtime/src/next/api-handler/handlers/webhook/site-published.ts
@@ -1,0 +1,10 @@
+import { revalidateTag } from 'next/cache'
+import { SitePublishedWebhookPayload, WebhookHandlerResult } from './types'
+
+export function handleSitePublished(_payload: SitePublishedWebhookPayload): WebhookHandlerResult {
+  revalidateTag(MAKESWIFT_CACHE_TAG)
+
+  return { body: { success: true }, status: 200 }
+}
+
+export const MAKESWIFT_CACHE_TAG = '@@makeswift'

--- a/packages/runtime/src/next/api-handler/handlers/webhook/types.ts
+++ b/packages/runtime/src/next/api-handler/handlers/webhook/types.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod'
+
+export const WebhookEventType = {
+  SITE_PUBLISHED: 'site.published',
+} as const
+
+export const sitePublishedWebhookPayloadSchema = z.object({
+  type: z.literal(WebhookEventType.SITE_PUBLISHED),
+  data: z.object({
+    siteId: z.string().uuid(),
+    publish: z.object({
+      from: z.string().uuid().nullable(),
+      to: z.string().uuid(),
+    }),
+    at: z.number(),
+  }),
+})
+
+export type SitePublishedWebhookPayload = z.infer<typeof sitePublishedWebhookPayloadSchema>
+
+const webhookPayloadSchema = sitePublishedWebhookPayloadSchema
+
+export type WebhookPayloadSchema = z.infer<typeof webhookPayloadSchema>
+
+type WebhookSuccessBody = { success: true }
+
+type WebhookErrorBody = { message: string }
+
+export type WebhookResponseBody = WebhookSuccessBody | WebhookErrorBody
+
+export type WebhookHandlerResult = {
+  body: WebhookResponseBody
+  status: 200
+}

--- a/packages/runtime/src/next/api-handler/index.ts
+++ b/packages/runtime/src/next/api-handler/index.ts
@@ -13,6 +13,8 @@ import proxyDraftMode, { ProxyDraftModeResponse } from './handlers/proxy-draft-m
 import { revalidate, RevalidationResponse } from './handlers/revalidate'
 import translatableData, { TranslatableDataResponse } from './handlers/translatable-data'
 import mergeTranslatedData, { TranslatedDataResponse } from './handlers/merge-translated-data'
+import webhook from './handlers/webhook'
+import { WebhookResponseBody } from './handlers/webhook/types'
 import { ReactRuntime } from '../../react'
 import { P, match } from 'ts-pattern'
 import { getSiteVersion } from '../draft-mode'
@@ -41,6 +43,7 @@ export type MakeswiftApiHandlerResponse =
   | TranslatedDataResponse
   | APIResource
   | NotFoundError
+  | WebhookResponseBody
 
 type MakeswiftApiHandlerArgs =
   | [NextRequest, Context]
@@ -192,6 +195,13 @@ export function MakeswiftApiHandler(
       return match(args)
         .with(routeHandlerPattern, args => mergeTranslatedData(...args, client))
         .with(apiRoutePattern, args => mergeTranslatedData(...args, client))
+        .exhaustive()
+    }
+
+    if (matches('/webhook')) {
+      return match(args)
+        .with(routeHandlerPattern, args => webhook(...args, { apiKey }))
+        .with(apiRoutePattern, args => webhook(...args, { apiKey }))
         .exhaustive()
     }
 

--- a/packages/runtime/src/next/client.ts
+++ b/packages/runtime/src/next/client.ts
@@ -46,6 +46,7 @@ import { deterministicUUID } from '../utils/deterministic-uuid'
 import { v4 as uuid } from 'uuid'
 import { Schema } from '@makeswift/controls'
 import { EMBEDDED_DOCUMENT_TYPE, EmbeddedDocument } from '../state/modules/read-only-documents'
+import { MAKESWIFT_CACHE_TAG } from './api-handler/handlers/webhook/site-published'
 
 const makeswiftPageResultSchema = z.object({
   id: z.string(),
@@ -336,6 +337,10 @@ export class Makeswift {
         ...init?.headers,
       },
       ...(siteVersion === MakeswiftSiteVersion.Working ? { cache: 'no-store' } : {}),
+      next: {
+        ...init?.next,
+        tags: [...(init?.next?.tags ?? []), MAKESWIFT_CACHE_TAG],
+      },
     })
 
     return response

--- a/packages/runtime/src/state/makeswift-api-client.ts
+++ b/packages/runtime/src/state/makeswift-api-client.ts
@@ -27,6 +27,7 @@ import {
   type LocalizedGlobalElement,
   type APIResourceLocale,
 } from '../api'
+import { MAKESWIFT_CACHE_TAG } from '../next/api-handler/handlers/webhook/site-published'
 
 const reducer = combineReducers({
   apiResources: APIResources.reducer,
@@ -104,6 +105,7 @@ type Thunk<ReturnType> = ThunkAction<ReturnType, State, unknown, Action>
 async function fetchJson<T>(url: string): Promise<T | null> {
   const response = await fetch(url, {
     headers: { 'Content-Type': 'application/json' },
+    next: { tags: [MAKESWIFT_CACHE_TAG] },
   })
 
   if (response.status === 404) return null


### PR DESCRIPTION
This adds revalidation support for <MakeswiftComponent /> on App Router