### PR TITLE
fix(workflows): update upload-artifact to v4

### DIFF
--- a/.github/workflows/preview-deployment-playwright-tests.yml
+++ b/.github/workflows/preview-deployment-playwright-tests.yml
@@ -23,7 +23,7 @@ jobs:
         run: pnpm exec playwright test tests/preview-deployment
         env:
           PLAYWRIGHT_TEST_BASE_URL: ${{ github.event.deployment_status.target_url }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report


### PR DESCRIPTION
upload-artifact@v3 was deprecated on 1/30/25. See https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/.