### PR TITLE
feat(runtime): allow forced http protocol

### DIFF
--- a/.changeset/eighty-ducks-thank.md
+++ b/.changeset/eighty-ducks-thank.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+feat(runtime): allow forced http protocol

--- a/.changeset/honest-swans-bake.md
+++ b/.changeset/honest-swans-bake.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+feat(runtime): Use headers to create proxied url

--- a/.changeset/honest-swans-bake.md
+++ b/.changeset/honest-swans-bake.md
@@ -1,5 +1,5 @@
 ---
-"@makeswift/runtime": patch
+'@makeswift/runtime': minor
 ---
 
 feat(runtime): Use headers to create proxied url

--- a/packages/runtime/src/next/api-handler/handlers/proxy-draft-mode.test.ts
+++ b/packages/runtime/src/next/api-handler/handlers/proxy-draft-mode.test.ts
@@ -2,11 +2,65 @@ import { NextRequest } from 'next/server'
 import { http, HttpResponse } from 'msw'
 import { server } from '../../../mocks/server'
 import proxyDraftMode from './proxy-draft-mode'
+import { env } from 'process';
 
 jest.mock('next/headers', () => ({
   draftMode: jest.fn().mockReturnValue({ enable: jest.fn(), disable: jest.fn() }),
   cookies: jest.fn().mockReturnValue({ get: jest.fn() }),
 }))
