### PR TITLE
fix(runtime): require passing `previewMode` to the runtime provider

### DIFF
--- a/apps/nextjs-app-router/src/makeswift/provider.tsx
+++ b/apps/nextjs-app-router/src/makeswift/provider.tsx
@@ -13,7 +13,7 @@ import '@/makeswift/components'
 export function MakeswiftProvider({
   children,
   locale = undefined,
-  previewMode = false,
+  previewMode,
 }: {
   children: ReactNode
   locale?: string

--- a/packages/runtime/src/next/components/tests/controls/page-control-prop-rendering.tsx
+++ b/packages/runtime/src/next/components/tests/controls/page-control-prop-rendering.tsx
@@ -101,7 +101,7 @@ export async function testPageControlPropRendering<D extends ControlDefinition>(
   // Assert
   await act(async () =>
     render(
-      <ReactRuntimeProvider runtime={runtime}>
+      <ReactRuntimeProvider runtime={runtime} previewMode={false}>
         <Page snapshot={snapshot} />
       </ReactRuntimeProvider>,
     ),

--- a/packages/runtime/src/next/components/tests/global-element-rendering.test.tsx
+++ b/packages/runtime/src/next/components/tests/global-element-rendering.test.tsx
@@ -206,7 +206,7 @@ async function testGlobalElementRendering({ locale }: { locale: string | null })
   // Assert
   await act(async () =>
     render(
-      <ReactRuntimeProvider runtime={runtime}>
+      <ReactRuntimeProvider runtime={runtime} previewMode={false}>
         <Page snapshot={snapshot} />
       </ReactRuntimeProvider>,
     ),

--- a/packages/runtime/src/next/components/tests/makeswift-component-rendering.test.tsx
+++ b/packages/runtime/src/next/components/tests/makeswift-component-rendering.test.tsx
@@ -68,7 +68,7 @@ async function testMakeswiftComponentRendering(snapshot: MakeswiftComponentSnaps
 
   await act(async () =>
     render(
-      <ReactRuntimeProvider runtime={runtime}>
+      <ReactRuntimeProvider runtime={runtime} previewMode={false}>
         <MakeswiftComponent
           label="Embedded Component"
           type={CustomComponentType}

--- a/packages/runtime/src/next/components/tests/prop-controllers/page-backgrounds-prop-controller.test.tsx
+++ b/packages/runtime/src/next/components/tests/prop-controllers/page-backgrounds-prop-controller.test.tsx
@@ -81,7 +81,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),
@@ -148,7 +148,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),

--- a/packages/runtime/src/next/components/tests/prop-controllers/page-border-prop-controller.test.tsx
+++ b/packages/runtime/src/next/components/tests/prop-controllers/page-border-prop-controller.test.tsx
@@ -76,7 +76,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),
@@ -140,7 +140,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),

--- a/packages/runtime/src/next/components/tests/prop-controllers/page-date-prop-controller.test.tsx
+++ b/packages/runtime/src/next/components/tests/prop-controllers/page-date-prop-controller.test.tsx
@@ -62,7 +62,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),
@@ -112,7 +112,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),

--- a/packages/runtime/src/next/components/tests/prop-controllers/page-element-id-prop-controller.test.tsx
+++ b/packages/runtime/src/next/components/tests/prop-controllers/page-element-id-prop-controller.test.tsx
@@ -65,7 +65,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),
@@ -118,7 +118,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),

--- a/packages/runtime/src/next/components/tests/prop-controllers/page-font-prop-controller.test.tsx
+++ b/packages/runtime/src/next/components/tests/prop-controllers/page-font-prop-controller.test.tsx
@@ -68,7 +68,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),
@@ -123,7 +123,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),

--- a/packages/runtime/src/next/components/tests/prop-controllers/page-gap-y-prop-controller.test.tsx
+++ b/packages/runtime/src/next/components/tests/prop-controllers/page-gap-y-prop-controller.test.tsx
@@ -68,7 +68,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),
@@ -123,7 +123,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),

--- a/packages/runtime/src/next/components/tests/prop-controllers/page-grid-prop-controller.test.tsx
+++ b/packages/runtime/src/next/components/tests/prop-controllers/page-grid-prop-controller.test.tsx
@@ -72,7 +72,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),
@@ -131,7 +131,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),

--- a/packages/runtime/src/next/components/tests/prop-controllers/page-image-prop-controller.test.tsx
+++ b/packages/runtime/src/next/components/tests/prop-controllers/page-image-prop-controller.test.tsx
@@ -67,7 +67,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),
@@ -126,7 +126,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),
@@ -185,7 +185,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),

--- a/packages/runtime/src/next/components/tests/prop-controllers/page-images-prop-controller.test.tsx
+++ b/packages/runtime/src/next/components/tests/prop-controllers/page-images-prop-controller.test.tsx
@@ -80,7 +80,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),
@@ -151,7 +151,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),
@@ -222,7 +222,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),

--- a/packages/runtime/src/next/components/tests/prop-controllers/page-link-prop-controller.test.tsx
+++ b/packages/runtime/src/next/components/tests/prop-controllers/page-link-prop-controller.test.tsx
@@ -69,7 +69,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),
@@ -125,7 +125,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),

