### PR TITLE
fix: kitchen sink app router 404 page

### DIFF
--- a/apps/nextjs-app-router/src/app/[lang]/not-found.tsx
+++ b/apps/nextjs-app-router/src/app/[lang]/not-found.tsx
@@ -1,0 +1,11 @@
+export default function NotFound() {
+  return (
+    <div className="bg-white dark:bg-black h-screen w-screen flex justify-center items-center">
+      <div className="text-black dark:text-white flex items-center gap-3">
+        <span className="text-3xl font-semibold">404</span>
+        <span className="text-base">-</span>
+        <span className="text-base">The page could not be found</span>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Introduces a `not-found` so that the 404 page is properly rendered.

Before:

![CleanShot 2025-03-07 at 09 44 17](https://github.com/user-attachments/assets/f801002d-3fe6-4328-82d7-1709cd5b284d)

After: 
![CleanShot 2025-03-07 at 09 51 18](https://github.com/user-attachments/assets/71c89575-a2bc-4e58-a6a5-9cc6758e9672)
