### PR TITLE
refactor: require passing `runtime` to `Makeswift` client/`MakeswiftApiHandler`

### DIFF
--- a/.changeset/good-falcons-yawn.md
+++ b/.changeset/good-falcons-yawn.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': minor
+---
+
+BREAKING: require passing a runtime instance to the `Makeswift` client/`MakeswiftApiHandler`, remove static `ReactRuntime` methods deprecated in [runtime@0.8.7](https://github.com/makeswift/makeswift/releases/tag/%40makeswift%2Fruntime%400.8.7) release

--- a/apps/nextjs-app-router/src/app/api/makeswift/[...makeswift]/route.ts
+++ b/apps/nextjs-app-router/src/app/api/makeswift/[...makeswift]/route.ts
@@ -1,7 +1,13 @@
 import { MAKESWIFT_SITE_API_KEY } from '@/makeswift/env'
 import { MakeswiftApiHandler } from '@makeswift/runtime/next/server'
 
+import { runtime } from '@/makeswift/runtime'
+
+// required to make custom components' data available for introspection
+import '@/makeswift/components'
+
 const handler = MakeswiftApiHandler(MAKESWIFT_SITE_API_KEY, {
+  runtime,
   apiOrigin: process.env.MAKESWIFT_API_ORIGIN,
   appOrigin: process.env.MAKESWIFT_APP_ORIGIN,
   getFonts() {

--- a/packages/runtime/src/next/api-handler/index.ts
+++ b/packages/runtime/src/next/api-handler/index.ts
@@ -27,7 +27,7 @@ type MakeswiftApiHandlerConfig = {
   appOrigin?: string
   apiOrigin?: string
   getFonts?: GetFonts
-  runtime?: ReactRuntime
+  runtime: ReactRuntime
 }
 
 type NotFoundError = { message: string }
@@ -61,8 +61,8 @@ export function MakeswiftApiHandler(
     appOrigin = 'https://app.makeswift.com',
     apiOrigin = 'https://api.makeswift.com',
     getFonts,
-    runtime = ReactRuntime,
-  }: MakeswiftApiHandlerConfig = {},
+    runtime,
+  }: MakeswiftApiHandlerConfig,
 ): (...args: MakeswiftApiHandlerArgs) => Promise<NextResponse<MakeswiftApiHandlerResponse> | void> {
   const cors = Cors({ origin: appOrigin })
 

--- a/packages/runtime/src/next/client.ts
+++ b/packages/runtime/src/next/client.ts
@@ -254,7 +254,7 @@ type LocalizedPage = {
 
 type MakeswiftConfig = {
   apiOrigin?: string
-  runtime?: ReactRuntime
+  runtime: ReactRuntime
 }
 
 export type Sitemap = {
@@ -310,7 +310,7 @@ export class Makeswift {
 
   constructor(
     apiKey: string,
-    { apiOrigin = 'https://api.makeswift.com', runtime = ReactRuntime }: MakeswiftConfig = {},
+    { apiOrigin = 'https://api.makeswift.com', runtime }: MakeswiftConfig,
   ) {
     if (typeof apiKey !== 'string') {
       throw new Error(

--- a/packages/runtime/src/next/tests/client.get-component-snapshot.test.ts
+++ b/packages/runtime/src/next/tests/client.get-component-snapshot.test.ts
@@ -1,17 +1,24 @@
 import { Makeswift, MakeswiftComponentDocument } from '../client'
 import { http, HttpResponse, graphql } from 'msw'
 
+import { ReactRuntime } from '../../runtimes/react'
+
 import { server } from '../../mocks/server'
 import { MakeswiftSiteVersion } from '../preview-mode'
 
 const TEST_API_KEY = 'myApiKey'
 const apiOrigin = 'https://api.fakeswift.com'
 const baseUrl = `${apiOrigin}/v1/element-trees`
+const runtime = new ReactRuntime()
+
+function createTestClient() {
+  return new Makeswift(TEST_API_KEY, { runtime, apiOrigin })
+}
 
 describe('getComponentSnapshot using v1 element tree endpoint', () => {
   test('return null document data on 404', async () => {
     // Arrange
-    const client = new Makeswift(TEST_API_KEY, { apiOrigin })
+    const client = createTestClient()
     const treeId = 'myTree'
     server.use(
       http.get(`${baseUrl}/${treeId}`, () => HttpResponse.text('', { status: 404 }), {
@@ -32,7 +39,7 @@ describe('getComponentSnapshot using v1 element tree endpoint', () => {
 
   test('successfully performs locale fallback by requesting base locale tree after receiving a 404 response for a locale variant tree', async () => {
     // Arrange
-    const client = new Makeswift(TEST_API_KEY, { apiOrigin })
+    const client = createTestClient()
     const localeToTest = 'fr-FR'
     const baseLocale = null
 
@@ -90,7 +97,7 @@ describe('getComponentSnapshot using v1 element tree endpoint', () => {
 
   test('does not perform locale fallback after receiving a 404 response for a locale variant tree, when allowFallback is false', async () => {
     // Arrange
-    const client = new Makeswift(TEST_API_KEY, { apiOrigin })
+    const client = createTestClient()
     const localeToTest = 'fr-FR'
     const baseLocale = null
 
@@ -149,7 +156,7 @@ describe('getComponentSnapshot using v1 element tree endpoint', () => {
 
   test('does not perform locale fallback after receiving a 200 response for the requested locale variant tree', async () => {
     // Arrange
-    const client = new Makeswift(TEST_API_KEY, { apiOrigin })
+    const client = createTestClient()
     const localeToTest = 'fr-FR'
 
     // mock locale variant tree document

--- a/packages/runtime/src/next/tests/client.get-pages.test.ts
+++ b/packages/runtime/src/next/tests/client.get-pages.test.ts
@@ -2,6 +2,8 @@ import { Makeswift } from '../client'
 import { http, HttpResponse } from 'msw'
 import { randomUUID } from 'crypto'
 
+import { ReactRuntime } from '../../runtimes/react'
+
 import { server } from '../../mocks/server'
 
 function createRandomPageV4() {
@@ -28,11 +30,16 @@ function createRandomPageV4() {
 const TEST_API_KEY = 'xxx'
 const apiOrigin = 'https://api.fakeswift.com'
 const baseUrl = `${apiOrigin}/v4/pages`
+const runtime = new ReactRuntime()
+
+function createTestClient() {
+  return new Makeswift(TEST_API_KEY, { runtime, apiOrigin })
+}
 
 describe('getPages v4', () => {
   test('empty', async () => {
     // Arrange
-    const client = new Makeswift(TEST_API_KEY, { apiOrigin })
+    const client = createTestClient()
     server.use(
       http.get(baseUrl, () => HttpResponse.json({ data: [], hasMore: false }), { once: true }),
     )
@@ -49,7 +56,7 @@ describe('getPages v4', () => {
 
   test('throws on unexpected data', async () => {
     // Arrange
-    const client = new Makeswift(TEST_API_KEY, { apiOrigin })
+    const client = createTestClient()
 
     server.use(
       http.get(baseUrl, () => HttpResponse.json({ data: { test: 'test' }, hasMore: false }), {
@@ -66,7 +73,7 @@ describe('getPages v4', () => {
 
   test('can get many pages', async () => {
     // Arrange
-    const client = new Makeswift(TEST_API_KEY, { apiOrigin })
+    const client = createTestClient()
     const mockPages = Array.from({ length: 10 }, createRandomPageV4)
     server.use(
       http.get(baseUrl, () => HttpResponse.json({ data: mockPages, hasMore: false }), {
@@ -86,7 +93,7 @@ describe('getPages v4', () => {
 
   test('toArray gets all pages', async () => {
     // Arrange
-    const client = new Makeswift(TEST_API_KEY, { apiOrigin })
+    const client = createTestClient()
     const [page1, page2, page3] = Array.from({ length: 3 }, createRandomPageV4)
     server.use(
       http.get(baseUrl, () => HttpResponse.json({ data: [page1], hasMore: true }), { once: true }),
@@ -103,7 +110,7 @@ describe('getPages v4', () => {
 
   test('async iterable gets all pages', async () => {
     // Arrange
-    const client = new Makeswift(TEST_API_KEY, { apiOrigin })
+    const client = createTestClient()
     const [page1, page2, page3] = Array.from({ length: 3 }, createRandomPageV4)
     server.use(
       http.get(baseUrl, () => HttpResponse.json({ data: [page1], hasMore: true }), { once: true }),
@@ -124,7 +131,7 @@ describe('getPages v4', () => {
 
   test('async iterable methods are chainable', async () => {
     // Arrange
-    const client = new Makeswift(TEST_API_KEY, { apiOrigin })
+    const client = createTestClient()
     const [page1, page2, page3] = Array.from({ length: 3 }, createRandomPageV4)
     server.use(
       http.get(baseUrl, () => HttpResponse.json({ data: [page1, page2, page3], hasMore: false }), {

--- a/packages/runtime/src/runtimes/react/__tests__/react-runtime.test.tsx
+++ b/packages/runtime/src/runtimes/react/__tests__/react-runtime.test.tsx
@@ -43,9 +43,11 @@ function Sandbox(props: {
   return <div>{JSON.stringify(props)}</div>
 }
 
+const runtime = new ReactRuntime()
+
 describe('registerComponent', () => {
   test("correctly deduces control definitions' resolved value types", () => {
-    ReactRuntime.registerComponent(Sandbox, {
+    runtime.registerComponent(Sandbox, {
       type: 'sandbox',
       label: 'Sandbox',
       props: {

--- a/packages/runtime/src/runtimes/react/components/PreviewProvider.tsx
+++ b/packages/runtime/src/runtimes/react/components/PreviewProvider.tsx
@@ -7,7 +7,6 @@ import * as ReactBuilderPreview from '../../../state/react-builder-preview'
 import { useReactRuntime } from '../hooks/use-react-runtime'
 import { StoreContext } from '../hooks/use-store'
 import { useMakeswiftHostApiClient } from '../host-api-client'
-import { ReactRuntime } from '../react-runtime'
 
 export default function PreviewProvider({ children }: PropsWithChildren): JSX.Element {
   const runtime = useReactRuntime()
@@ -15,7 +14,7 @@ export default function PreviewProvider({ children }: PropsWithChildren): JSX.El
   const store = useMemo(
     () =>
       ReactBuilderPreview.configureStore({
-        preloadedState: runtime ? runtime.store.getState() : ReactRuntime.store.getState(),
+        preloadedState: runtime.store.getState(),
         client,
       }),
     [client, runtime],

--- a/packages/runtime/src/runtimes/react/hooks/use-dispatch.ts
+++ b/packages/runtime/src/runtimes/react/hooks/use-dispatch.ts
@@ -1,12 +1,11 @@
-import { useContext } from 'react'
-import { StoreContext } from './use-store'
+import { useStore } from './use-store'
 import { Dispatch as ReactPageDispatch } from '../../../state/react-page'
 import { Dispatch as ReactBuilderPreviewDispatch } from '../../../state/react-builder-preview'
 
 type Dispatch = ReactPageDispatch & ReactBuilderPreviewDispatch
 
 export function useDispatch(): Dispatch {
-  const store = useContext(StoreContext)
+  const store = useStore()
 
   return store.dispatch
 }

--- a/packages/runtime/src/runtimes/react/hooks/use-react-runtime.tsx
+++ b/packages/runtime/src/runtimes/react/hooks/use-react-runtime.tsx
@@ -3,8 +3,13 @@
 import { createContext, useContext } from 'react'
 import { ReactRuntime } from '../react-runtime'
 
-export const ReactRuntimeContext = createContext<ReactRuntime>(ReactRuntime)
+export const ReactRuntimeContext = createContext<ReactRuntime | null>(null)
 
 export function useReactRuntime(): ReactRuntime {
-  return useContext(ReactRuntimeContext)
+  const runtime = useContext(ReactRuntimeContext)
+  if (runtime === null) {
+    throw new Error('`useReactRuntime` must be used within a `ReactRuntimeProvider`')
+  }
+
+  return runtime
 }

--- a/packages/runtime/src/runtimes/react/hooks/use-store.ts
+++ b/packages/runtime/src/runtimes/react/hooks/use-store.ts
@@ -1,11 +1,15 @@
 'use client'
 
 import { createContext, useContext } from 'react'
-import { RuntimeCore } from '../runtime-core'
 import { Store } from '../../../state/react-page'
 
-export const StoreContext = createContext(RuntimeCore.store)
+export const StoreContext = createContext<Store | null>(null)
 
 export function useStore(): Store {
-  return useContext(StoreContext)
+  const store = useContext(StoreContext)
+  if (store == null) {
+    throw new Error('`useStore` must be used within a `StoreProvider`')
+  }
+
+  return store
 }

--- a/packages/runtime/src/runtimes/react/react-runtime.ts
+++ b/packages/runtime/src/runtimes/react/react-runtime.ts
@@ -20,41 +20,6 @@ function validateComponentType(type: string, component?: ComponentType): void {
 }
 
 export class ReactRuntime extends RuntimeCore {
-  // TODO: the static methods here are deprecated and only keep here for backward-compatibility purpose.
-  // We will remove them when we release a new breaking change.
-  // ------------------ Deprecated API ------------------ //
-  static registerComponent<
-    ControlDef extends UnifiedControlDefinition,
-    P extends Record<string, LegacyDescriptor | ControlDef>,
-    C extends ComponentType<{ [K in keyof P]: DescriptorValueType<P[K]> }>,
-  >(
-    component: C,
-    {
-      type,
-      label,
-      icon = ComponentIcon.Code,
-      hidden = false,
-      props,
-    }: { type: string; label: string; icon?: ComponentIcon; hidden?: boolean; props?: P },
-  ): () => void {
-    validateComponentType(type, component as unknown as ComponentType)
-
-    const unregisterComponent = this.store.dispatch(
-      registerComponentEffect(type, { label, icon, hidden }, props ?? {}),
-    )
-
-    const unregisterReactComponent = this.store.dispatch(
-      registerReactComponentEffect(type, component as unknown as ComponentType),
-    )
-
-    return () => {
-      unregisterComponent()
-      unregisterReactComponent()
-    }
-  }
-
-  // ------------------ Deprecated API ends here ------------------ //
-
   registerComponent<
     ControlDef extends UnifiedControlDefinition,
     P extends Record<string, LegacyDescriptor | ControlDef>,
@@ -91,6 +56,3 @@ export class ReactRuntime extends RuntimeCore {
     registerBuiltinComponents(this)
   }
 }
-
-// TODO: We should delete this once we remove the static methods in ReactRuntime.
-registerBuiltinComponents(ReactRuntime)

--- a/packages/runtime/src/runtimes/react/runtime-core.ts
+++ b/packages/runtime/src/runtimes/react/runtime-core.ts
@@ -19,35 +19,6 @@ import {
 } from '../../state/react-page'
 
 export class RuntimeCore {
-  // TODO: the static methods here are deprecated and only keep here for backward-compatibility purpose.
-  // We will remove them when we release a new breaking change.
-  // ------------------ Deprecated API ------------------ //
-  static store = configureStore({ name: 'Runtime store (static)' })
-
-  static copyElementTree(
-    elementTree: ElementData,
-    replacementContext: SerializableReplacementContext,
-  ): Element {
-    return copyElementTree(this.store.getState(), elementTree, replacementContext)
-  }
-
-  static getBreakpoints(): Breakpoints {
-    return getBreakpoints(this.store.getState())
-  }
-
-  static getTranslatableData(elementTree: ElementData): Record<string, Data> {
-    return getElementTreeTranslatableData(this.store.getState(), elementTree)
-  }
-
-  static mergeTranslatedData(
-    elementTree: ElementData,
-    translatedData: Record<string, Data>,
-  ): Element {
-    return mergeElementTreeTranslatedData(this.store.getState(), elementTree, translatedData)
-  }
-
-  // ------------------ Deprecated API ends here ------------------ //
-
   store: Store
 
   constructor({ breakpoints }: { breakpoints?: BreakpointsInput }) {


### PR DESCRIPTION
Removing a potential source of hard-to-trace issues stemming from users forgetting to pass the runtime instance to the classes in subj.