### PR TITLE
fix: patched fetch in the builder to preserve existing request headers

### DIFF
--- a/.changeset/tall-queens-smile.md
+++ b/.changeset/tall-queens-smile.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+fix: patched fetch in the builder to preserve existing request headers

--- a/packages/runtime/src/next/draft-mode/draft-mode-script.tsx
+++ b/packages/runtime/src/next/draft-mode/draft-mode-script.tsx
@@ -36,9 +36,12 @@ if (window.parent !== window) {
             return originalFetch.call(this, resource, options)
           }
 
+          const newHeaders = new Headers(request.headers)
+          newHeaders.set(headerName, secret)
+
           return originalFetch.call(
             this,
-            new Request(request, { headers: { [headerName]: secret } }),
+            new Request(request, { headers: newHeaders })
           )
         }
       }

--- a/packages/runtime/src/next/preview-mode.tsx
+++ b/packages/runtime/src/next/preview-mode.tsx
@@ -56,10 +56,13 @@ if (window.parent !== window) {
           if (new URL(request.url).origin !== window.location.origin) {
             return originalFetch.call(this, resource, options)
           }
+          
+          const newHeaders = new Headers(request.headers)
+          newHeaders.set(headerName, secret)
 
           return originalFetch.call(
             this,
-            new Request(request, { headers: { [headerName]: secret } }),
+            new Request(request, { headers: newHeaders })
           )
         }
       }


### PR DESCRIPTION
**Steps to reproduce the issue:**
- Open a page in the builder
- Open the console on the dev tools
- Select the host console instead of `top`, 
- Send a fetch request with a custom header. 

**Before the fix, the custom header is overwritten:**
<img width="603" alt="patched-fetch-headers-before" src="https://github.com/user-attachments/assets/950cced0-e1bc-411c-981b-5f99dd802d19" />

---

**After the fix, the custom header is preserved:**
<img width="601" alt="patched-fetch-headers-after" src="https://github.com/user-attachments/assets/2fdfe992-57d3-4dc7-94fc-5d119d3f87b4" />

