### PR TITLE
feat: introduce draft proxy utility functions

### DIFF
--- a/.changeset/kind-dryers-beam.md
+++ b/.changeset/kind-dryers-beam.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+feat: introduces experimental APIs for replacing the proxy rewrite endpoint with middleware

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -58,6 +58,11 @@
       "import": "./dist/esm/next/index.js",
       "types": "./dist/types/next/index.d.ts"
     },
+    "./next/middleware": {
+      "require": "./dist/cjs/next/middleware/index.js",
+      "import": "./dist/esm/next/middleware/index.js",
+      "types": "./dist/types/next/middleware/index.d.ts"
+    },
     "./next/document": {
       "require": "./dist/cjs/next/document.js",
       "module": "./dist/esm/next/document.js",
@@ -143,6 +148,7 @@
     "@types/uuid": "^9.0.1",
     "@use-gesture/react": "^10.2.24",
     "color": "^3.1.3",
+    "cookie": "^1.0.2",
     "corporate-ipsum": "^1.0.1",
     "cors": "^2.8.5",
     "css-box-model": "^1.2.1",
@@ -163,6 +169,7 @@
     "redux-thunk": "^2.3.0",
     "reselect": "^5.1.1",
     "scroll-into-view-if-needed": "^2.2.20",
+    "set-cookie-parser": "^2.7.1",
     "slate": "^0.91.4",
     "slate-hyperscript": "^0.77.0",
     "slate-react": "^0.91.7",
@@ -189,6 +196,8 @@
     "@types/node": "^17.0.21",
     "@types/react": "^18.2.14",
     "@types/react-dom": "^18.2.6",
+    "@types/set-cookie-parser": "^2.4.10",
+    "@types/web": "^0.0.208",
     "concurrently": "^5.3.0",
     "expect-type": "^0.19.0",
     "jest": "^29.7.0",

--- a/packages/runtime/src/next/api-handler/handlers/draft-mode.ts
+++ b/packages/runtime/src/next/api-handler/handlers/draft-mode.ts
@@ -1,0 +1,106 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { NextRequest, NextResponse } from 'next/server'
+import { P, match } from 'ts-pattern'
+import { cookies, draftMode } from 'next/headers'
+import { MakeswiftSiteVersion } from '../../../api/site-version'
+
+const PRERENDER_BYPASS_COOKIE = '__prerender_bypass'
+const DRAFT_DATA_COOKIE = 'x-makeswift-draft-data'
+
+type Context = { params: { [key: string]: string | string[] } }
+
+type DraftModeError = string
+
+type Response = { __brand: 'DraftModeResponse' }
+
+export type DraftModeResponse = DraftModeError | Response
+
+type DraftModeHandlerArgs =
+  | [request: NextRequest, context: Context, params: { apiKey: string }]
+  | [req: NextApiRequest, res: NextApiResponse<DraftModeResponse>, params: { apiKey: string }]
+
+const routeHandlerPattern = [P.instanceOf(Request), P.any, P.any] as const
+const apiRoutePattern = [P.any, P.any, P.any] as const
+
+export default async function draftModeHandler(
+  request: NextRequest,
+  context: Context,
+  { apiKey }: { apiKey: string },
+): Promise<NextResponse<DraftModeResponse>>
+export default async function draftModeHandler(
+  req: NextApiRequest,
+  res: NextApiResponse<DraftModeResponse>,
+  { apiKey }: { apiKey: string },
+): Promise<void>
+export default async function draftModeHandler(
+  ...args: DraftModeHandlerArgs
+): Promise<NextResponse<DraftModeResponse> | void> {
+  return match(args)
+    .with(routeHandlerPattern, args => draftModeRouteHandler(...args))
+    .with(apiRoutePattern, args => draftModeApiRouteHandler(...args))
+    .exhaustive()
+}
+
+async function draftModeRouteHandler(
+  request: NextRequest,
+  _context: Context,
+  { apiKey }: { apiKey: string },
+): Promise<NextResponse<DraftModeResponse>> {
+  const secret = request.nextUrl.searchParams.get('secret')
+
+  if (secret == null) {
+    return new NextResponse('Unauthorized to enable draft mode: no secret provided', {
+      status: 401,
+    })
+  }
+  if (secret !== apiKey) {
+    return new NextResponse('Unauthorized to enable draft mode: incorrect secret', { status: 401 })
+  }
+
+  const draft = await draftMode()
+  const cookieStore = await cookies()
+
+  draft.enable()
+
+  const bypassCookie = cookieStore.get(PRERENDER_BYPASS_COOKIE)
+
+  if (bypassCookie?.value == null) {
+    return new NextResponse('Could not retrieve draft mode bypass cookie', { status: 500 })
+  }
+
+  cookieStore.set({
+    name: bypassCookie.name,
+    value: bypassCookie.value,
+    sameSite: 'none',
+    secure: true,
+    partitioned: true,
+  })
+
+  cookieStore.set({
+    name: DRAFT_DATA_COOKIE,
+    // Eventually, we can make the value dynamic using the request
+    value: JSON.stringify({ makeswift: true, siteVersion: MakeswiftSiteVersion.Working }),
+    sameSite: 'none',
+    secure: true,
+    partitioned: true,
+  })
+
+  const siteVersionCookie = cookieStore.get(DRAFT_DATA_COOKIE)
+
+  if (siteVersionCookie?.value == null) {
+    return new NextResponse('Could not retrieve draft mode site version cookie', { status: 500 })
+  }
+
+  return NextResponse.json({ __brand: 'DraftModeResponse' })
+}
+
+async function draftModeApiRouteHandler(
+  _req: NextApiRequest,
+  res: NextApiResponse<DraftModeResponse>,
+  {}: { apiKey: string },
+): Promise<void> {
+  const message =
+    'Cannot request draft endpoint from an API handler registered in `pages`. Move your Makeswift API handler to the `app` directory'
+  console.error(message)
+  return res.status(500).send(message)
+}

--- a/packages/runtime/src/next/api-handler/handlers/preview-mode.ts
+++ b/packages/runtime/src/next/api-handler/handlers/preview-mode.ts
@@ -1,0 +1,101 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { NextRequest, NextResponse } from 'next/server'
+import { P, match } from 'ts-pattern'
+import { parse as parseSetCookie } from 'set-cookie-parser'
+import { serialize as serializeCookie } from 'cookie'
+import { MakeswiftSiteVersion } from '../../../api/site-version'
+
+const SET_COOKIE_HEADER = 'set-cookie'
+const PRERENDER_BYPASS_COOKIE = '__prerender_bypass'
+const PREVIEW_DATA_COOKIE = '__next_preview_data'
+
+type Context = { params: { [key: string]: string | string[] } }
+
+type PreviewModeError = string
+
+type Response = { __brand: 'PreviewModeResponse' }
+
+export type PreviewModeResponse = PreviewModeError | Response
+
+type PreviewModeHandlerArgs =
+  | [request: NextRequest, context: Context, params: { apiKey: string }]
+  | [req: NextApiRequest, res: NextApiResponse<PreviewModeResponse>, params: { apiKey: string }]
+
+const routeHandlerPattern = [P.instanceOf(Request), P.any, P.any] as const
+const apiRoutePattern = [P.any, P.any, P.any] as const
+
+export default async function previewModeHandler(
+  request: NextRequest,
+  context: Context,
+  { apiKey }: { apiKey: string },
+): Promise<NextResponse<PreviewModeResponse>>
+export default async function previewModeHandler(
+  req: NextApiRequest,
+  res: NextApiResponse<PreviewModeResponse>,
+  { apiKey }: { apiKey: string },
+): Promise<void>
+export default async function previewModeHandler(
+  ...args: PreviewModeHandlerArgs
+): Promise<NextResponse<PreviewModeResponse> | void> {
+  return match(args)
+    .with(routeHandlerPattern, args => previewModeRouteHandler(...args))
+    .with(apiRoutePattern, args => previewModeApiRouteHandler(...args))
+    .exhaustive()
+}
+
+async function previewModeRouteHandler(
+  _request: NextRequest,
+  _context: Context,
+  {}: { apiKey: string },
+): Promise<NextResponse<PreviewModeResponse>> {
+  const message =
+    'Cannot request preview endpoint from an API handler registered in `app`. Move your Makeswift API handler to the `pages/api` directory'
+  console.error(message)
+  return NextResponse.json(message, { status: 500 })
+}
+
+async function previewModeApiRouteHandler(
+  req: NextApiRequest,
+  res: NextApiResponse<PreviewModeResponse>,
+  { apiKey }: { apiKey: string },
+): Promise<void> {
+  const secret = req.query.secret
+
+  if (secret == null) {
+    return res.status(401).send('Unauthorized to enable preview mode: no secret provided')
+  }
+  if (secret !== apiKey) {
+    return res.status(401).send('Unauthorized to enable preview mode: secret is incorrect')
+  }
+
+  // Eventually, we can make the preview data value dynamic using the request
+  const setCookie = res
+    .setPreviewData({ makeswift: true, siteVersion: MakeswiftSiteVersion.Working })
+    .getHeader(SET_COOKIE_HEADER)
+
+  res.removeHeader(SET_COOKIE_HEADER)
+
+  const parsedCookies = parseSetCookie(Array.isArray(setCookie) ? setCookie : '')
+
+  const prerenderBypassCookie = parsedCookies.find(c => c.name === PRERENDER_BYPASS_COOKIE)
+  const previewDataCookie = parsedCookies.find(c => c.name === PREVIEW_DATA_COOKIE)
+
+  if (prerenderBypassCookie?.value == null || previewDataCookie?.value == null) {
+    return res.status(500).send('Could not retrieve preview mode cookies')
+  }
+
+  const patchedCookies = [prerenderBypassCookie, previewDataCookie].map(
+    ({ name, value, ...options }) => {
+      return serializeCookie(name, value, {
+        ...options,
+        sameSite: 'none',
+        secure: true,
+        partitioned: true,
+      })
+    },
+  )
+
+  res.setHeader(SET_COOKIE_HEADER, patchedCookies)
+
+  return res.json({ __brand: 'PreviewModeResponse' })
+}

--- a/packages/runtime/src/next/api-handler/index.ts
+++ b/packages/runtime/src/next/api-handler/index.ts
@@ -10,6 +10,8 @@ import fonts, { Font, FontsResponse, GetFonts } from './handlers/fonts'
 import manifest, { Manifest, ManifestResponse } from './handlers/manifest'
 import proxyPreviewMode, { ProxyPreviewModeResponse } from './handlers/proxy-preview-mode'
 import proxyDraftMode, { ProxyDraftModeResponse } from './handlers/proxy-draft-mode'
+import draftMode, { type DraftModeResponse } from './handlers/draft-mode'
+import previewMode, { type PreviewModeResponse } from './handlers/preview-mode'
 import { revalidate, RevalidationResponse } from './handlers/revalidate'
 import translatableData, { TranslatableDataResponse } from './handlers/translatable-data'
 import mergeTranslatedData, { TranslatedDataResponse } from './handlers/merge-translated-data'
@@ -41,6 +43,8 @@ export type MakeswiftApiHandlerResponse =
   | RevalidationResponse
   | ProxyPreviewModeResponse
   | ProxyDraftModeResponse
+  | DraftModeResponse
+  | PreviewModeResponse
   | FontsResponse
   | ElementTreeResponse
   | TranslatableDataResponse
@@ -181,6 +185,20 @@ export function MakeswiftApiHandler(
       return match(args)
         .with(routeHandlerPattern, args => proxyDraftMode(...args, { apiKey }))
         .with(apiRoutePattern, args => proxyDraftMode(...args, { apiKey }))
+        .exhaustive()
+    }
+
+    if (matches('/draft-mode')) {
+      return match(args)
+        .with(routeHandlerPattern, args => draftMode(...args, { apiKey }))
+        .with(apiRoutePattern, args => draftMode(...args, { apiKey }))
+        .exhaustive()
+    }
+
+    if (matches('/preview-mode')) {
+      return match(args)
+        .with(routeHandlerPattern, args => previewMode(...args, { apiKey }))
+        .with(apiRoutePattern, args => previewMode(...args, { apiKey }))
         .exhaustive()
     }
 

--- a/packages/runtime/src/next/middleware/exceptions.ts
+++ b/packages/runtime/src/next/middleware/exceptions.ts
@@ -1,0 +1,20 @@
+export class MiddlewareError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options)
+    this.name = this.constructor.name
+
+    Error.captureStackTrace(this, this.constructor)
+  }
+}
+
+export class InvariantDraftRequestError extends MiddlewareError {}
+
+export class UnauthorizedDraftRequestError extends MiddlewareError {}
+
+export class UnparseableDraftCookieResponseError extends MiddlewareError {}
+
+export class MissingDraftEndpointError extends MiddlewareError {}
+
+export class UnknownDraftFetchRequestError extends MiddlewareError {}
+
+export class InvalidProxyRequestInputError extends MiddlewareError {}

