### PR TITLE
refactor(runtime): decouple api handler endpoints from Next.js draft mode

### DIFF
--- a/.changeset/tidy-dragons-sing.md
+++ b/.changeset/tidy-dragons-sing.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+refactor: reconfigure `MakeswiftAPIHandler` endpoints to not rely on Next.js's draft mode, and instead request resource versions using an explicit header

--- a/packages/runtime/src/api/react.ts
+++ b/packages/runtime/src/api/react.ts
@@ -19,6 +19,7 @@ import {
   CreateTableRecordMutationResult,
   CreateTableRecordMutationVariables,
 } from './graphql/generated/types'
+import { MakeswiftSiteVersion } from './site-version'
 
 export type CacheData = MakeswiftApiClient.SerializedState
 
@@ -51,17 +52,28 @@ export const CacheData = {
  * snapshot for use in the builder, not the lives pages.
  */
 export class MakeswiftHostApiClient {
+  siteVersion: MakeswiftSiteVersion
   graphqlClient: GraphQLClient
   makeswiftApiClient: MakeswiftApiClient.Store
   subscribe: MakeswiftApiClient.Store['subscribe']
 
-  constructor({ uri, cacheData, locale }: { uri: string; cacheData?: CacheData; locale?: string }) {
+  constructor({
+    uri,
+    siteVersion,
+    cacheData,
+    locale,
+  }: {
+    uri: string
+    siteVersion: MakeswiftSiteVersion
+    cacheData?: CacheData
+    locale?: string
+  }) {
     this.graphqlClient = new GraphQLClient(uri)
     this.makeswiftApiClient = MakeswiftApiClient.configureStore({
       serializedState: cacheData,
       defaultLocale: locale,
     })
-
+    this.siteVersion = siteVersion
     this.subscribe = this.makeswiftApiClient.subscribe
   }
 
@@ -75,7 +87,7 @@ export class MakeswiftHostApiClient {
 
   async fetchSwatch(swatchId: string): Promise<Swatch | null> {
     return await this.makeswiftApiClient.dispatch(
-      MakeswiftApiClient.fetchAPIResource(APIResourceType.Swatch, swatchId),
+      MakeswiftApiClient.fetchAPIResource(APIResourceType.Swatch, swatchId, this.siteVersion),
     )
   }
 
@@ -97,7 +109,7 @@ export class MakeswiftHostApiClient {
 
   async fetchFile(fileId: string): Promise<File | null> {
     return await this.makeswiftApiClient.dispatch(
-      MakeswiftApiClient.fetchAPIResource(APIResourceType.File, fileId),
+      MakeswiftApiClient.fetchAPIResource(APIResourceType.File, fileId, this.siteVersion),
     )
   }
 
@@ -119,7 +131,11 @@ export class MakeswiftHostApiClient {
 
   async fetchTypography(typographyId: string): Promise<Typography | null> {
     return await this.makeswiftApiClient.dispatch(
-      MakeswiftApiClient.fetchAPIResource(APIResourceType.Typography, typographyId),
+      MakeswiftApiClient.fetchAPIResource(
+        APIResourceType.Typography,
+        typographyId,
+        this.siteVersion,
+      ),
     )
   }
 
@@ -141,7 +157,11 @@ export class MakeswiftHostApiClient {
 
   async fetchGlobalElement(globalElementId: string): Promise<GlobalElement | null> {
     return await this.makeswiftApiClient.dispatch(
-      MakeswiftApiClient.fetchAPIResource(APIResourceType.GlobalElement, globalElementId),
+      MakeswiftApiClient.fetchAPIResource(
+        APIResourceType.GlobalElement,
+        globalElementId,
+        this.siteVersion,
+      ),
     )
   }
 
@@ -171,6 +191,7 @@ export class MakeswiftHostApiClient {
       MakeswiftApiClient.fetchAPIResource(
         APIResourceType.LocalizedGlobalElement,
         globalElementId,
+        this.siteVersion,
         locale,
       ),
     )
@@ -199,7 +220,12 @@ export class MakeswiftHostApiClient {
     locale: string | null
   }): Promise<PagePathnameSlice | null> {
     return await this.makeswiftApiClient.dispatch(
-      MakeswiftApiClient.fetchAPIResource(APIResourceType.PagePathnameSlice, pageId, locale),
+      MakeswiftApiClient.fetchAPIResource(
+        APIResourceType.PagePathnameSlice,
+        pageId,
+        this.siteVersion,
+        locale,
+      ),
     )
   }
 
@@ -252,7 +278,7 @@ export class MakeswiftHostApiClient {
 
   async fetchTable(tableId: string): Promise<Table | null> {
     return await this.makeswiftApiClient.dispatch(
-      MakeswiftApiClient.fetchAPIResource(APIResourceType.Table, tableId),
+      MakeswiftApiClient.fetchAPIResource(APIResourceType.Table, tableId, this.siteVersion),
     )
   }
 

--- a/packages/runtime/src/api/site-version.ts
+++ b/packages/runtime/src/api/site-version.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod'
+
+export const makeswiftSiteVersionSchema = z.enum(['Live', 'Working'])
+export const MakeswiftSiteVersion = makeswiftSiteVersionSchema.Enum
+export type MakeswiftSiteVersion = z.infer<typeof makeswiftSiteVersionSchema>
+
+export const API_HANDLER_SITE_VERSION_HEADER = 'X-Makeswift-Site-Version'

--- a/packages/runtime/src/next/api-handler/handlers/proxy-draft-mode.ts
+++ b/packages/runtime/src/next/api-handler/handlers/proxy-draft-mode.ts
@@ -4,7 +4,7 @@ import { P, match } from 'ts-pattern'
 import { cookies, draftMode } from 'next/headers'
 
 import { MAKESWIFT_DRAFT_MODE_DATA_COOKIE, MakeswiftDraftData } from '../../draft-mode'
-import { MakeswiftSiteVersion } from '../../preview-mode'
+import { MakeswiftSiteVersion } from '../../../api/site-version'
 
 type Context = { params: { [key: string]: string | string[] } }
 

--- a/packages/runtime/src/next/api-handler/handlers/proxy-preview-mode.ts
+++ b/packages/runtime/src/next/api-handler/handlers/proxy-preview-mode.ts
@@ -1,7 +1,8 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { MakeswiftPreviewData, MakeswiftSiteVersion } from '../../preview-mode'
+import { MakeswiftPreviewData } from '../../preview-mode'
 import { NextRequest, NextResponse } from 'next/server'
 import { P, match } from 'ts-pattern'
+import { MakeswiftSiteVersion } from '../../../api/site-version'
 
 type Context = { params: { [key: string]: string | string[] } }
 

--- a/packages/runtime/src/next/client.ts
+++ b/packages/runtime/src/next/client.ts
@@ -40,7 +40,8 @@ import {
   getPropControllerDescriptors,
   isElementReference,
 } from '../state/react-page'
-import { getMakeswiftSiteVersion, MakeswiftSiteVersion } from './preview-mode'
+import { getMakeswiftSiteVersion } from './preview-mode'
+import { MakeswiftSiteVersion } from '../api/site-version'
 import { toIterablePaginationResult } from './utils/pagination'
 import { deterministicUUID } from '../utils/deterministic-uuid'
 import { Schema } from '@makeswift/controls'

--- a/packages/runtime/src/next/draft-mode/index.tsx
+++ b/packages/runtime/src/next/draft-mode/index.tsx
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { cookies, draftMode } from 'next/headers'
-import { makeswiftSiteVersionSchema, MakeswiftSiteVersion } from '../preview-mode'
+import { MakeswiftSiteVersion, makeswiftSiteVersionSchema } from '../../api/site-version'
 
 export const MAKESWIFT_DRAFT_MODE_DATA_COOKIE = 'x-makeswift-draft-data'
 

--- a/packages/runtime/src/next/preview-mode.tsx
+++ b/packages/runtime/src/next/preview-mode.tsx
@@ -1,10 +1,7 @@
 import { PreviewData } from 'next'
 import { z } from 'zod'
 import { ActionTypes } from '../react'
-
-export const makeswiftSiteVersionSchema = z.enum(['Live', 'Working'])
-export const MakeswiftSiteVersion = makeswiftSiteVersionSchema.Enum
-export type MakeswiftSiteVersion = z.infer<typeof makeswiftSiteVersionSchema>
+import { type MakeswiftSiteVersion, makeswiftSiteVersionSchema } from '../api/site-version'
 
 const makeswiftPreviewDataSchema = z.object({
   makeswift: z.literal(true),

--- a/packages/runtime/src/next/tests/client.get-component-snapshot.test.ts
+++ b/packages/runtime/src/next/tests/client.get-component-snapshot.test.ts
@@ -4,7 +4,7 @@ import { http, HttpResponse, graphql } from 'msw'
 import { ReactRuntime } from '../../runtimes/react'
 
 import { server } from '../../mocks/server'
-import { MakeswiftSiteVersion } from '../preview-mode'
+import { MakeswiftSiteVersion } from '../../api/site-version'
 
 const TEST_API_KEY = 'myApiKey'
 const apiOrigin = 'https://api.fakeswift.com'

--- a/packages/runtime/src/runtimes/react/components/RuntimeProvider.tsx
+++ b/packages/runtime/src/runtimes/react/components/RuntimeProvider.tsx
@@ -6,6 +6,7 @@ import { MakeswiftHostApiClient } from '../../../api/react'
 import { ReactRuntimeContext } from '../hooks/use-react-runtime'
 import { ReactRuntime } from '../react-runtime'
 import { MakeswiftHostApiClientProvider } from '../host-api-client'
+import { MakeswiftSiteVersion } from '../../../api/site-version'
 
 const LiveProvider = lazy(() => import('./LiveProvider'))
 const PreviewProvider = lazy(() => import('./PreviewProvider'))
@@ -28,8 +29,9 @@ export function ReactRuntimeProvider({
       new MakeswiftHostApiClient({
         uri: new URL('graphql', apiOrigin).href,
         locale,
+        siteVersion: previewMode ? MakeswiftSiteVersion.Working : MakeswiftSiteVersion.Live,
       }),
-    [apiOrigin, locale],
+    [apiOrigin, locale, previewMode],
   )
 
   const StoreProvider = previewMode ? PreviewProvider : LiveProvider

--- a/packages/runtime/src/runtimes/react/host-api-client.tsx
+++ b/packages/runtime/src/runtimes/react/host-api-client.tsx
@@ -2,9 +2,13 @@
 
 import { ReactNode, createContext, useContext } from 'react'
 import { MakeswiftHostApiClient } from '../../api/react'
+import { MakeswiftSiteVersion } from '../../api/site-version'
 
 const Context = createContext(
-  new MakeswiftHostApiClient({ uri: 'https://api.makeswift.com/graphql' }),
+  new MakeswiftHostApiClient({
+    uri: 'https://api.makeswift.com/graphql',
+    siteVersion: MakeswiftSiteVersion.Live,
+  }),
 )
 
 export function useMakeswiftHostApiClient(): MakeswiftHostApiClient {


### PR DESCRIPTION


Refactor the API Handler to no longer rely on API requests being proxied. Instead, the host client is configured to retrieve certain versions of resources based on an explicit version passed to it.