### PR TITLE
runtime: getComponentSnapshot performs locale fallback

### DIFF
--- a/.changeset/young-shoes-cheer.md
+++ b/.changeset/young-shoes-cheer.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+Update getComponentSnapshot to perform locale fallback by default

--- a/packages/runtime/src/next/components/tests/makeswift-component-rendering.test.tsx
+++ b/packages/runtime/src/next/components/tests/makeswift-component-rendering.test.tsx
@@ -43,15 +43,17 @@ const existingDocumentFixture = {
 
 function createMakeswiftComponentSnapshot(
   document: MakeswiftComponentDocumentFallback | MakeswiftComponentDocument,
+  localeFallbackOccurred: boolean,
   cacheData: CacheData = {
     apiResources: {},
     localizedResourcesMap: {},
   },
-) {
+): MakeswiftComponentSnapshot {
   return {
     document,
     cacheData,
     key: '00000000-0000-0000-0000-000000000000',
+    localeFallbackOccurred
   }
 }
 
@@ -81,14 +83,14 @@ async function testMakeswiftComponentRendering(snapshot: MakeswiftComponentSnaps
 
 describe('MakeswiftComponent', () => {
   test('empty snapshot renders component with default props', async () => {
-    const snapshot = createMakeswiftComponentSnapshot(emptyDocumentFixture)
+    const snapshot = createMakeswiftComponentSnapshot(emptyDocumentFixture, false)
     await testMakeswiftComponentRendering(snapshot)
 
     expect(screen.queryByTestId(customComponentContentTestId)).toHaveTextContent('Default Text')
   })
 
   test('existing snapshot renders component with saved props', async () => {
-    const snapshot = createMakeswiftComponentSnapshot(existingDocumentFixture)
+    const snapshot = createMakeswiftComponentSnapshot(existingDocumentFixture, false)
     await testMakeswiftComponentRendering(snapshot)
 
     expect(screen.queryByTestId(customComponentContentTestId)).toHaveTextContent('Hello World')

--- a/packages/runtime/src/next/tests/client.get-component-snapshot.test.ts
+++ b/packages/runtime/src/next/tests/client.get-component-snapshot.test.ts
@@ -1,0 +1,234 @@
+import { Makeswift, MakeswiftComponentDocument } from '../client'
+import { http, HttpResponse, graphql } from 'msw'
+
+import { server } from '../../mocks/server'
+import { MakeswiftSiteVersion } from '../preview-mode'
+import { ZodError } from 'zod'
+
+const TEST_API_KEY = 'myApiKey'
+const apiOrigin = 'https://api.fakeswift.com'
+const baseUrl = `${apiOrigin}/v1/element-trees`
+
+describe('getComponentSnapshot using v1 element tree endpoint', () => {
+  test('return fallback document on 404', async () => {
+    // Arrange
+    const client = new Makeswift(TEST_API_KEY, { apiOrigin })
+    const treeId = 'myTree'
+    server.use(
+      http.get(`${baseUrl}/${treeId}`, () => HttpResponse.text('', { status: 404 }), {
+        once: true,
+      }),
+    )
+
+    // Act
+    const result = await client.getComponentSnapshot(treeId, {
+      siteVersion: MakeswiftSiteVersion.Working,
+    })
+
+    // Assert
+    expect(result.document).not.toBeNull()
+    expect(result.document.id).toBe(treeId)
+    expect(result.document.data).toBeNull()
+    expect(result.cacheData).not.toBeNull()
+    expect(result.cacheData.apiResources).toStrictEqual({})
+    expect(result.cacheData.localizedResourcesMap).toStrictEqual({})
+  })
+
+  test('throws if response is 200 but element tree result is null', async () => {
+    // Arrange
+    const client = new Makeswift(TEST_API_KEY, { apiOrigin })
+    const treeId = 'myTree'
+    const responseWithInvalidFormat = {
+      id: 'someTreeId',
+      name: 'someTreeName',
+      locale: null,
+      data: {},
+      type: null,
+      siteId: null,
+    }
+    server.use(
+      http.get(
+        `${baseUrl}/${treeId}`,
+        () => HttpResponse.json(responseWithInvalidFormat, { status: 200 }),
+        { once: true },
+      ),
+    )
+
+    // Act
+    const getResult = async () => {
+      return client.getComponentSnapshot(treeId, { siteVersion: MakeswiftSiteVersion.Working })
+    }
+
+    // Assert
+    expect(getResult).rejects.toThrow(ZodError)
+  })
+
+  test('successfully performs locale fallback by requesting base locale tree after receiving a 404 response for a locale variant tree', async () => {
+    // Arrange
+    const client = new Makeswift(TEST_API_KEY, { apiOrigin })
+    const localeToTest = 'fr-FR'
+    const baseLocale = null
+
+    // mock base locale tree document
+    const treeId = 'myTree123'
+    const elementTreeName = 'myElementTree'
+    const elementTreeKey = 'abc123'
+    const document: MakeswiftComponentDocument = {
+      id: treeId,
+      name: elementTreeName,
+      data: {
+        type: 'myType',
+        key: elementTreeKey,
+        props: {},
+      },
+      locale: baseLocale,
+      siteId: 'mySiteId',
+    }
+
+    /*
+        Intercept:
+        (1) initial request to v1 endpoint for the locale variant tree
+        (2) subsequent request to v1 endpoint for the base locale tree
+            - this is the step that we're really testing here - we want the logic in getComponentSnapshot to execute this subsequent request
+        (3) graphql query for introspection
+    */
+    server.use(
+      http.get(
+        `${baseUrl}/${treeId}?locale=${localeToTest}`,
+        () => HttpResponse.text('', { status: 404 }),
+        { once: true },
+      ),
+      http.get(`${baseUrl}/${treeId}`, () => HttpResponse.json(document, { status: 200 }), {
+        once: true,
+      }),
+      graphql.operation(() => {
+        return HttpResponse.json({})
+      }),
+    )
+
+    // Act
+    const result = await client.getComponentSnapshot(treeId, {
+      siteVersion: MakeswiftSiteVersion.Working,
+      locale: localeToTest,
+    })
+
+    // Assert
+    expect(result).not.toBeNull()
+    expect(result.document).not.toBeNull()
+    expect(result.document.data).not.toBeNull()
+    expect(result.document.data?.key).toBe(elementTreeKey)
+    expect(result.document.locale).toBe(baseLocale)
+  }),
+    test('does not perform locale fallback after receiving a 404 response for a locale variant tree, when allowFallback is false', async () => {
+      // Arrange
+      const client = new Makeswift(TEST_API_KEY, { apiOrigin })
+      const localeToTest = 'fr-FR'
+      const baseLocale = null
+
+      // mock base locale tree document
+      const treeId = 'myTree123'
+      const elementTreeName = 'myElementTree'
+      const elementTreeKey = 'abc123'
+      const document: MakeswiftComponentDocument = {
+        id: treeId,
+        name: elementTreeName,
+        data: {
+          type: 'myType',
+          key: elementTreeKey,
+          props: {},
+        },
+        locale: baseLocale,
+        siteId: 'mySiteId',
+      }
+
+      /*
+        Intercept:
+        (1) initial request to v1 endpoint for the locale variant tree
+        (2) subsequent request to v1 endpoint for the base locale tree
+            - should not execute for this test
+        (3) graphql query for introspection
+      */
+      server.use(
+        http.get(
+          `${baseUrl}/${treeId}?locale=${localeToTest}`,
+          () => HttpResponse.text('', { status: 404 }),
+          { once: true },
+        ),
+        http.get(`${baseUrl}/${treeId}`, () => HttpResponse.json(document, { status: 200 }), {
+          once: true,
+        }),
+        graphql.operation(() => {
+          return HttpResponse.json({})
+        }),
+      )
+
+      // Act
+      const result = await client.getComponentSnapshot(treeId, {
+        siteVersion: MakeswiftSiteVersion.Working,
+        locale: localeToTest,
+        allowLocaleFallback: false,
+      })
+
+      // Assert
+      expect(result).not.toBeNull()
+      expect(result.document).not.toBeNull()
+      expect(result.document.id).toBe(treeId)
+      expect(result.document.data).toBeNull()
+      expect(result.document.locale).toBe(localeToTest)
+    }),
+    test('does not perform locale fallback after receiving a 200 response for the requested locale variant tree', async () => {
+      // Arrange
+      const client = new Makeswift(TEST_API_KEY, { apiOrigin })
+      const localeToTest = 'fr-FR'
+
+      // mock locale variant tree document
+      const treeId = 'myTree123'
+      const elementTreeName = 'myElementTree'
+      const elementTreeKey = 'abc123'
+      const document: MakeswiftComponentDocument = {
+        id: treeId,
+        name: elementTreeName,
+        data: {
+          type: 'myType',
+          key: elementTreeKey,
+          props: {},
+        },
+        locale: localeToTest,
+        siteId: 'mySiteId',
+      }
+
+      /*
+        Intercept:
+        (1) initial request to v1 endpoint for the locale variant tree
+        (2) subsequent request to v1 endpoint for the base locale tree
+            - should not happen for this test
+        (3) graphql query for introspection
+      */
+      server.use(
+        http.get(
+          `${baseUrl}/${treeId}?locale=${localeToTest}`,
+          () => HttpResponse.json(document, { status: 200 }),
+          { once: true },
+        ),
+        http.get(`${baseUrl}/${treeId}`, () => HttpResponse.text('', { status: 404 }), {
+          once: true,
+        }),
+        graphql.operation(() => {
+          return HttpResponse.json({})
+        }),
+      )
+
+      // Act
+      const result = await client.getComponentSnapshot(treeId, {
+        siteVersion: MakeswiftSiteVersion.Working,
+        locale: localeToTest,
+      })
+
+      // Assert
+      expect(result).not.toBeNull()
+      expect(result.document).not.toBeNull()
+      expect(result.document.id).toBe(treeId)
+      expect(result.document.locale).toBe(localeToTest)
+      expect(result.document.data).not.toBeNull()
+    })
+})


### PR DESCRIPTION
eng-7269

This would make the default behavior of getComponentSnapshot be to perform locale fallback if a request for some localized element tree 404s. By "locale fallback" here we're referring to execution of a subsequent request for the same element tree ID but in the base locale.

Whether or not locale fallback is utilized is configurable via an argument 'allowLocaleFallback' to getComponentSnapshot. In the future, when getComponentSnapshot is internal to MakeswiftComponent, I'm imagining this being configurable via a prop. 

This change, along with eng-7271 (not done yet), are working towards creating the UX we want for element tree variants as described in [Localized element trees, inheritance, and fanouts](https://linear.app/makeswift/document/localized-element-trees-inheritance-and-fanouts-2e2ff9f29c60)

