### PR TITLE
fix: encode component ID when fetching its element tree

### DIFF
--- a/.changeset/curvy-forks-give.md
+++ b/.changeset/curvy-forks-give.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+fix: "lost" edits to slots/embedded components with slashes in their IDs

--- a/packages/runtime/src/next/client.ts
+++ b/packages/runtime/src/next/client.ts
@@ -685,12 +685,12 @@ export class Makeswift {
 
     let response
     const responseForRequestedLocale = await this.fetch(
-      `v1/element-trees/${id}?${searchParams.toString()}`,
+      `v1/element-trees/${encodeURIComponent(id)}?${searchParams.toString()}`,
       siteVersion,
     )
 
     if (responseForRequestedLocale.status === 404 && canAttemptLocaleFallback) {
-      response = await this.fetch(`v1/element-trees/${id}`, siteVersion)
+      response = await this.fetch(`v1/element-trees/${encodeURIComponent(id)}`, siteVersion)
     } else {
       response = responseForRequestedLocale
     }


### PR DESCRIPTION
Fixes "lost" edits to slots/embedded components with slashes in their IDs (a likely scenario for dynamic pages).

### Before

https://github.com/user-attachments/assets/34247fc1-c36a-42ce-95e4-7bef4dbf42a0

### After

https://github.com/user-attachments/assets/494f9a3c-e252-49cb-8de6-af3c93b8baa3

