### PR TITLE
fix: fallback to default during individual prop resolution

### DIFF
--- a/.changeset/new-pandas-heal.md
+++ b/.changeset/new-pandas-heal.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+fix: fallback to default value when individual prop resolution fails

--- a/packages/runtime/src/runtimes/react/controls/control.tsx
+++ b/packages/runtime/src/runtimes/react/controls/control.tsx
@@ -27,8 +27,11 @@ export function ControlValue({
   const stylesheetFactory = useStylesheetFactory()
   const id = `cv-${useCssId()}`
 
-  const value = useResolvedValue(data, (data, resourceResolver) =>
-    definition.resolveValue(data, resourceResolver, stylesheetFactory.get(id), control),
+  const value = useResolvedValue(
+    data,
+    (data, resourceResolver) =>
+      definition.resolveValue(data, resourceResolver, stylesheetFactory.get(id), control),
+    (definition.config as any)?.defaultValue,
   )
 
   stylesheetFactory.useDefinedStyles()

--- a/packages/runtime/src/runtimes/react/hooks/use-resolved-value.ts
+++ b/packages/runtime/src/runtimes/react/hooks/use-resolved-value.ts
@@ -2,13 +2,19 @@ import { useMemo, useEffect, useSyncExternalStore } from 'react'
 import { Resolvable, ResourceResolver } from '@makeswift/controls'
 
 import { useResourceResolver } from './use-resource-resolver'
+import { propErrorHandlingProxy } from '../utils/prop-error-handling-proxy'
 
 export function useResolvedValue<D, T>(
   data: D,
   resolver: (data: D, resourceResolver: ResourceResolver) => Resolvable<T>,
-): T {
+  defaultValue?: T,
+): T | undefined {
   const resourceResolver = useResourceResolver()
-  const resolvable = useMemo(() => resolver(data, resourceResolver), [data, resourceResolver])
+  const resolvable = useMemo(() => {
+    return propErrorHandlingProxy(resolver(data, resourceResolver), defaultValue, error => {
+      console.warn(`Error resolving data, falling back to \`${defaultValue}\`.`, { error, data })
+    })
+  }, [data, resourceResolver, defaultValue])
 
   useEffect(() => {
     resolvable.triggerResolve()

--- a/packages/runtime/src/runtimes/react/utils/prop-error-handling-proxy.ts
+++ b/packages/runtime/src/runtimes/react/utils/prop-error-handling-proxy.ts
@@ -1,0 +1,19 @@
+import { type Resolvable } from '@makeswift/controls'
+
+export function propErrorHandlingProxy<T>(
+  resolvable: Resolvable<T>,
+  fallback: T,
+  onError?: (error: unknown) => void,
+): Resolvable<T> {
+  return {
+    ...resolvable,
+    readStable: () => {
+      try {
+        return resolvable.readStable()
+      } catch (err: unknown) {
+        onError?.(err)
+        return fallback
+      }
+    },
+  }
+}


### PR DESCRIPTION
Also switches to using `console.warn` for data parsing failures instead of `console.error`.