### PR TITLE
fix: don't pass `locale` prop to `NextLink` when running under App Router

### DIFF
--- a/.changeset/famous-dingos-talk.md
+++ b/.changeset/famous-dingos-talk.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+fix: don't pass `locale` prop to `NextLink` when running under App Router

--- a/packages/runtime/src/components/shared/Link/index.tsx
+++ b/packages/runtime/src/components/shared/Link/index.tsx
@@ -6,6 +6,8 @@ import NextLink from 'next/link'
 import { LinkData } from '@makeswift/prop-controllers'
 
 import { Link as LinkDef } from '../../../controls/link'
+
+import { useIsPagesRouter } from '../../../next/hooks/use-is-pages-router'
 import { useResolvedValue } from '../../../runtimes/react/hooks/use-resolved-value'
 
 type BaseProps = {
@@ -62,6 +64,8 @@ export const Link = forwardRef<HTMLAnchorElement, Props>(function Link(
     link &&
     (link.type === 'OPEN_PAGE' || (link.type === 'OPEN_URL' && isValidHref(link.payload.url)))
 
+  const isPagesRouter = useIsPagesRouter()
+
   if (useNextLink) {
     return (
       <NextLink
@@ -70,7 +74,7 @@ export const Link = forwardRef<HTMLAnchorElement, Props>(function Link(
         target={target}
         onClick={handleClick}
         href={href}
-        locale={false}
+        {...(isPagesRouter ? { locale: false } : {})}
         // Next.js v12 has legacyBehavior set to true by default
         legacyBehavior={false}
       />

--- a/packages/runtime/src/next/hooks/use-is-pages-router.ts
+++ b/packages/runtime/src/next/hooks/use-is-pages-router.ts
@@ -1,6 +1,8 @@
 import { useRouter } from 'next/router'
 
 export function useIsPagesRouter() {
+  // switch to `next/compat/router` once we drop support for Next.js 14:
+  // https://nextjs.org/docs/pages/api-reference/functions/use-router#the-nextcompatrouter-export
   try {
     useRouter()
     return true


### PR DESCRIPTION
Passing `locale={false}` to `NextLink` in the App Router context is silently ignored in Next 13/14, but [generates a console error in Next 15](https://github.com/vercel/next.js/discussions/74703).
