### PR TITLE
fix: update `@types/react` peer deps to 19.0.0

### DIFF
--- a/.changeset/famous-clocks-relate.md
+++ b/.changeset/famous-clocks-relate.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+fix: update `@types/{react,react-dom}` peer deps to 19.0.0

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -112,11 +112,11 @@
     "madge": "madge --circular --warning --extensions ts,tsx src/ --exclude \"dist/.+\""
   },
   "peerDependencies": {
-    "@types/react": "^18.0.0",
-    "@types/react-dom": "^18.0.0",
+    "@types/react": "^18.0.0 || ^19.0.0",
+    "@types/react-dom": "^18.0.0 || ^19.0.0",
     "next": "^13.4.0 || ^14.0.0 || ^15.0.0",
-    "react": "^18.0.0 || ^19.0.0 || 19.0.0-rc",
-    "react-dom": "^18.0.0 || ^19.0.0 || 19.0.0-rc"
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {


### PR DESCRIPTION
Also remove React's `19.0.0-rc` peer deps now that React 19 is officially out.