### PR TITLE
fix(runtime): correctly handle reset element ops

### DIFF
--- a/.changeset/cool-rats-enjoy.md
+++ b/.changeset/cool-rats-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+fix: on empty path operations, don't show error messages and properly cleanup removed elements.

--- a/packages/runtime/src/state/modules/__tests__/__snapshots__/element-trees.test.ts.snap
+++ b/packages/runtime/src/state/modules/__tests__/__snapshots__/element-trees.test.ts.snap
@@ -1,5 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`resetting an element tree garbage collects all elements that were removed on reset 1`] = `
+[
+  "e4e70b30-af46-5f25-93ee-2c550ec4a5f4",
+  "51115f2a-12ac-4a0f-8be3-7e4006cf7c09",
+  "f46bb567-8964-4606-b544-295b4b7d05fd",
+  "c5010c7f-2eec-4042-abc8-be48836f8aef",
+  "7039524a-c2a1-42be-9988-a799c21fe734",
+  "618f069e-9515-4546-8abc-75cec6d33af4",
+  "9745df8d-1589-46fd-8320-f3238bb94cbe",
+  "92fd0115-ff8f-4218-b23f-9f861166ef35",
+]
+`;
+
+exports[`resetting an element tree garbage collects all elements that were removed on reset 2`] = `
+[
+  "38bf059f-9a17-4626-bec4-e286130fd9da",
+  "6ddc735a-3098-410a-b3b6-801f4ae1a0be",
+]
+`;
+
 exports[`traverseElementTree walks the tree in the correct order 1`] = `
 [
   {

--- a/packages/runtime/src/state/modules/__tests__/fixtures/element-trees-demo-component.tsx
+++ b/packages/runtime/src/state/modules/__tests__/fixtures/element-trees-demo-component.tsx
@@ -1,0 +1,12 @@
+import { type ReactNode } from 'react'
+
+export const ELEMENT_TREE_DEMO_COMPONENT_TYPE = 'Demo'
+
+export function ElementTreesDemo({ left, right }: { left: ReactNode; right: ReactNode }) {
+  return (
+    <div>
+      <div>{left}</div>
+      <div>{right}</div>
+    </div>
+  )
+}

--- a/packages/runtime/src/state/modules/__tests__/fixtures/element-trees.ts
+++ b/packages/runtime/src/state/modules/__tests__/fixtures/element-trees.ts
@@ -4008,3 +4008,282 @@ export const homePage = {
   },
   type: './components/Root/index.js',
 }
+
+export const resetElementTree = {
+  beforeReset: {
+    type: 'Demo',
+    key: 'e4e70b30-af46-5f25-93ee-2c550ec4a5f4',
+    props: {
+      left: {
+        columns: [
+          {
+            value: {
+              count: 12,
+              spans: [[12]],
+            },
+            deviceId: 'desktop',
+          },
+        ],
+        elements: [
+          {
+            key: '51115f2a-12ac-4a0f-8be3-7e4006cf7c09',
+            type: './components/Box/index.js',
+            props: {
+              padding: [
+                {
+                  value: {
+                    paddingTop: {
+                      unit: 'px',
+                      value: 10,
+                    },
+                    paddingLeft: {
+                      unit: 'px',
+                      value: 10,
+                    },
+                    paddingRight: {
+                      unit: 'px',
+                      value: 10,
+                    },
+                    paddingBottom: {
+                      unit: 'px',
+                      value: 10,
+                    },
+                  },
+                  deviceId: 'desktop',
+                },
+              ],
+              children: {
+                value: {
+                  columns: [
+                    {
+                      value: {
+                        count: 12,
+                        spans: [[6, 6]],
+                      },
+                      deviceId: 'desktop',
+                    },
+                  ],
+                  elements: [
+                    {
+                      key: 'f46bb567-8964-4606-b544-295b4b7d05fd',
+                      type: './components/Box/index.js',
+                      props: {
+                        padding: [
+                          {
+                            value: {
+                              paddingTop: {
+                                unit: 'px',
+                                value: 10,
+                              },
+                              paddingLeft: {
+                                unit: 'px',
+                                value: 10,
+                              },
+                              paddingRight: {
+                                unit: 'px',
+                                value: 10,
+                              },
+                              paddingBottom: {
+                                unit: 'px',
+                                value: 10,
+                              },
+                            },
+                            deviceId: 'desktop',
+                          },
+                        ],
+                        children: {
+                          value: {
+                            columns: [
+                              {
+                                value: {
+                                  count: 12,
+                                  spans: [[12]],
+                                },
+                                deviceId: 'desktop',
+                              },
+                            ],
+                            elements: [
+                              {
+                                key: 'c5010c7f-2eec-4042-abc8-be48836f8aef',
+                                type: './components/Button/index.js',
+                                props: {},
+                              },
+                            ],
+                          },
+                          '@@makeswift/type': 'prop-controllers::grid::v1',
+                        },
+                      },
+                    },
+                    {
+                      key: '7039524a-c2a1-42be-9988-a799c21fe734',
+                      type: './components/Box/index.js',
+                      props: {
+                        padding: [
+                          {
+                            value: {
+                              paddingTop: {
+                                unit: 'px',
+                                value: 10,
+                              },
+                              paddingLeft: {
+                                unit: 'px',
+                                value: 10,
+                              },
+                              paddingRight: {
+                                unit: 'px',
+                                value: 10,
+                              },
+                              paddingBottom: {
+                                unit: 'px',
+                                value: 10,
+                              },
+                            },
+                            deviceId: 'desktop',
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+                '@@makeswift/type': 'prop-controllers::grid::v1',
+              },
+            },
+          },
+        ],
+      },
+      right: {
+        columns: [
+          {
+            value: {
+              count: 12,
+              spans: [[12]],
+            },
+            deviceId: 'desktop',
+          },
+        ],
+        elements: [
+          {
+            key: '618f069e-9515-4546-8abc-75cec6d33af4',
+            type: './components/Box/index.js',
+            props: {
+              padding: [
+                {
+                  value: {
+                    paddingTop: {
+                      unit: 'px',
+                      value: 10,
+                    },
+                    paddingLeft: {
+                      unit: 'px',
+                      value: 10,
+                    },
+                    paddingRight: {
+                      unit: 'px',
+                      value: 10,
+                    },
+                    paddingBottom: {
+                      unit: 'px',
+                      value: 10,
+                    },
+                  },
+                  deviceId: 'desktop',
+                },
+              ],
+              children: {
+                value: {
+                  columns: [
+                    {
+                      value: {
+                        count: 12,
+                        spans: [[12]],
+                      },
+                      deviceId: 'desktop',
+                    },
+                  ],
+                  elements: [
+                    {
+                      key: '9745df8d-1589-46fd-8320-f3238bb94cbe',
+                      type: './components/Box/index.js',
+                      props: {
+                        padding: [
+                          {
+                            value: {
+                              paddingTop: {
+                                unit: 'px',
+                                value: 10,
+                              },
+                              paddingLeft: {
+                                unit: 'px',
+                                value: 10,
+                              },
+                              paddingRight: {
+                                unit: 'px',
+                                value: 10,
+                              },
+                              paddingBottom: {
+                                unit: 'px',
+                                value: 10,
+                              },
+                            },
+                            deviceId: 'desktop',
+                          },
+                        ],
+                        children: {
+                          value: {
+                            columns: [
+                              {
+                                value: {
+                                  count: 12,
+                                  spans: [[12]],
+                                },
+                                deviceId: 'desktop',
+                              },
+                            ],
+                            elements: [
+                              {
+                                key: '92fd0115-ff8f-4218-b23f-9f861166ef35',
+                                type: './components/Image/index.js',
+                                props: {},
+                              },
+                            ],
+                          },
+                          '@@makeswift/type': 'prop-controllers::grid::v1',
+                        },
+                      },
+                    },
+                  ],
+                },
+                '@@makeswift/type': 'prop-controllers::grid::v1',
+              },
+            },
+          },
+        ],
+      },
+    },
+  },
+
+  afterReset: {
+    type: 'Demo',
+    key: '38bf059f-9a17-4626-bec4-e286130fd9da',
+    props: {
+      left: {
+        columns: [
+          {
+            value: {
+              count: 12,
+              spans: [[12]],
+            },
+            deviceId: 'desktop',
+          },
+        ],
+        elements: [
+          {
+            key: '6ddc735a-3098-410a-b3b6-801f4ae1a0be',
+            type: './components/Button/index.js',
+            props: {},
+          },
+        ],
+      },
+    },
+  },
+}


### PR DESCRIPTION
Do not show an error message for reset ops with an empty path. Also correctly handle element deletion on resets.