+
+describe('ForceHTTP proxyDraftMode URL handling', () => {
+  const mockApiKey = 'test-api-key'
+  
+  server.use(
+    http.all('*', () => {
+      return new HttpResponse()
+    })
+  )
+
+  beforeAll(() => {
+    server.listen()
+  })
+
+  afterAll(() => {
+    server.close()
+  })
+
+  afterEach(() => {
+    server.resetHandlers()
+    jest.clearAllMocks()
+  })
+
+  it('should force protocol to http and use host from `host` from headers instead of `x-forwarded-host`', async () => {
+    const originalUrl = new URL(`https://example.com?x-makeswift-draft-mode=${mockApiKey}&keep=this`)
+    
+    const request = new NextRequest(originalUrl)
+    request.headers.append("X-Makeswift-Draft-Mode",mockApiKey )
+    request.headers.append("x-forwarded-host", "localhost:3000")
+
+    const originalProtocol = request.nextUrl.protocol
+    await proxyDraftMode(request, { params: {} }, { apiKey: mockApiKey })
+
+
+    // Make sure original request is not changed.
+    expect(request.nextUrl.protocol).toBe(originalProtocol)
+
+    // Verify fetch was called with modified URL
+    expect(global.fetch).toHaveBeenCalled()
+    const fetchCall = (global.fetch as jest.Mock).mock.calls[0][0] as NextRequest
+    
+    // Verify host is same as original host.
+    expect(fetchCall.headers.get('host')).toBe(request.headers.get('host'))
+    
+    // Verify https was replaced with http after force_http
+    expect(fetchCall.nextUrl.protocol).toBe('http:')
+    expect(fetchCall.headers.has('X-Makeswift-Draft-Mode')).toBe(false)
+    expect(fetchCall.nextUrl.searchParams.has('x-makeswift-draft-mode')).toBe(false)
+    expect(fetchCall.nextUrl.searchParams.get('keep')).toBe('this')
+    
+  })
+
+})
 
 describe('proxyDraftMode URL handling', () => {
   const mockApiKey = 'test-api-key'

--- a/packages/runtime/src/next/api-handler/handlers/proxy-draft-mode.test.ts
+++ b/packages/runtime/src/next/api-handler/handlers/proxy-draft-mode.test.ts
@@ -1,4 +1,6 @@
 import { NextRequest } from 'next/server'
+import { http, HttpResponse } from 'msw'
+import { server } from '../../../mocks/server'
 import proxyDraftMode from './proxy-draft-mode'
 
 jest.mock('next/headers', () => ({
@@ -8,38 +10,65 @@ jest.mock('next/headers', () => ({
 
 describe('proxyDraftMode URL handling', () => {
   const mockApiKey = 'test-api-key'
-  let originalFetch: typeof global.fetch
+  
+  server.use(
+    http.all('*', () => {
+      return new HttpResponse()
+    })
+  )
 
   beforeAll(() => {
-    originalFetch = global.fetch
-    global.fetch = jest.fn().mockResolvedValue(new Response())
+    server.listen()
   })
 
   afterAll(() => {
-    global.fetch = originalFetch
+    server.close()
   })
 
-  beforeEach(() => {
+  afterEach(() => {
+    server.resetHandlers()
     jest.clearAllMocks()
   })
 
   describe('URL mutation safety', () => {
     it('should not modify the original request URL when removing search params', async () => {
-      const originalUrl = new URL('https://example.com?x-makeswift-draft-mode=test-api-key&keep=this')
+      const originalUrl = new URL(`https://example.com?x-makeswift-draft-mode=${mockApiKey}&keep=this`)
+      
       const request = new NextRequest(originalUrl)
+      request.headers.append("X-Makeswift-Draft-Mode", mockApiKey)
+
       const originalSearchParams = new URLSearchParams(request.nextUrl.search)
+      const originalHeaders = new Headers(request.headers)
 
       await proxyDraftMode(request, { params: {} }, { apiKey: mockApiKey })
 
       // Verify original request URL remains unchanged
-      expect(request.nextUrl.search).toBe(originalUrl.search)
       expect(request.nextUrl.searchParams.toString()).toBe(originalSearchParams.toString())
-      
-      // Verify fetch was called with modified URL
-      expect(global.fetch).toHaveBeenCalled()
-      const fetchCall = (global.fetch as jest.Mock).mock.calls[0][0] as NextRequest
-      expect(fetchCall.nextUrl.searchParams.has('x-makeswift-draft-mode')).toBe(false)
-      expect(fetchCall.nextUrl.searchParams.get('keep')).toBe('this')
+      expect(JSON.stringify(request.headers)).toBe(JSON.stringify(originalHeaders))
     })
-})
+
+    it('should clone the original request URL by removing makeswift header and searchparam', async () => {
+      const originalUrl = new URL(`https://example.com?x-makeswift-draft-mode=${mockApiKey}&keep=this`)
+      
+      let capturedRequest: Request | null = null
+      server.use(
+        http.all('*', ({ request }) => {
+          capturedRequest = request
+          return new HttpResponse()
+        })
+      )
+      
+      const request = new NextRequest(originalUrl)
+      request.headers.append("X-Makeswift-Draft-Mode", mockApiKey)
+  
+      await proxyDraftMode(request, { params: {} }, { apiKey: mockApiKey })
+
+      // Verify request was modified correctly
+      expect(capturedRequest).not.toBeNull()
+      expect(capturedRequest!.headers.has('X-Makeswift-Draft-Mode')).toBe(false)
+      const url = new URL(capturedRequest!.url)
+      expect(url.searchParams.has('x-makeswift-draft-mode')).toBe(false)
+      expect(url.searchParams.get('keep')).toBe('this')
+    })
+  })
 })

--- a/packages/runtime/src/next/api-handler/handlers/proxy-draft-mode.test.ts
+++ b/packages/runtime/src/next/api-handler/handlers/proxy-draft-mode.test.ts
@@ -1,0 +1,45 @@
+import { NextRequest } from 'next/server'
+import proxyDraftMode from './proxy-draft-mode'
+
+jest.mock('next/headers', () => ({
+  draftMode: jest.fn().mockReturnValue({ enable: jest.fn(), disable: jest.fn() }),
+  cookies: jest.fn().mockReturnValue({ get: jest.fn() }),
+}))
+
+describe('proxyDraftMode URL handling', () => {
+  const mockApiKey = 'test-api-key'
+  let originalFetch: typeof global.fetch
+
+  beforeAll(() => {
+    originalFetch = global.fetch
+    global.fetch = jest.fn().mockResolvedValue(new Response())
+  })
+
+  afterAll(() => {
+    global.fetch = originalFetch
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('URL mutation safety', () => {
+    it('should not modify the original request URL when removing search params', async () => {
+      const originalUrl = new URL('https://example.com?x-makeswift-draft-mode=test-api-key&keep=this')
+      const request = new NextRequest(originalUrl)
+      const originalSearchParams = new URLSearchParams(request.nextUrl.search)
+
+      await proxyDraftMode(request, { params: {} }, { apiKey: mockApiKey })
+
+      // Verify original request URL remains unchanged
+      expect(request.nextUrl.search).toBe(originalUrl.search)
+      expect(request.nextUrl.searchParams.toString()).toBe(originalSearchParams.toString())
+      
+      // Verify fetch was called with modified URL
+      expect(global.fetch).toHaveBeenCalled()
+      const fetchCall = (global.fetch as jest.Mock).mock.calls[0][0] as NextRequest
+      expect(fetchCall.nextUrl.searchParams.has('x-makeswift-draft-mode')).toBe(false)
+      expect(fetchCall.nextUrl.searchParams.get('keep')).toBe('this')
+    })
+})
+})

--- a/packages/runtime/src/next/api-handler/handlers/proxy-draft-mode.ts
+++ b/packages/runtime/src/next/api-handler/handlers/proxy-draft-mode.ts
@@ -59,8 +59,8 @@ async function proxyDraftModeRouteHandler(
   const draft = await draftMode()
   draft.enable()
 
-  const forwardingHost = request.headers.get('x-forwarded-host') ?? request.headers.get('host') 
-  const forwardingProto = request.headers.get('x-forwarded-proto') ?? request.nextUrl.protocol
+  const forwardingHost = process.env.FORCE_HTTP ? request.headers.get('host') : request.headers.get('x-forwarded-host') ?? request.headers.get('host') 
+  const forwardingProto = process.env.FORCE_HTTP ? 'http:' : request.headers.get('x-forwarded-proto') ?? request.nextUrl.protocol
 
   const searchParams = new URLSearchParams(request.nextUrl.searchParams)
   searchParams.delete('x-makeswift-draft-mode')

--- a/packages/runtime/src/next/api-handler/handlers/proxy-draft-mode.ts
+++ b/packages/runtime/src/next/api-handler/handlers/proxy-draft-mode.ts
@@ -62,12 +62,12 @@ async function proxyDraftModeRouteHandler(
   const forwardingHost = request.headers.get('x-forwarded-host') ?? request.headers.get('host') 
   const forwardingProto = request.headers.get('x-forwarded-proto') ?? request.nextUrl.protocol
 
-  const searchParams = request.nextUrl.searchParams
+  const searchParams = new URLSearchParams(request.nextUrl.searchParams)
   searchParams.delete('x-makeswift-draft-mode')
-  const headers = request.headers
+  const headers = new Headers(request.headers)
   headers.delete('X-Makeswift-Draft-Mode')
 
-  const proxyUrl = `${forwardingProto}://${forwardingHost}${request.nextUrl.pathname}?${searchParams}`
+  const proxyUrl = `${forwardingProto}//${forwardingHost}${request.nextUrl.pathname}?${searchParams}`
   const proxyRequest = new NextRequest(proxyUrl, { headers: headers })
 
   const draftModeCookie = (await cookies()).get('__prerender_bypass')

--- a/packages/runtime/src/next/api-handler/handlers/proxy-draft-mode.ts
+++ b/packages/runtime/src/next/api-handler/handlers/proxy-draft-mode.ts
@@ -59,11 +59,16 @@ async function proxyDraftModeRouteHandler(
   const draft = await draftMode()
   draft.enable()
 
-  const proxyUrl = request.nextUrl.clone()
-  proxyUrl.searchParams.delete('x-makeswift-draft-mode')
+  const forwardingHost = request.headers.get('x-forwarded-host') ?? request.headers.get('host') 
+  const forwardingProto = request.headers.get('x-forwarded-proto') ?? request.nextUrl.protocol
 
-  const proxyRequest = new NextRequest(proxyUrl, { headers: request.headers })
-  proxyRequest.headers.delete('x-makeswift-draft-mode')
+  const searchParams = request.nextUrl.searchParams
+  searchParams.delete('x-makeswift-draft-mode')
+  const headers = request.headers
+  headers.delete('X-Makeswift-Draft-Mode')
+
+  const proxyUrl = `${forwardingProto}://${forwardingHost}${request.nextUrl.pathname}?${searchParams}`
+  const proxyRequest = new NextRequest(proxyUrl, { headers: headers })
 
   const draftModeCookie = (await cookies()).get('__prerender_bypass')
   if (draftModeCookie) {


### PR DESCRIPTION
This is a workaround for GCP cloud run. This makes sure the proxied url has the correct protocol so our transaction is fulfilled.