### PR TITLE
fix: prevent corrupted data from stopping rendering

### DIFF
--- a/.changeset/great-crabs-prove.md
+++ b/.changeset/great-crabs-prove.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+Fallback to default value for prop if prop resolution fails


### PR DESCRIPTION
Updates prop resolution to fallback to the default value for a prop (if available) on failure.

https://github.com/user-attachments/assets/279012a5-067d-4fd7-8ea6-4e950280a28e

