### PR TITLE
Update document payload to support 'detach' UX for editing localized element trees that inherit from a parent locale

### DIFF
--- a/.changeset/young-shoes-cheer.md
+++ b/.changeset/young-shoes-cheer.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": minor
+---
+
+Update `getComponentSnapshot` to perform locale fallback

--- a/packages/runtime/src/next/components/MakeswiftComponent.tsx
+++ b/packages/runtime/src/next/components/MakeswiftComponent.tsx
@@ -22,6 +22,7 @@ export const MakeswiftComponent = memo(({ snapshot, label, type }: Props) => {
         documentKey: snapshot.key,
         name: label,
         type,
+        meta: snapshot.meta,
       }),
     [snapshot, label, type],
   )

--- a/packages/runtime/src/next/components/tests/makeswift-component-rendering.test.tsx
+++ b/packages/runtime/src/next/components/tests/makeswift-component-rendering.test.tsx
@@ -7,6 +7,7 @@ import { ReactRuntime } from '../../../react'
 import { ReactRuntimeProvider } from '../../../runtimes/react'
 import { MakeswiftComponent } from '../MakeswiftComponent'
 import {
+  type MakeswiftComponentSnapshotMetadata,
   type MakeswiftComponentDocument,
   type MakeswiftComponentDocumentFallback,
   type MakeswiftComponentSnapshot,
@@ -39,19 +40,22 @@ const existingDocumentFixture = {
   locale: null,
   name: 'Custom Component',
   siteId: '1111-1111-1111-1111',
+  inheritsFromParent: false,
 }
 
 function createMakeswiftComponentSnapshot(
   document: MakeswiftComponentDocumentFallback | MakeswiftComponentDocument,
+  meta: MakeswiftComponentSnapshotMetadata,
   cacheData: CacheData = {
     apiResources: {},
     localizedResourcesMap: {},
   },
-) {
+): MakeswiftComponentSnapshot {
   return {
     document,
     cacheData,
     key: '00000000-0000-0000-0000-000000000000',
+    meta,
   }
 }
 
@@ -81,14 +85,20 @@ async function testMakeswiftComponentRendering(snapshot: MakeswiftComponentSnaps
 
 describe('MakeswiftComponent', () => {
   test('empty snapshot renders component with default props', async () => {
-    const snapshot = createMakeswiftComponentSnapshot(emptyDocumentFixture)
+    const snapshot = createMakeswiftComponentSnapshot(emptyDocumentFixture, {
+      allowLocaleFallback: false,
+      requestedLocale: null,
+    })
     await testMakeswiftComponentRendering(snapshot)
 
     expect(screen.queryByTestId(customComponentContentTestId)).toHaveTextContent('Default Text')
   })
 
   test('existing snapshot renders component with saved props', async () => {
-    const snapshot = createMakeswiftComponentSnapshot(existingDocumentFixture)
+    const snapshot = createMakeswiftComponentSnapshot(existingDocumentFixture, {
+      allowLocaleFallback: false,
+      requestedLocale: null,
+    })
     await testMakeswiftComponentRendering(snapshot)
 
     expect(screen.queryByTestId(customComponentContentTestId)).toHaveTextContent('Hello World')

--- a/packages/runtime/src/next/tests/client.get-component-snapshot.test.ts
+++ b/packages/runtime/src/next/tests/client.get-component-snapshot.test.ts
@@ -1,0 +1,206 @@
+import { Makeswift, MakeswiftComponentDocument } from '../client'
+import { http, HttpResponse, graphql } from 'msw'
+
+import { server } from '../../mocks/server'
+import { MakeswiftSiteVersion } from '../preview-mode'
+
+const TEST_API_KEY = 'myApiKey'
+const apiOrigin = 'https://api.fakeswift.com'
+const baseUrl = `${apiOrigin}/v1/element-trees`
+
+describe('getComponentSnapshot using v1 element tree endpoint', () => {
+  test('return null document data on 404', async () => {
+    // Arrange
+    const client = new Makeswift(TEST_API_KEY, { apiOrigin })
+    const treeId = 'myTree'
+    server.use(
+      http.get(`${baseUrl}/${treeId}`, () => HttpResponse.text('', { status: 404 }), {
+        once: true,
+      }),
+    )
+
+    // Act
+    const result = await client.getComponentSnapshot(treeId, {
+      siteVersion: MakeswiftSiteVersion.Working,
+    })
+
+    // Assert
+    expect(result.document).not.toBeNull()
+    expect(result.document.id).toBe(treeId)
+    expect(result.document.data).toBeNull()
+  })
+
+  test('successfully performs locale fallback by requesting base locale tree after receiving a 404 response for a locale variant tree', async () => {
+    // Arrange
+    const client = new Makeswift(TEST_API_KEY, { apiOrigin })
+    const localeToTest = 'fr-FR'
+    const baseLocale = null
+
+    // mock base locale tree document
+    const treeId = 'myTree123'
+    const elementTreeName = 'myElementTree'
+    const elementTreeKey = 'abc123'
+    const document: MakeswiftComponentDocument = {
+      id: treeId,
+      name: elementTreeName,
+      data: {
+        type: 'myType',
+        key: elementTreeKey,
+        props: {},
+      },
+      locale: baseLocale,
+      siteId: 'mySiteId',
+      inheritsFromParent: false,
+    }
+
+    /*
+        Intercept:
+        (1) initial request to v1 endpoint for the locale variant tree
+        (2) subsequent request to v1 endpoint for the base locale tree
+            - this is the step that we're really testing here - we want the logic in getComponentSnapshot to execute this subsequent request
+        (3) graphql query for introspection
+    */
+    server.use(
+      http.get(
+        `${baseUrl}/${treeId}?locale=${localeToTest}`,
+        () => HttpResponse.text('', { status: 404 }),
+        { once: true },
+      ),
+      http.get(`${baseUrl}/${treeId}`, () => HttpResponse.json(document, { status: 200 }), {
+        once: true,
+      }),
+      graphql.operation(() => {
+        return HttpResponse.json({})
+      }),
+    )
+
+    // Act
+    const result = await client.getComponentSnapshot(treeId, {
+      siteVersion: MakeswiftSiteVersion.Working,
+      locale: localeToTest,
+    })
+
+    // Assert
+    expect(result).not.toBeNull()
+    expect(result.document).not.toBeNull()
+    expect(result.document.data).not.toBeNull()
+    expect(result.document.data?.key).toBe(elementTreeKey)
+    expect(result.document.locale).toBeNull()
+  })
+
+  test('does not perform locale fallback after receiving a 404 response for a locale variant tree, when allowFallback is false', async () => {
+    // Arrange
+    const client = new Makeswift(TEST_API_KEY, { apiOrigin })
+    const localeToTest = 'fr-FR'
+    const baseLocale = null
+
+    // mock base locale tree document
+    const treeId = 'myTree123'
+    const elementTreeName = 'myElementTree'
+    const elementTreeKey = 'abc123'
+    const document: MakeswiftComponentDocument = {
+      id: treeId,
+      name: elementTreeName,
+      data: {
+        type: 'myType',
+        key: elementTreeKey,
+        props: {},
+      },
+      locale: baseLocale,
+      siteId: 'mySiteId',
+      inheritsFromParent: false,
+    }
+
+    /*
+        Intercept:
+        (1) initial request to v1 endpoint for the locale variant tree
+        (2) subsequent request to v1 endpoint for the base locale tree
+            - should not execute for this test
+        (3) graphql query for introspection
+      */
+    server.use(
+      http.get(
+        `${baseUrl}/${treeId}?locale=${localeToTest}`,
+        () => HttpResponse.text('', { status: 404 }),
+        { once: true },
+      ),
+      http.get(`${baseUrl}/${treeId}`, () => HttpResponse.json(document, { status: 200 }), {
+        once: true,
+      }),
+      graphql.operation(() => {
+        return HttpResponse.json({})
+      }),
+    )
+
+    // Act
+    const result = await client.getComponentSnapshot(treeId, {
+      siteVersion: MakeswiftSiteVersion.Working,
+      locale: localeToTest,
+      allowLocaleFallback: false,
+    })
+
+    // Assert
+    expect(result).not.toBeNull()
+    expect(result.document).not.toBeNull()
+    expect(result.document.id).toBe(treeId)
+    expect(result.document.data).toBeNull()
+    expect(result.document.locale).toBe(localeToTest)
+  })
+
+  test('does not perform locale fallback after receiving a 200 response for the requested locale variant tree', async () => {
+    // Arrange
+    const client = new Makeswift(TEST_API_KEY, { apiOrigin })
+    const localeToTest = 'fr-FR'
+
+    // mock locale variant tree document
+    const treeId = 'myTree123'
+    const elementTreeName = 'myElementTree'
+    const elementTreeKey = 'abc123'
+    const document: MakeswiftComponentDocument = {
+      id: treeId,
+      name: elementTreeName,
+      data: {
+        type: 'myType',
+        key: elementTreeKey,
+        props: {},
+      },
+      locale: localeToTest,
+      siteId: 'mySiteId',
+      inheritsFromParent: false,
+    }
+
+    /*
+        Intercept:
+        (1) initial request to v1 endpoint for the locale variant tree
+        (2) subsequent request to v1 endpoint for the base locale tree
+            - should not happen for this test
+        (3) graphql query for introspection
+      */
+    server.use(
+      http.get(
+        `${baseUrl}/${treeId}?locale=${localeToTest}`,
+        () => HttpResponse.json(document, { status: 200 }),
+        { once: true },
+      ),
+      http.get(`${baseUrl}/${treeId}`, () => HttpResponse.text('', { status: 404 }), {
+        once: true,
+      }),
+      graphql.operation(() => {
+        return HttpResponse.json({})
+      }),
+    )
+
+    // Act
+    const result = await client.getComponentSnapshot(treeId, {
+      siteVersion: MakeswiftSiteVersion.Working,
+      locale: localeToTest,
+    })
+
+    // Assert
+    expect(result).not.toBeNull()
+    expect(result.document).not.toBeNull()
+    expect(result.document.id).toBe(treeId)
+    expect(result.document.locale).toBe(localeToTest)
+    expect(result.document.data).not.toBeNull()
+  })
+})

--- a/packages/runtime/src/state/actions.ts
+++ b/packages/runtime/src/state/actions.ts
@@ -106,6 +106,7 @@ type DocumentPayloadEmbeddedDocument = {
   type: string
   name: string
   rootElement: Element
+  meta: { allowLocaleFallback: boolean; requestedLocale: string | null }
   __type: typeof EMBEDDED_DOCUMENT_TYPE
 }
 

--- a/packages/runtime/src/state/modules/read-only-documents.ts
+++ b/packages/runtime/src/state/modules/read-only-documents.ts
@@ -32,6 +32,7 @@ export type EmbeddedDocument = {
   type: string
   name: string
   rootElement: Element
+  meta: { allowLocaleFallback: boolean; requestedLocale: string | null }
   __type: typeof EMBEDDED_DOCUMENT_TYPE
 }
 


### PR DESCRIPTION
companion PR: https://github.com/makeswift/cosmos/pull/765 

eng-7353 (part of eng-7271)