--- a/packages/runtime/src/next/components/tests/prop-controllers/page-margin-prop-controller.test.tsx
+++ b/packages/runtime/src/next/components/tests/prop-controllers/page-margin-prop-controller.test.tsx
@@ -73,7 +73,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),
@@ -134,7 +134,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),

--- a/packages/runtime/src/next/components/tests/prop-controllers/page-navigation-links-prop-controller.test.tsx
+++ b/packages/runtime/src/next/components/tests/prop-controllers/page-navigation-links-prop-controller.test.tsx
@@ -76,7 +76,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),
@@ -139,7 +139,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),

--- a/packages/runtime/src/next/components/tests/prop-controllers/page-padding-prop-controller.test.tsx
+++ b/packages/runtime/src/next/components/tests/prop-controllers/page-padding-prop-controller.test.tsx
@@ -73,7 +73,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),
@@ -134,7 +134,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),

--- a/packages/runtime/src/next/components/tests/prop-controllers/page-prop-controller.tsx
+++ b/packages/runtime/src/next/components/tests/prop-controllers/page-prop-controller.tsx
@@ -66,7 +66,7 @@ export const pagePropControllerTest = <
 
       await act(async () =>
         render(
-          <ReactRuntimeProvider runtime={runtime}>
+          <ReactRuntimeProvider runtime={runtime} previewMode={false}>
             <Page snapshot={snapshot} />
           </ReactRuntimeProvider>,
         ),
@@ -107,7 +107,7 @@ export const pagePropControllerTest = <
 
       await act(async () =>
         render(
-          <ReactRuntimeProvider runtime={runtime}>
+          <ReactRuntimeProvider runtime={runtime} previewMode={false}>
             <Page snapshot={snapshot} />
           </ReactRuntimeProvider>,
         ),

--- a/packages/runtime/src/next/components/tests/prop-controllers/page-social-links-prop-controller.test.tsx
+++ b/packages/runtime/src/next/components/tests/prop-controllers/page-social-links-prop-controller.test.tsx
@@ -76,7 +76,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),
@@ -138,7 +138,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),

--- a/packages/runtime/src/next/components/tests/prop-controllers/page-table-form-fields-prop-controller.test.tsx
+++ b/packages/runtime/src/next/components/tests/prop-controllers/page-table-form-fields-prop-controller.test.tsx
@@ -71,7 +71,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),
@@ -129,7 +129,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),

--- a/packages/runtime/src/next/components/tests/prop-controllers/page-table-prop-controller.test.tsx
+++ b/packages/runtime/src/next/components/tests/prop-controllers/page-table-prop-controller.test.tsx
@@ -62,7 +62,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),
@@ -112,7 +112,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),

--- a/packages/runtime/src/next/components/tests/prop-controllers/page-text-area-prop-controller.test.tsx
+++ b/packages/runtime/src/next/components/tests/prop-controllers/page-text-area-prop-controller.test.tsx
@@ -62,7 +62,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),
@@ -112,7 +112,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),

--- a/packages/runtime/src/next/components/tests/prop-controllers/page-text-input-prop-controller.test.tsx
+++ b/packages/runtime/src/next/components/tests/prop-controllers/page-text-input-prop-controller.test.tsx
@@ -62,7 +62,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),
@@ -112,7 +112,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),

--- a/packages/runtime/src/next/components/tests/prop-controllers/page-text-style-prop-controller.test.tsx
+++ b/packages/runtime/src/next/components/tests/prop-controllers/page-text-style-prop-controller.test.tsx
@@ -78,7 +78,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),
@@ -143,7 +143,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),

--- a/packages/runtime/src/next/components/tests/prop-controllers/page-video-prop-controller.test.tsx
+++ b/packages/runtime/src/next/components/tests/prop-controllers/page-video-prop-controller.test.tsx
@@ -65,7 +65,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),
@@ -119,7 +119,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),

--- a/packages/runtime/src/next/components/tests/prop-controllers/page-width-prop-controller.test.tsx
+++ b/packages/runtime/src/next/components/tests/prop-controllers/page-width-prop-controller.test.tsx
@@ -68,7 +68,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),
@@ -124,7 +124,7 @@ describe('Page', () => {
 
     await act(async () =>
       render(
-        <ReactRuntimeProvider runtime={runtime}>
+        <ReactRuntimeProvider runtime={runtime} previewMode={false}>
           <Page snapshot={snapshot} />
         </ReactRuntimeProvider>,
       ),

--- a/packages/runtime/src/runtimes/react/components/RuntimeProvider.tsx
+++ b/packages/runtime/src/runtimes/react/components/RuntimeProvider.tsx
@@ -13,13 +13,13 @@ const PreviewProvider = lazy(() => import('./PreviewProvider'))
 export function ReactRuntimeProvider({
   children,
   runtime,
-  previewMode = false,
+  previewMode,
   apiOrigin = 'https://api.makeswift.com',
   locale = undefined,
 }: {
   children: ReactNode
   runtime: ReactRuntime
-  previewMode?: boolean
+  previewMode: boolean
   apiOrigin?: string
   locale?: string
 }) {


### PR DESCRIPTION
As long as passing `previewMode` is required for making the site editable in the builder, there is no good reason for defaulting it. See [this thread](https://makeswifthq.slack.com/archives/C057U8TLT9U/p1736182157072199?thread_ts=1735925807.739969&cid=C057U8TLT9U) for context.