--- a/packages/runtime/src/next/middleware/index.ts
+++ b/packages/runtime/src/next/middleware/index.ts
@@ -1,0 +1,7 @@
+export {
+  isDraftModeRequest as unstable_isDraftModeRequest,
+  isPreviewModeRequest as unstable_isPreviewModeRequest,
+  getDraftSecret as unstable_getMakeswiftDraftSecret,
+  createDraftRequest as unstable_createMakeswiftDraftRequest,
+  fetchDraftProxyResponse as unstable_fetchMakeswiftDraftProxyResponse,
+} from './request-utils'

--- a/packages/runtime/src/next/middleware/request-utils.test.ts
+++ b/packages/runtime/src/next/middleware/request-utils.test.ts
@@ -1,0 +1,283 @@
+import { http } from 'msw'
+import { server } from '../../mocks/server'
+import { NextRequest } from 'next/server'
+import {
+  createDraftRequest,
+  fetchDraftProxyResponse,
+  getDraftSecret,
+  isDraftModeRequest,
+  isPreviewModeRequest,
+} from './request-utils'
+import {
+  InvalidProxyRequestInputError,
+  InvariantDraftRequestError,
+  MissingDraftEndpointError,
+  UnauthorizedDraftRequestError,
+  UnknownDraftFetchRequestError,
+  UnparseableDraftCookieResponseError,
+} from './exceptions'
+
+const TEST_SECRET = 'my-secret-api-key'
+const TEST_ORIGIN = 'https://localhost:3001'
+const TEST_PATH = `${TEST_ORIGIN}/page`
+
+describe('middleware proxy utils', () => {
+  beforeAll(() => {
+    server.listen()
+  })
+
+  afterAll(() => {
+    server.close()
+  })
+
+  afterEach(() => {
+    server.resetHandlers()
+  })
+
+  describe('isDraftModeRequest', () => {
+    test.each([
+      [
+        'draft mode search param present',
+        new NextRequest(new URL(`${TEST_PATH}?x-makeswift-draft-mode=${TEST_SECRET}`)),
+        true,
+      ],
+      [
+        'draft mode header present',
+        new NextRequest(new URL(TEST_PATH), { headers: { 'X-Makeswift-Draft-Mode': TEST_SECRET } }),
+        true,
+      ],
+      [
+        'preview mode search param present',
+        new NextRequest(new URL(`${TEST_PATH}?x-makeswift-preview-mode=${TEST_SECRET}`)),
+        false,
+      ],
+      [
+        'preview mode header present',
+        new NextRequest(new URL(TEST_PATH), {
+          headers: { 'X-Makeswift-Preview-Mode': TEST_SECRET },
+        }),
+        false,
+      ],
+      ['normal request', new NextRequest(new URL(TEST_PATH)), false],
+    ])('request with %s', (_name, request, expected) => {
+      expect(isDraftModeRequest(request)).toBe(expected)
+    })
+  })
+
+  describe('isPreviewModeRequest', () => {
+    test.each([
+      [
+        'draft mode search param present',
+        new NextRequest(new URL(`${TEST_PATH}?x-makeswift-draft-mode=${TEST_SECRET}`)),
+        false,
+      ],
+      [
+        'draft mode header present',
+        new NextRequest(new URL(TEST_PATH), { headers: { 'X-Makeswift-Draft-Mode': TEST_SECRET } }),
+        false,
+      ],
+      [
+        'preview mode search param present',
+        new NextRequest(new URL(`${TEST_PATH}?x-makeswift-preview-mode=${TEST_SECRET}`)),
+        true,
+      ],
+      [
+        'preview mode header present',
+        new NextRequest(new URL(TEST_PATH), {
+          headers: { 'X-Makeswift-Preview-Mode': TEST_SECRET },
+        }),
+        true,
+      ],
+      ['normal request', new NextRequest(new URL(TEST_PATH)), false],
+    ])('request with %s', (_name, request, expected) => {
+      expect(isPreviewModeRequest(request)).toBe(expected)
+    })
+  })
+
+  describe('getDraftSecret', () => {
+    test.each([
+      [
+        'search param',
+        new NextRequest(new URL(`${TEST_PATH}?x-makeswift-draft-mode=${TEST_SECRET}`)),
+      ],
+      [
+        'header',
+        new NextRequest(new URL(TEST_PATH), {
+          headers: { 'X-Makeswift-Draft-Mode': TEST_SECRET },
+        }),
+      ],
+    ])('gets secret from %s', (_name, request) => {
+      expect(getDraftSecret(request)).toEqual(TEST_SECRET)
+    })
+
+    test('returns null when no secret available', () => {
+      const req = new NextRequest(new URL(TEST_PATH))
+      expect(getDraftSecret(req)).toBe(null)
+    })
+
+    test('throws InvariantRequestError when draft/preview secrets are present', () => {
+      const req = new NextRequest(new URL(TEST_PATH), {
+        headers: { 'X-Makeswift-Draft-Mode': TEST_SECRET, 'X-Makeswift-Preview-Mode': TEST_SECRET },
+      })
+      expect(() => getDraftSecret(req)).toThrow(InvariantDraftRequestError)
+    })
+  })
+
+  describe('createDraftRequest', () => {
+    test.each([
+      [
+        'request secret does not match',
+        new NextRequest(new URL(`${TEST_PATH}?x-makeswift-draft-mode=DOES-NOT-MATCH`)),
+      ],
+      ['secret is not present', new NextRequest(new URL(TEST_PATH))],
+    ])('returns `null` when %s', async (_name, request) => {
+      expect(await createDraftRequest(request, TEST_SECRET)).toBe(null)
+    })
+
+    test('attaches cookies from draft endpoint to returned request', async () => {
+      // Arrange
+      const SAMPLE_COOKIE_NAME = '__prerender-bypass'
+      const SAMPLE_COOKIE_VALUE = '1234567890'
+
+      server.use(
+        http.get(
+          `${TEST_ORIGIN}/api/makeswift/draft-mode`,
+          () =>
+            new Response(null, {
+              headers: { 'set-cookie': `${SAMPLE_COOKIE_NAME}=${SAMPLE_COOKIE_VALUE}` },
+            }),
+        ),
+      )
+
+      const req = new NextRequest(new URL(`${TEST_PATH}?x-makeswift-draft-mode=${TEST_SECRET}`))
+
+      // Act
+      const draftReq = await createDraftRequest(req, TEST_SECRET)
+
+      // Assert
+      expect(draftReq?.cookies.get(SAMPLE_COOKIE_NAME)).toEqual({
+        name: SAMPLE_COOKIE_NAME,
+        value: SAMPLE_COOKIE_VALUE,
+      })
+      expect(draftReq?.nextUrl.href.includes('x-makeswift-draft-mode')).toBe(false)
+      expect(draftReq?.nextUrl.href.includes('x-makeswift-preview-mode')).toBe(false)
+      expect(draftReq?.headers.has('x-makeswift-preview-mode')).toBe(false)
+      expect(draftReq?.headers.has('x-makeswift-draft-mode')).toBe(false)
+    })
+
+    test('throws error if endpoint does not return cookies', async () => {
+      // Arrange
+      server.use(http.get(`${TEST_ORIGIN}/api/makeswift/draft-mode`, () => new Response(null)))
+
+      const req = new NextRequest(new URL(`${TEST_PATH}?x-makeswift-draft-mode=${TEST_SECRET}`))
+
+      // Act
+      const draftReq = createDraftRequest(req, TEST_SECRET)
+
+      // Assert
+      await expect(draftReq).rejects.toThrow(UnparseableDraftCookieResponseError)
+    })
+
+    test('throws MissingDraftEndpointError if endpoint 404s', async () => {
+      // Arrange
+      server.use(
+        http.get(
+          `${TEST_ORIGIN}/api/makeswift/draft-mode`,
+          () => new Response(null, { status: 404 }),
+        ),
+      )
+
+      const req = new NextRequest(new URL(`${TEST_PATH}?x-makeswift-draft-mode=${TEST_SECRET}`))
+
+      // Act
+      const draftReq = createDraftRequest(req, TEST_SECRET)
+
+      // Assert
+      await expect(draftReq).rejects.toThrow(MissingDraftEndpointError)
+    })
+
+    test('throws UnauthorizedDraftRequestError if endpoint 401s', async () => {
+      // Arrange
+      server.use(
+        http.get(
+          `${TEST_ORIGIN}/api/makeswift/draft-mode`,
+          () => new Response(null, { status: 401 }),
+        ),
+      )
+
+      const req = new NextRequest(new URL(`${TEST_PATH}?x-makeswift-draft-mode=${TEST_SECRET}`))
+
+      // Act
+      const draftReq = createDraftRequest(req, TEST_SECRET)
+
+      // Assert
+      await expect(draftReq).rejects.toThrow(UnauthorizedDraftRequestError)
+    })
+
+    test.each([
+      ['internal server error', 500],
+      ['unrecognized status code', 488],
+    ])('throws UnknownDraftFetchRequestError if endpoint has %s', async (_name, status) => {
+      // Arrange
+      server.use(
+        http.get(`${TEST_ORIGIN}/api/makeswift/draft-mode`, () => new Response(null, { status })),
+      )
+
+      const req = new NextRequest(new URL(`${TEST_PATH}?x-makeswift-draft-mode=${TEST_SECRET}`))
+
+      // Act
+      const draftReq = createDraftRequest(req, TEST_SECRET)
+
+      // Assert
+      await expect(draftReq).rejects.toThrow(UnknownDraftFetchRequestError)
+    })
+  })
+
+  describe('fetchDraftProxyResponse', () => {
+    test.each([
+      ['web request', new Request(TEST_PATH)],
+      ['NextRequest', new NextRequest(TEST_PATH)],
+      ['null', null],
+    ])('fails if input is %s', async (_name, req) => {
+      // @ts-expect-error Intentionally passing wrong types to simulate JS SDK users
+      const response = fetchDraftProxyResponse(req)
+
+      await expect(response).rejects.toThrow(InvalidProxyRequestInputError)
+    })
+
+    test('proxied response correctly transfers headers from response', async () => {
+      // Arrange
+      const SAMPLE_COOKIE_NAME = '__prerender-bypass'
+      const SAMPLE_COOKIE_VALUE = '1234567890'
+
+      server.use(
+        http.get(
+          `${TEST_ORIGIN}/api/makeswift/draft-mode`,
+          () =>
+            new Response(null, {
+              headers: { 'set-cookie': `${SAMPLE_COOKIE_NAME}=${SAMPLE_COOKIE_VALUE}` },
+            }),
+        ),
+      )
+
+      server.use(
+        http.get(
+          TEST_PATH,
+          () => new Response('proxy response body', { headers: { 'x-proxied-sample': '1' } }),
+        ),
+      )
+
+      const req = new NextRequest(new URL(`${TEST_PATH}?x-makeswift-draft-mode=${TEST_SECRET}`))
+
+      // Act
+      const draftReq = await createDraftRequest(req, TEST_SECRET)
+
+      // Assert
+      expect(draftReq).not.toBeNull()
+      if (draftReq == null) return
+
+      const proxyResponse = await fetchDraftProxyResponse(draftReq)
+      expect(proxyResponse.headers.has('x-proxied-sample'))
+    })
+  })
+})

