### PR TITLE
fix: trigger resolution when resolvable in `useResolvedValue` changes

### DIFF
--- a/.changeset/hot-shoes-cheat.md
+++ b/.changeset/hot-shoes-cheat.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+fix: resolve issue with `Link` prop controller not updating when changed

--- a/packages/runtime/src/runtimes/react/hooks/use-resolved-value.ts
+++ b/packages/runtime/src/runtimes/react/hooks/use-resolved-value.ts
@@ -18,7 +18,7 @@ export function useResolvedValue<D, T>(
 
   useEffect(() => {
     resolvable.triggerResolve()
-  }, [])
+  }, [resolvable])
 
   return useSyncExternalStore(resolvable.subscribe, resolvable.readStable, resolvable.readStable)
 }


### PR DESCRIPTION
Regression was found when the builtin Link component (present on the builtin button, image, etc.) would not update links whenever prop data changed. This is because the builtin Link uses the `useResolvedValue` hook, which only triggers prop resolution on mount. Fixes the issue by triggering resolution whenever the resolvable constructed inside changes. Sister fix to: https://github.com/makeswift/makeswift/pull/955

Demos (in both demos, pay attention to the browser link preview in the bottom left):

Before

https://github.com/user-attachments/assets/0dc564b6-c977-44bb-89dd-59e92a743a01

After:

https://github.com/user-attachments/assets/c62dea5e-772a-4a24-be02-698950d3d7ec
