### PR TITLE
fix: expose `ShapeV2Control.CHILD_CONTROL_MESSAGE` constant for the builder

### DIFF
--- a/packages/controls/src/controls/group/group.ts
+++ b/packages/controls/src/controls/group/group.ts
@@ -30,7 +30,7 @@ import { GroupControl } from './group-control'
 type ItemDefinition = ControlDefinition<string, unknown, any, any, any>
 type KeyDefinitions = Record<string, ItemDefinition>
 
-export type Config<Defs extends KeyDefinitions = KeyDefinitions> = {
+type Config<Defs extends KeyDefinitions = KeyDefinitions> = {
   readonly label?: string
   readonly preferredLayout?:
     | typeof Definition.Layout.Inline

--- a/packages/controls/src/controls/shape/v2/index.ts
+++ b/packages/controls/src/controls/shape/v2/index.ts
@@ -1,1 +1,2 @@
 export * from './shape-v2'
+export * from './shape-v2-control'

--- a/packages/controls/src/controls/shape/v2/shape-v2-control.ts
+++ b/packages/controls/src/controls/shape/v2/shape-v2-control.ts
@@ -1,0 +1,11 @@
+import { ControlInstance, type ControlMessage } from '../../instance'
+
+type Message = {
+  type: typeof ShapeV2Control.CHILD_CONTROL_MESSAGE
+  payload: { message: ControlMessage; key: string }
+}
+
+export abstract class ShapeV2Control extends ControlInstance<Message> {
+  static readonly CHILD_CONTROL_MESSAGE =
+    'makeswift::controls::shape-v2::message::child-control-message'
+}

--- a/packages/runtime/src/core/index.ts
+++ b/packages/runtime/src/core/index.ts
@@ -10,4 +10,5 @@ export {
   ControlDefinition,
   ControlInstance,
   DefaultControlInstance,
+  ShapeV2Control,
 } from '@makeswift/controls'


### PR DESCRIPTION
Required for backward compatibility with the pre-release runtime snapshots.