### PR TITLE
fix: prioritize cache hydration over prop resolution

### DIFF
--- a/.changeset/odd-crabs-prove.md
+++ b/.changeset/odd-crabs-prove.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+fix: ensure host API client cache is hydrated on render, ahead of prop resolution

--- a/packages/runtime/src/runtimes/react/hooks/use-cache-data.ts
+++ b/packages/runtime/src/runtimes/react/hooks/use-cache-data.ts
@@ -1,10 +1,15 @@
+import { useMemo } from 'react'
 import { type CacheData } from '../../../api/react'
 import { updateAPIClientCache } from '../../../state/actions'
 
 import { useMakeswiftHostApiClient } from '../host-api-client'
-import { useUniversalDispatch } from './use-universal-dispatch'
 
 export function useCacheData(cacheData: CacheData) {
   const { makeswiftApiClient: apiStore } = useMakeswiftHostApiClient()
-  useUniversalDispatch(apiStore.dispatch, updateAPIClientCache, [cacheData])
+
+  // We perform cache hydration immediately on render - this is safe to do per
+  // render because updating the API cache is idempotent. For precedence, see:
+  //
+  // https://github.com/TanStack/query/blob/8f9f183f11df3709a1a38c4efce1452788041f88/packages/react-query/src/HydrationBoundary.tsx#L41
+  useMemo(() => apiStore.dispatch(updateAPIClientCache(cacheData)), [cacheData])
 }


### PR DESCRIPTION
Fixes an issue where element prop resolution occurs before the cache hydration action from the parent is kicked off from an effect. By prioritizing parent dispatches ahead of children effects, we ensure that the children are reading from hydrated state.