--- a/packages/runtime/src/next/middleware/request-utils.ts
+++ b/packages/runtime/src/next/middleware/request-utils.ts
@@ -1,0 +1,195 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  InvalidProxyRequestInputError,
+  InvariantDraftRequestError,
+  MiddlewareError,
+  MissingDraftEndpointError,
+  UnauthorizedDraftRequestError,
+  UnknownDraftFetchRequestError,
+  UnparseableDraftCookieResponseError,
+} from './exceptions'
+
+import { type Cookie, parse as parseSetCookie } from 'set-cookie-parser'
+
+const HeaderNames = {
+  DraftMode: 'X-Makeswift-Draft-Mode',
+  PreviewMode: 'X-Makeswift-Preview-Mode',
+} as const
+
+const SearchParams = {
+  DraftMode: 'x-makeswift-draft-mode',
+  PreviewMode: 'x-makeswift-preview-mode',
+} as const
+
+const CookieRequestEndpoints = {
+  DraftMode: '/api/makeswift/draft-mode',
+  PreviewMode: '/api/makeswift/preview-mode',
+} as const
+
+function getDraftModeSecret(request: NextRequest): string | null {
+  return (
+    request.nextUrl.searchParams.get(SearchParams.DraftMode) ??
+    request.headers.get(HeaderNames.DraftMode) ??
+    null
+  )
+}
+
+function getPreviewModeSecret(request: NextRequest): string | null {
+  return (
+    request.nextUrl.searchParams.get(SearchParams.PreviewMode) ??
+    request.headers.get(HeaderNames.PreviewMode) ??
+    null
+  )
+}
+
+export function isDraftModeRequest(request: NextRequest): boolean {
+  return getDraftModeSecret(request) != null
+}
+
+export function isPreviewModeRequest(request: NextRequest): boolean {
+  return getPreviewModeSecret(request) != null
+}
+
+export function isDraftRequest(request: NextRequest): boolean {
+  return isDraftModeRequest(request) || isPreviewModeRequest(request)
+}
+
+export function getDraftSecret(request: NextRequest): string | null {
+  const draftSecret = getDraftModeSecret(request)
+  const previewSecret = getPreviewModeSecret(request)
+  if (draftSecret != null && previewSecret != null) {
+    throw new InvariantDraftRequestError(
+      "Request can't include draft mode and preview mode secrets",
+    )
+  }
+  return draftSecret ?? previewSecret
+}
+
+async function fetchCookies(url: URL, draftSecret: string): Promise<Cookie[]> {
+  const requestUrl = new URL(url)
+  requestUrl.searchParams.set('secret', draftSecret)
+
+  const response = await fetch(requestUrl)
+    .then(res => {
+      if (res.ok) return res
+      if (res.status === 401) {
+        throw new UnauthorizedDraftRequestError(`Unauthorized draft request to ${url}`)
+      }
+      if (res.status === 404) {
+        throw new MissingDraftEndpointError(
+          `Could not find draft endpoint at ${url}. Please make sure you properly registered a \`MakeswiftApiHandler\``,
+        )
+      }
+      throw new UnknownDraftFetchRequestError(
+        'Encountered unknown error while fetching draft cookies',
+      )
+    })
+    .catch((err: unknown) => {
+      if (err instanceof MiddlewareError) throw err
+      throw new UnknownDraftFetchRequestError(
+        'Encountered unknown error while fetching draft cookies',
+        { cause: err },
+      )
+    })
+
+  const setCookieHeader = response.headers.getSetCookie()
+
+  if (setCookieHeader.length <= 0) {
+    throw new UnparseableDraftCookieResponseError(
+      "Received empty draft cookies. If you're seeing this error, please report a bug to https://github.com/makeswift/makeswift",
+    )
+  }
+
+  try {
+    return parseSetCookie(setCookieHeader)
+  } catch (err) {
+    throw new UnparseableDraftCookieResponseError(
+      "Could not parse draft cookies. If you're seeing this error, please report a bug to https://github.com/makeswift/makeswift",
+      { cause: err },
+    )
+  }
+}
+
+async function fetchDraftModeCookies(origin: string, draftSecret: string): Promise<Cookie[]> {
+  return await fetchCookies(new URL(CookieRequestEndpoints.DraftMode, origin), draftSecret)
+}
+
+async function fetchPreviewModeCookies(origin: string, draftSecret: string): Promise<Cookie[]> {
+  return await fetchCookies(new URL(CookieRequestEndpoints.PreviewMode, origin), draftSecret)
+}
+
+async function fetchDraftCookies(request: NextRequest, draftSecret: string): Promise<Cookie[]> {
+  if (isDraftModeRequest(request)) {
+    return await fetchDraftModeCookies(request.nextUrl.origin, draftSecret)
+  } else if (isPreviewModeRequest(request)) {
+    return await fetchPreviewModeCookies(request.nextUrl.origin, draftSecret)
+  }
+
+  return []
+}
+
+class MakeswiftDraftRequest extends NextRequest {}
+
+/**
+ * Creates a new `NextRequest` that can be used for fetching a working version
+ * of the page (that will also bypass the Vercel cache). Returns `null` if the
+ * given request does not have a draft secret that matches the `apiKey`.
+ */
+export async function createDraftRequest(
+  requestInit: NextRequest,
+  apiKey: string,
+): Promise<MakeswiftDraftRequest | null> {
+  const requestSecret = getDraftSecret(requestInit)
+
+  if (requestSecret == null || requestSecret !== apiKey) return null
+
+  const draftCookies = await fetchDraftCookies(requestInit, requestSecret)
+
+  // https://github.com/vercel/next.js/issues/52967#issuecomment-1644675602
+  // if we don't pass request twice, headers are stripped
+  const draftRequest = new MakeswiftDraftRequest(requestInit, requestInit)
+
+  draftCookies.forEach(({ name, value }) => {
+    draftRequest.cookies.set(name, value)
+  })
+
+  draftRequest.nextUrl.searchParams.delete(SearchParams.DraftMode)
+  draftRequest.nextUrl.searchParams.delete(SearchParams.PreviewMode)
+  draftRequest.headers.delete(HeaderNames.DraftMode)
+  draftRequest.headers.delete(HeaderNames.PreviewMode)
+
+  return draftRequest
+}
+
+export async function fetchDraftProxyResponse(
+  draftRequest: MakeswiftDraftRequest,
+): Promise<NextResponse> {
+  if (!(draftRequest instanceof MakeswiftDraftRequest)) {
+    throw new InvalidProxyRequestInputError(
+      'Draft request must be instance of `MakeswiftDraftRequest`',
+    )
+  }
+  // Passing `draftRequest.nextUrl` to fetch directly won't work when deployed
+  // on Vercel - it results in a `TypeError: Invalid URL` error. Constructing
+  // the URL works.
+  const proxyUrl = new URL(draftRequest.nextUrl, draftRequest.nextUrl.origin)
+  const proxyResponse = await fetch(proxyUrl, { headers: draftRequest.headers })
+
+  const response = new NextResponse(proxyResponse.body, {
+    headers: proxyResponse.headers,
+    status: proxyResponse.status,
+  })
+
+  // `fetch` automatically decompresses the response, but the response headers
+  // will keep the `content-encoding` and `content-length` headers. This will
+  // cause decoding issues if the client attempts to decompress the response
+  // again. To prevent  this, we remove these headers.
+  //
+  // See https://github.com/nodejs/undici/issues/2514.
+  if (response.headers.has('content-encoding')) {
+    response.headers.delete('content-encoding')
+    response.headers.delete('content-length')
+  }
+
+  return response
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -356,6 +356,9 @@ importers:
       color:
         specifier: ^3.1.3
         version: 3.2.1
+      cookie:
+        specifier: ^1.0.2
+        version: 1.0.2
       corporate-ipsum:
         specifier: ^1.0.1
         version: 1.0.1
@@ -416,6 +419,9 @@ importers:
       scroll-into-view-if-needed:
         specifier: ^2.2.20
         version: 2.2.29
+      set-cookie-parser:
+        specifier: ^2.7.1
+        version: 2.7.1
       slate:
         specifier: ^0.91.4
         version: 0.91.4
@@ -489,6 +495,12 @@ importers:
       '@types/react-dom':
         specifier: ^18.2.6
         version: 18.2.6
+      '@types/set-cookie-parser':
+        specifier: ^2.4.10
+        version: 2.4.10
+      '@types/web':
+        specifier: ^0.0.208
+        version: 0.0.208
       concurrently:
         specifier: ^5.3.0
         version: 5.3.0
@@ -2030,6 +2042,7 @@ packages:
   '@playwright/test@1.41.1':
     resolution: {integrity: sha512-9g8EWTjiQ9yFBXc6HjCWe41msLpxEX0KhmfmPl9RPLJdfzL4F0lg2BdJ91O9azFdl11y1pmpwdjBiSxvqc+btw==}
     engines: {node: '>=16'}
+    deprecated: Please update to the latest version of Playwright to test up-to-date browsers.
     hasBin: true
 
   '@popmotion/easing@1.0.2':
@@ -2565,6 +2578,9 @@ packages:
   '@types/semver@7.5.6':
     resolution: {integrity: sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==}
 
+  '@types/set-cookie-parser@2.4.10':
+    resolution: {integrity: sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==}
+
   '@types/stack-utils@2.0.1':
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
 
@@ -2582,6 +2598,9 @@ packages:
 
   '@types/uuid@9.0.1':
     resolution: {integrity: sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==}
+
+  '@types/web@0.0.208':
+    resolution: {integrity: sha512-YG5w2+B3w+s2cQwTVC7LErJun7p3lrO66bzfoH1hXN/8WtTHaXSLx7QKxDLTw0QqlJYdeUR+zSlwCZQccb+Gxg==}
 
   '@types/websocket@1.0.5':
     resolution: {integrity: sha512-NbsqiNX9CnEfC1Z0Vf4mE1SgAJ07JnRYcNex7AJ9zAVzmiGHmjKFEk7O4TJIsgv2B1sLEb6owKFZrACwdYngsQ==}
@@ -3349,6 +3368,10 @@ packages:
   cookie@0.5.0:
     resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
     engines: {node: '>= 0.6'}
+
+  cookie@1.0.2:
+    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
+    engines: {node: '>=18'}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -6543,6 +6566,9 @@ packages:
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+
+  set-cookie-parser@2.7.1:
+    resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
 
   set-function-length@1.2.0:
     resolution: {integrity: sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==}
@@ -10194,6 +10220,10 @@ snapshots:
 
   '@types/semver@7.5.6': {}
 
+  '@types/set-cookie-parser@2.4.10':
+    dependencies:
+      '@types/node': 20.14.11
+
   '@types/stack-utils@2.0.1': {}
 
   '@types/statuses@2.0.5': {}
@@ -10207,6 +10237,8 @@ snapshots:
   '@types/use-sync-external-store@0.0.3': {}
 
   '@types/uuid@9.0.1': {}
+
+  '@types/web@0.0.208': {}
 
   '@types/websocket@1.0.5':
     dependencies:
@@ -11190,6 +11222,8 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   cookie@0.5.0: {}
+
+  cookie@1.0.2: {}
 
   core-util-is@1.0.3: {}
 
@@ -15418,6 +15452,8 @@ snapshots:
       upper-case-first: 2.0.2
 
   set-blocking@2.0.0: {}
+
+  set-cookie-parser@2.7.1: {}
 
   set-function-length@1.2.0:
     dependencies:


### PR DESCRIPTION
Adds utility functions for getting draft/preview data and bypass tokens and constructing a proxy response. Will be used for bringing proxying capabilities to hosts that are currently patching requests with a bypass token in middleware, which does not work for SSGd pages.