### PR TITLE
fix: `FORCE_HTTP` -> `MAKESWIFT_DRAFT_MODE_PROXY_FORCE_HTTP`

### DIFF
--- a/.changeset/kind-garlics-tease.md
+++ b/.changeset/kind-garlics-tease.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+fix: `FORCE_HTTP` -> `MAKESWIFT_DRAFT_MODE_PROXY_FORCE_HTTP`

--- a/packages/runtime/src/next/api-handler/handlers/proxy-draft-mode.test.ts
+++ b/packages/runtime/src/next/api-handler/handlers/proxy-draft-mode.test.ts
@@ -11,10 +11,10 @@ jest.mock('next/headers', () => ({
 
 const mockApiKey = 'test-api-key'
 
-describe('ForceHTTP proxyDraftMode URL handling', () => {
+describe('proxyDraftMode w/ MAKESWIFT_DRAFT_MODE_PROXY_FORCE_HTTP=true', () => {
   it('should force protocol to http and use host from `host` from headers instead of `x-forwarded-host`', async () => {
     try {
-      env.FORCE_HTTP = 'true'
+      env.MAKESWIFT_DRAFT_MODE_PROXY_FORCE_HTTP = 'true'
       const originalUrl = new URL(
         `https://example.com?x-makeswift-draft-mode=${mockApiKey}&keep=this`,
       )
@@ -48,7 +48,7 @@ describe('ForceHTTP proxyDraftMode URL handling', () => {
       expect(capturedRequest!.nextUrl.searchParams.has('x-makeswift-draft-mode')).toBe(false)
       expect(capturedRequest!.nextUrl.searchParams.get('keep')).toBe('this')
     } finally {
-      env.FORCE_HTTP = undefined
+      env.MAKESWIFT_DRAFT_MODE_PROXY_FORCE_HTTP = undefined
     }
   })
 })

--- a/packages/runtime/src/next/api-handler/handlers/proxy-draft-mode.ts
+++ b/packages/runtime/src/next/api-handler/handlers/proxy-draft-mode.ts
@@ -59,19 +59,19 @@ async function proxyDraftModeRouteHandler(
   const draft = await draftMode()
   draft.enable()
 
-  const proxyUrl = request.nextUrl.clone()  
-  
-  if (process.env.FORCE_HTTP == null) {
+  const proxyUrl = request.nextUrl.clone()
+
+  if (process.env.MAKESWIFT_DRAFT_MODE_PROXY_FORCE_HTTP == null) {
     proxyUrl.protocol = request.headers.get('x-forwarded-proto') ?? request.nextUrl.protocol
   } else {
     proxyUrl.protocol = 'http'
   }
 
-  const forwardingHost = request.headers.get('x-forwarded-host') ?? request.headers.get('host') 
+  const forwardingHost = request.headers.get('x-forwarded-host') ?? request.headers.get('host')
   if (forwardingHost) {
     proxyUrl.host = forwardingHost
   }
-  
+
   proxyUrl.searchParams.delete('x-makeswift-draft-mode')
 
   const proxyHeaders = new Headers(request.headers)


### PR DESCRIPTION
Rename the [recently introduced `FORCE_HTTP` env variable](https://github.com/makeswift/makeswift/releases/tag/%40makeswift%2Fruntime%400.23.2) to better reflect its scope. 

See [this thread](https://makeswifthq.slack.com/archives/C014SCS4G75/p1738608865174819) for more context.