### PR TITLE
fix: missing `Carousel` styles

### DIFF
--- a/.changeset/good-turtles-compare.md
+++ b/.changeset/good-turtles-compare.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+fix: missing padding, arrow hover styles on `Carousel` when running under the App Router

--- a/packages/runtime/src/components/builtin/Carousel/Carousel.tsx
+++ b/packages/runtime/src/components/builtin/Carousel/Carousel.tsx
@@ -78,6 +78,10 @@ type Props = {
 const SWIPE_THRESHOLD = 20
 const swipePower = (dx: number, velocity: number) => dx * (1 + velocity)
 
+// constructs a CSS [class selector](https://developer.mozilla.org/en-US/docs/Web/CSS/Class_selectors),
+// returns a compound class selector if the `classname` string includes multiple class names
+const classSelector = (classname: string) => `.${classname.split(' ').join('.')}`
+
 const Carousel = forwardRef(function Carousel(
   {
     images = [],
@@ -174,17 +178,19 @@ const Carousel = forwardRef(function Carousel(
       useResponsiveStyle([slideAlignment] as const, ([alignItems = 'center']) => ({ alignItems })),
     ),
   )
+
   const reelClassName = cx(
     useStyle({ display: 'flex', position: 'relative', flexWrap: 'nowrap' }),
     useStyle(
       useResponsiveStyle([gap] as const, ([gap = { value: 0, unit: 'px' }]) => ({
         margin: `0 ${`${-gap.value / 2}${gap.unit}`}`,
-        [`& > .${slideClassName}`]: {
+        [`& > ${classSelector(slideClassName)}`]: {
           padding: `0 ${`${gap.value / 2}${gap.unit}`}`,
         },
       })),
     ),
   )
+
   const arrowClassName = cx(
     useStyle({
       padding: 10,
@@ -209,6 +215,7 @@ const Carousel = forwardRef(function Carousel(
     ),
     useStyle({ svg: { transition: 'transform 0.15s', stroke: 'currentcolor' } }),
   )
+
   const slopClassName = cx(
     useStyle({
       position: 'absolute',
@@ -233,6 +240,7 @@ const Carousel = forwardRef(function Carousel(
       ),
     ),
   )
+
   const leftSlopClassName = cx(
     slopClassName,
     useStyle(
@@ -252,13 +260,14 @@ const Carousel = forwardRef(function Carousel(
     useStyle({
       left: 0,
 
-      [`&:hover > .${arrowClassName}`]: {
+      [`&:hover > ${classSelector(arrowClassName)}`]: {
         '& > svg': {
           transform: 'translateX(-2px)',
         },
       },
     }),
   )
+
   const rightSlopClassName = cx(
     slopClassName,
     useStyle(
@@ -277,14 +286,14 @@ const Carousel = forwardRef(function Carousel(
     ),
     useStyle({
       right: 0,
-
-      [`&:hover > .${arrowClassName}`]: {
+      [`&:hover > ${classSelector(arrowClassName)}`]: {
         '& > svg': {
           transform: 'translateX(2px)',
         },
       },
     }),
   )
+
   const dotsClassName = cx(
     useStyle({ display: showDots ? 'flex' : 'none', justifyContent: 'center', marginTop: 20 }),
     useStyle(


### PR DESCRIPTION
Fix missing padding, arrow hover styles on `Carousel` when running under the App Router. Note that this has been broken since we introduced support for the App Router. See inline comments below for details.

## Before

<img width="1038" alt="before" src="https://github.com/user-attachments/assets/c9eca1ff-9ae5-4ae0-8f81-7d4043f4e156" />

![before hover](https://github.com/user-attachments/assets/db85df99-015c-4e2f-b4ed-845b0be3fac7)

## After

<img width="1013" alt="after" src="https://github.com/user-attachments/assets/9b4488c0-f6fc-4236-8064-45bf97e375d2" />

![after hover](https://github.com/user-attachments/assets/431c314d-e79b-4a61-8462-b1f57ed31532)

