### PR TITLE
fix(actions): Use ubuntu-22.04

### DIFF
--- a/.github/workflows/preview-deployment-playwright-tests.yml
+++ b/.github/workflows/preview-deployment-playwright-tests.yml
@@ -4,7 +4,7 @@ on:
 jobs:
   test:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event.deployment_status.state == 'success'
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Since Jan 9th our tests have been failing. This was caused by Github Actions now pointing to Ubuntu 24 for `ubuntu-latest`. This PR switches it back to `ubuntu-22.04` since it will be supported for the next two years