### PR TITLE
chore: log missing components' types

### DIFF
--- a/.changeset/nervous-badgers-lay.md
+++ b/.changeset/nervous-badgers-lay.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+chore: log missing components' types

--- a/packages/runtime/src/runtimes/react/components/ElementData.tsx
+++ b/packages/runtime/src/runtimes/react/components/ElementData.tsx
@@ -17,6 +17,7 @@ export const ElementData = memo(
     const Component = useComponent(elementData.type)
 
     if (Component == null) {
+      console.warn(`Unknown component '${elementData.type}'`, { elementData })
       return <FallbackComponent ref={ref as Ref<HTMLDivElement>} text="Component not found" />
     }
 


### PR DESCRIPTION
The message on the placeholder component we show to the user when we can't find a registered component doesn't reveal any component details (see below), which is probably appropriate, but we should log the details to the console to aid the troubleshooting.

<img width="1707" alt="Screenshot 2025-01-29 at 5 15 10 PM" src="https://github.com/user-attachments/assets/0504f7a0-b441-4df2-9fac-e7770fba8617" />
