### PR TITLE
feat: selectively render head tags in Page

### DIFF
--- a/.changeset/sweet-days-return.md
+++ b/.changeset/sweet-days-return.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+feat(runtime): introduce `metadata` prop on `Page` component to allow selectively rendering head tags with data from Makeswift

--- a/packages/runtime/src/components/page/Page.tsx
+++ b/packages/runtime/src/components/page/Page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useMemo } from 'react'
 import { BodySnippet } from './BodySnippet'
 import { DocumentRoot } from '../../runtimes/react'
 import { type Document } from '../../state/react-page'
@@ -7,20 +8,23 @@ import { MakeswiftPageDocument } from '../../next'
 import { useRouterLocaleSync } from '../hooks/useRouterLocaleSync'
 import { usePageSnippets } from '../hooks/usePageSnippets'
 import { PageHead } from './PageHead'
+import { flattenMetadataSettings, type PageMetadataSettings } from './page-seo-settings'
 
 type Props = {
   page: MakeswiftPageDocument
   rootDocument: Document
+  metadata?: boolean | PageMetadataSettings
 }
 
-export function Page({ page, rootDocument }: Props): JSX.Element {
+export function Page({ page, rootDocument, metadata = true }: Props): JSX.Element {
   const { bodySnippets } = usePageSnippets({ page })
+  const pageMetadataSettings = useMemo(() => flattenMetadataSettings(metadata), [metadata])
 
   useRouterLocaleSync()
 
   return (
     <>
-      <PageHead document={page} />
+      <PageHead document={page} metadata={pageMetadataSettings} />
 
       <DocumentRoot rootDocument={rootDocument} />
 

--- a/packages/runtime/src/components/page/PageHead.tsx
+++ b/packages/runtime/src/components/page/PageHead.tsx
@@ -9,6 +9,7 @@ import { useSyncExternalStore } from 'use-sync-external-store/shim'
 import { Site } from '../../api'
 import { PageTitle, PageMeta, PageLink, PageStyle } from '../../next/components/head-tags'
 import { HeadSnippet } from './HeadSnippet'
+import { type PageMetadataSettings } from './page-seo-settings'
 
 const defaultFavicon = {
   id: 'default-favicon',
@@ -19,9 +20,20 @@ const defaultFavicon = {
 
 type Props = {
   document: MakeswiftPageDocument
+  metadata?: PageMetadataSettings
 }
 
-export function PageHead({ document: page }: Props): JSX.Element {
+export function PageHead({ document: page, metadata = {} }: Props): JSX.Element {
+  const {
+    title: useTitle = false,
+    favicon: useFavicon = false,
+    canonicalUrl: useCanonicalUrl = false,
+    indexingBlocked: useIndexingBlocked = false,
+    description: useDescription = false,
+    keywords: useKeywords = false,
+    socialImage: useSocialImage = false,
+  } = metadata
+
   const { headSnippets } = usePageSnippets({ page })
 
   const isInBuilder = useIsInBuilder()
@@ -73,19 +85,21 @@ export function PageHead({ document: page }: Props): JSX.Element {
         }
         `}
       </PageStyle>
-      {title && <PageTitle>{title}</PageTitle>}
-      {favicon && <PageLink rel="icon" type={favicon.mimetype} href={favicon.publicUrl} />}
-      {canonicalUrl && <PageLink rel="canonical" href={canonicalUrl} />}
-      {isIndexingBlocked && <PageMeta name="robots" content="noindex" />}
-      {description && (
+      {useTitle && title && <PageTitle>{title}</PageTitle>}
+      {useFavicon && favicon && (
+        <PageLink rel="icon" type={favicon.mimetype} href={favicon.publicUrl} />
+      )}
+      {useCanonicalUrl && canonicalUrl && <PageLink rel="canonical" href={canonicalUrl} />}
+      {useIndexingBlocked && isIndexingBlocked && <PageMeta name="robots" content="noindex" />}
+      {useDescription && description && (
         <>
           <PageMeta name="description" content={description} />
           <PageMeta property="og:description" content={description} />
           <PageMeta name="twitter:description" content={description} />
         </>
       )}
-      {keywords && <PageMeta name="keywords" content={keywords} />}
-      {socialImage && (
+      {useKeywords && keywords && <PageMeta name="keywords" content={keywords} />}
+      {useSocialImage && socialImage && (
         <>
           <PageMeta property="og:image" content={socialImage.publicUrl} />
           <PageMeta property="og:image:type" content={socialImage.mimetype} />

--- a/packages/runtime/src/components/page/page-seo-settings.ts
+++ b/packages/runtime/src/components/page/page-seo-settings.ts
@@ -1,0 +1,26 @@
+export type PageMetadataSettings = {
+  title?: boolean
+  description?: boolean
+  keywords?: boolean
+  socialImage?: boolean
+  canonicalUrl?: boolean
+  indexingBlocked?: boolean
+  favicon?: boolean
+}
+
+export function flattenMetadataSettings(
+  settings?: boolean | PageMetadataSettings,
+): PageMetadataSettings {
+  if (typeof settings === 'boolean')
+    return {
+      title: settings,
+      description: settings,
+      keywords: settings,
+      socialImage: settings,
+      canonicalUrl: settings,
+      indexingBlocked: settings,
+      favicon: settings,
+    }
+  if (settings == null) return {}
+  return settings
+}

--- a/packages/runtime/src/next/components/page.tsx
+++ b/packages/runtime/src/next/components/page.tsx
@@ -14,9 +14,11 @@ import {
 } from '../client'
 import * as ReactPage from '../../state/react-page'
 import { registerDocumentsEffect } from '../../state/actions'
+import { type PageMetadataSettings } from '../../components/page/page-seo-settings'
 
 export type PageProps = {
   snapshot: MakeswiftPageSnapshot
+  metadata?: boolean | PageMetadataSettings
 }
 
 function useRegisterPageDocument(pageDocument: MakeswiftPageDocument): ReactPage.Document {
@@ -31,7 +33,25 @@ function useRegisterPageDocument(pageDocument: MakeswiftPageDocument): ReactPage
   return rootDocuments[0]
 }
 
-export const Page = memo(({ snapshot, ...props }: PageProps) => {
+/**
+ * @param snapshot - The snapshot of the page to render, from
+ * `client.getPageSnapshot()`.
+ * @param metadata - Allows control over whether to use data from Makeswift for
+ * rendering metadata tags in the `<head>` of the page. Pass `true` (default if
+ * not provided) to render all metadata tags, or `false` to not render any. For
+ * more granular control, pass an object with boolean values for specific
+ * metadata fields. Valid fields include:
+ *  - `title`
+ *  - `description`
+ *  - `keywords`
+ *  - `socialImage`
+ *  - `canonicalUrl`
+ *  - `indexingBlocked`
+ *  - `favicon`
+ *
+ * If a field is not provided, it will default to `false`.
+ */
+export const Page = memo(({ snapshot, metadata = true, ...props }: PageProps) => {
   if ('runtime' in props) {
     throw new Error(
       `The \`runtime\` prop is no longer supported in the \`@makeswift/runtime\` \`Page\` component as of \`0.15.0\`.
@@ -50,6 +70,7 @@ See our docs for more information on what's changed and instructions to migrate:
         key={snapshot.document.data.key}
         page={snapshot.document}
         rootDocument={rootDocument}
+        metadata={metadata}
       />
     </Suspense>
   )

--- a/packages/runtime/src/next/components/tests/__snapshots__/makeswift-page-metadata-rendering.test.tsx.snap
+++ b/packages/runtime/src/next/components/tests/__snapshots__/makeswift-page-metadata-rendering.test.tsx.snap
@@ -1,0 +1,290 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MakeswiftPage metadata and seo tag rendering does NOT render any metadata when passing all options as false 1`] = `
+<head>
+  <style
+    href="makeswift-base-styles"
+    precedence="high"
+  >
+    
+        html {
+            font-family: sans-serif;
+        }
+        div#__next {
+            overflow: hidden;
+        }
+        
+  </style>
+</head>
+`;
+
+exports[`MakeswiftPage metadata and seo tag rendering does NOT render any metadata when passing empty options 1`] = `
+<head>
+  <style
+    href="makeswift-base-styles"
+    precedence="high"
+  >
+    
+        html {
+            font-family: sans-serif;
+        }
+        div#__next {
+            overflow: hidden;
+        }
+        
+  </style>
+</head>
+`;
+
+exports[`MakeswiftPage metadata and seo tag rendering does NOT render any metadata when passing false 1`] = `
+<head>
+  <style
+    href="makeswift-base-styles"
+    precedence="high"
+  >
+    
+        html {
+            font-family: sans-serif;
+        }
+        div#__next {
+            overflow: hidden;
+        }
+        
+  </style>
+</head>
+`;
+
+exports[`MakeswiftPage metadata and seo tag rendering only renders selective metadata when passing options 1`] = `
+<head>
+  <style
+    href="makeswift-base-styles"
+    precedence="high"
+  >
+    
+        html {
+            font-family: sans-serif;
+        }
+        div#__next {
+            overflow: hidden;
+        }
+        
+  </style>
+  <title>
+    Test Title
+  </title>
+  <meta
+    content="Test Description"
+    name="description"
+  />
+  <meta
+    content="Test Description"
+    property="og:description"
+  />
+  <meta
+    content="Test Description"
+    name="twitter:description"
+  />
+  <meta
+    content="test, keywords"
+    name="keywords"
+  />
+</head>
+`;
+
+exports[`MakeswiftPage metadata and seo tag rendering renders all metadata by default (without passing prop) 1`] = `
+<head>
+  <style
+    href="makeswift-base-styles"
+    precedence="high"
+  >
+    
+        html {
+            font-family: sans-serif;
+        }
+        div#__next {
+            overflow: hidden;
+        }
+        
+  </style>
+  <title>
+    Test Title
+  </title>
+  <link
+    href="https://example.com/favicon.ico"
+    rel="icon"
+    type="image/x-icon"
+  />
+  <link
+    href="https://example.com"
+    rel="canonical"
+  />
+  <meta
+    content="noindex"
+    name="robots"
+  />
+  <meta
+    content="Test Description"
+    name="description"
+  />
+  <meta
+    content="Test Description"
+    property="og:description"
+  />
+  <meta
+    content="Test Description"
+    name="twitter:description"
+  />
+  <meta
+    content="test, keywords"
+    name="keywords"
+  />
+  <meta
+    content="https://example.com/image.jpg"
+    property="og:image"
+  />
+  <meta
+    content="image/jpeg"
+    property="og:image:type"
+  />
+  <meta
+    content="https://example.com/image.jpg"
+    name="twitter:image"
+  />
+  <meta
+    content="summary_large_image"
+    name="twitter:card"
+  />
+</head>
+`;
+
+exports[`MakeswiftPage metadata and seo tag rendering renders all metadata when passing all options as true 1`] = `
+<head>
+  <style
+    href="makeswift-base-styles"
+    precedence="high"
+  >
+    
+        html {
+            font-family: sans-serif;
+        }
+        div#__next {
+            overflow: hidden;
+        }
+        
+  </style>
+  <title>
+    Test Title
+  </title>
+  <link
+    href="https://example.com/favicon.ico"
+    rel="icon"
+    type="image/x-icon"
+  />
+  <link
+    href="https://example.com"
+    rel="canonical"
+  />
+  <meta
+    content="noindex"
+    name="robots"
+  />
+  <meta
+    content="Test Description"
+    name="description"
+  />
+  <meta
+    content="Test Description"
+    property="og:description"
+  />
+  <meta
+    content="Test Description"
+    name="twitter:description"
+  />
+  <meta
+    content="test, keywords"
+    name="keywords"
+  />
+  <meta
+    content="https://example.com/image.jpg"
+    property="og:image"
+  />
+  <meta
+    content="image/jpeg"
+    property="og:image:type"
+  />
+  <meta
+    content="https://example.com/image.jpg"
+    name="twitter:image"
+  />
+  <meta
+    content="summary_large_image"
+    name="twitter:card"
+  />
+</head>
+`;
+
+exports[`MakeswiftPage metadata and seo tag rendering renders all metadata when passing true 1`] = `
+<head>
+  <style
+    href="makeswift-base-styles"
+    precedence="high"
+  >
+    
+        html {
+            font-family: sans-serif;
+        }
+        div#__next {
+            overflow: hidden;
+        }
+        
+  </style>
+  <title>
+    Test Title
+  </title>
+  <link
+    href="https://example.com/favicon.ico"
+    rel="icon"
+    type="image/x-icon"
+  />
+  <link
+    href="https://example.com"
+    rel="canonical"
+  />
+  <meta
+    content="noindex"
+    name="robots"
+  />
+  <meta
+    content="Test Description"
+    name="description"
+  />
+  <meta
+    content="Test Description"
+    property="og:description"
+  />
+  <meta
+    content="Test Description"
+    name="twitter:description"
+  />
+  <meta
+    content="test, keywords"
+    name="keywords"
+  />
+  <meta
+    content="https://example.com/image.jpg"
+    property="og:image"
+  />
+  <meta
+    content="image/jpeg"
+    property="og:image:type"
+  />
+  <meta
+    content="https://example.com/image.jpg"
+    name="twitter:image"
+  />
+  <meta
+    content="summary_large_image"
+    name="twitter:card"
+  />
+</head>
+`;

--- a/packages/runtime/src/next/components/tests/makeswift-page-metadata-rendering.test.tsx
+++ b/packages/runtime/src/next/components/tests/makeswift-page-metadata-rendering.test.tsx
@@ -1,0 +1,161 @@
+/** @jest-environment jsdom */
+
+import '@testing-library/jest-dom'
+import { act } from 'react-dom/test-utils'
+import { render } from '@testing-library/react'
+import { ReactRuntime } from '../../../react'
+import * as Testing from '../../../runtimes/react/testing'
+import { type MakeswiftPageSnapshot, type MakeswiftPageDocument } from '../../client'
+import { type CacheData } from '../../../api/react'
+import { Page as MakeswiftPage } from '../page'
+import { ComponentPropsWithoutRef } from 'react'
+
+const NoOpComponentType = 'NoOpComponent'
+function NoOpComponent() {
+  return <></>
+}
+
+const pageDocumentFixture = {
+  id: '2222-2222-2222-2222',
+  site: {
+    id: '1111-1111-1111-1111',
+  },
+  data: {
+    type: NoOpComponentType,
+    key: '0000-0000-0000-0000',
+    props: {},
+  },
+  snippets: [],
+  fonts: [],
+  localizedPages: [],
+  locale: null,
+  meta: {
+    title: 'Test Title',
+    description: 'Test Description',
+    keywords: 'test, keywords',
+    socialImage: {
+      id: '0000-0000-0000-0001',
+      publicUrl: 'https://example.com/image.jpg',
+      mimetype: 'image/jpeg',
+    },
+    favicon: {
+      id: '0000-0000-0000-0002',
+      publicUrl: 'https://example.com/favicon.ico',
+      mimetype: 'image/x-icon',
+    },
+  },
+  seo: {
+    canonicalUrl: 'https://example.com',
+    isIndexingBlocked: true,
+  },
+}
+
+function createMakeswiftPageSnapshot(
+  document: MakeswiftPageDocument,
+  cacheData: CacheData = {
+    apiResources: {},
+    localizedResourcesMap: {},
+  },
+): MakeswiftPageSnapshot {
+  return {
+    document,
+    cacheData,
+  }
+}
+
+async function testMakeswiftPageMetadataRendering(
+  props: ComponentPropsWithoutRef<typeof MakeswiftPage>,
+) {
+  const runtime = new ReactRuntime()
+
+  runtime.registerComponent(NoOpComponent, {
+    type: NoOpComponentType,
+    label: 'NoOp Component',
+    props: {},
+  })
+
+  return await act(async () =>
+    render(
+      <Testing.ReactProvider runtime={runtime} previewMode={false}>
+        <MakeswiftPage {...props} />
+      </Testing.ReactProvider>,
+      {
+        container: document.body.appendChild(document.createElement('head')),
+      },
+    ),
+  )
+}
+
+describe('MakeswiftPage', () => {
+  describe('metadata and seo tag rendering', () => {
+    test('renders all metadata by default (without passing prop)', async () => {
+      const snapshot = createMakeswiftPageSnapshot(pageDocumentFixture)
+
+      const render = await testMakeswiftPageMetadataRendering({ snapshot })
+      expect(render.container).toMatchSnapshot()
+    })
+
+    test.each([
+      { label: true, metadata: true },
+      {
+        label: 'all options as true',
+        metadata: {
+          title: true,
+          description: true,
+          keywords: true,
+          socialImage: true,
+          favicon: true,
+          canonicalUrl: true,
+          indexingBlocked: true,
+        },
+      },
+    ])(`renders all metadata when passing $label`, async ({ metadata }) => {
+      const snapshot = createMakeswiftPageSnapshot(pageDocumentFixture)
+
+      const render = await testMakeswiftPageMetadataRendering({ snapshot, metadata })
+      expect(render.container).toMatchSnapshot()
+    })
+
+    test.each([
+      { label: false, metadata: false },
+      {
+        label: 'empty options',
+        metadata: {},
+      },
+      {
+        label: 'all options as false',
+        metadata: {
+          title: false,
+          description: false,
+          keywords: false,
+          socialImage: false,
+          favicon: false,
+          canonicalUrl: false,
+          indexingBlocked: false,
+        },
+      },
+    ])(`does NOT render any metadata when passing $label`, async ({ metadata }) => {
+      const snapshot = createMakeswiftPageSnapshot(pageDocumentFixture)
+
+      const render = await testMakeswiftPageMetadataRendering({ snapshot, metadata })
+      expect(render.container).toMatchSnapshot()
+      expect(render.container.getElementsByTagName('meta').length).toBe(0)
+      expect(render.container.getElementsByTagName('link').length).toBe(0)
+    })
+
+    test('only renders selective metadata when passing options', async () => {
+      const snapshot = createMakeswiftPageSnapshot(pageDocumentFixture)
+
+      // Only render title, description, and keywords
+      const render = await testMakeswiftPageMetadataRendering({
+        snapshot,
+        metadata: {
+          title: true,
+          description: true,
+          keywords: true,
+        },
+      })
+      expect(render.container).toMatchSnapshot()
+    })
+  })
+})


### PR DESCRIPTION
Introduce prop to the Page component that will selectively render metadata in the page `head` with data from Makeswift, or pass booleans to blanket enable/disable this data.