### PR TITLE
fix: don't run snapshot release action on release PRs

### DIFF
--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -10,6 +10,7 @@ jobs:
   snapshot_release:
     name: Snapshot Release
     runs-on: ubuntu-latest
+    if: github.event.pull_request.title != 'Version and publish packages'
     steps:
       - name: Check out git repo
         uses: actions/checkout@v3
@@ -38,16 +39,24 @@ jobs:
 
       # Now we do the snapshot release
       - name: Version Packages
+        id: version_packages
         run: |
-          pnpm exec changeset version --snapshot snapshot
+          output=$(pnpm exec changeset version --snapshot snapshot 2>&1)
+          echo "$output"
+          if echo "$output" | grep -q " warn "; then
+            echo "Warning detected, skipping publishing"
+            echo "SKIP_PUBLISH=true" >> "$GITHUB_OUTPUT"
+          fi
 
           cat packages/runtime/package.json | jq -r .version >> version.txt
 
       - name: Publish Packages
+        if: steps.version_packages.outputs.SKIP_PUBLISH != 'true'
         run: pnpm exec changeset publish --tag snapshot
 
       # Let the developer know
       - name: Write Message
+        if: steps.version_packages.outputs.SKIP_PUBLISH != 'true'
         run: |
           cat << EOF > message.txt
           # Snapshot Release
@@ -60,5 +69,6 @@ jobs:
           EOF
 
       - uses: mshick/add-pr-comment@v2
+        if: steps.version_packages.outputs.SKIP_PUBLISH != 'true'
         with:
           message-path: message.txt


### PR DESCRIPTION
Don't run snapshot release action on "Version and publish packages" PRs, skip publishing if there are warnings.

<img width="632" alt="skip publishing" src="https://github.com/user-attachments/assets/9336a87b-7bcd-4036-b0a1-521e41846cbe" />

See [this thread](https://makeswifthq.slack.com/archives/C014SCS4G75/p1734489089618689) for more context.