### PR TITLE
fix:  "attempted import" errors on registering components in server-side code

### DIFF
--- a/.changeset/healthy-baboons-switch.md
+++ b/.changeset/healthy-baboons-switch.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+fix: "attempted import" errors on registering components in server-side code

--- a/packages/runtime/src/runtimes/react/controls/rich-text-v2/ReadOnlyTextV2.tsx
+++ b/packages/runtime/src/runtimes/react/controls/rich-text-v2/ReadOnlyTextV2.tsx
@@ -1,13 +1,14 @@
 import { ForwardedRef, forwardRef } from 'react'
+import { Descendant, Element, Text } from 'slate'
+import { RenderElementProps, RenderLeafProps } from 'slate-react'
 
 import { RichTextV2Definition, RichText } from '../../../../controls/rich-text-v2'
 import { useStyle } from '../../use-style'
-import { Descendant, Element, Text } from 'slate'
-import { toText } from '../../../../slate'
-import { ControlValue } from '../control'
-import { RenderElementProps, RenderLeafProps } from 'slate-react'
+import { toText } from '../../../../slate/utils'
 import { RichTextV2Plugin } from '../../../../controls/rich-text-v2/plugin'
 import { RichTextDataV2 } from '../../../../controls/rich-text-v2'
+
+import { ControlValue } from '../control'
 
 type Props = {
   text: RichTextDataV2 | undefined

--- a/packages/runtime/src/runtimes/react/controls/rich-text/ReadOnlyText.tsx
+++ b/packages/runtime/src/runtimes/react/controls/rich-text/ReadOnlyText.tsx
@@ -5,7 +5,7 @@ import { Descendant, Text } from 'slate'
 import { Slate, RichTextValue, richTextDTOtoDAO } from '@makeswift/controls'
 
 import { useResponsiveStyle } from '../../../../components/utils/responsive-style'
-import { InlineType, BlockType } from '../../../../slate'
+import { InlineType, BlockType } from '../../../../slate/types'
 import { useStyle } from '../../use-style'
 import useEnhancedTypography, { useTypographyClassName } from '../typography'
 import { Link } from '../../../../components/shared/Link'


### PR DESCRIPTION
This was [previously fixed in 0.23.0 canary builds](https://github.com/makeswift/makeswift/pull/868), but lost during the merge from `main`.