### PR TITLE
fix: cache key mismatch when default locale is passed to getPageSnapshot

### DIFF
--- a/.changeset/new-sheep-matter.md
+++ b/.changeset/new-sheep-matter.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Fix cache data mismatch that causes resources to be fetched on the client side when the default locale is passed to `getPageSnapshot`.

--- a/packages/runtime/src/next/client.ts
+++ b/packages/runtime/src/next/client.ts
@@ -474,7 +474,7 @@ export class Makeswift {
   private async introspect(
     element: Element,
     siteVersion: MakeswiftSiteVersion,
-    locale?: string,
+    locale: string | null,
   ): Promise<CacheData> {
     const runtime = this.runtime
     const descriptors = getPropControllerDescriptors(runtime.store.getState())
@@ -654,7 +654,10 @@ export class Makeswift {
     const cacheData = await this.introspect(
       baseLocalizedPage?.data ?? document.data,
       siteVersion,
-      localeInput,
+      // The /v3/pages endpoint returns null for document.locale when the requested locale is the default.
+      // This legacy behavior is set to change with the upcoming /v4/pages endpoint.
+      // We rely on document.locale when reading from the API cache, so ensure the cache is built during introspection using the same value.
+      document.locale,
     )
 
     return {
@@ -718,7 +721,7 @@ export class Makeswift {
     }
 
     const document = makeswiftComponentDocumentSchema.parse(json)
-    const cacheData = await this.introspect(document.data, siteVersion, locale)
+    const cacheData = await this.introspect(document.data, siteVersion, locale ?? null)
 
     return {
       document,
@@ -814,7 +817,7 @@ export class Makeswift {
   async getPagePathnameSlices(
     pageIds: string[],
     siteVersion: MakeswiftSiteVersion,
-    { locale }: { locale?: string },
+    { locale }: { locale?: string | null },
   ): Promise<(PagePathnameSlice | null)[]> {
     if (pageIds.length === 0) return []
 


### PR DESCRIPTION
When we read from the API resource reducer, we're using the locale from `useDocumentLocale`, which is coming from `snapshot.document.locale`. We have a legacy behavior in our API server where if the `locale === defaultLocale`, the server will return the locale as `null`.

When we write to the API resource reducer, we're using the `cacheData` from the introspect function, which gets the locale from `getPageSnapshot` argument directly, without checking if it's the defaultLocale or not.

When we pass the default locale to `getPageSnapshot`:
```
const snapshot = getPageSnapshot({ locale: 'en-US' })
```
The snapshot:
```
{ document: { locale: null } }
```
The cacheData:
```
{ "id": "...", "value": { ... }, "locale": "en-US" }
```

This commit fixes the issue by using the locale returned from the snapshot, instead of from the `getPageSnapshot` argument, to make sure there is no locale mismatch on the document locale and the `cacheData`.

Before:

https://github.com/user-attachments/assets/651034bb-8d67-4d77-b2fa-a192351297cd

After:


https://github.com/user-attachments/assets/1db74c71-7390-4524-9174-a3de656bb62f

