### PR TITLE
chore: syntax change for dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,10 @@
 version: 2
 updates:
-  - package-ecosystem: 'pnpm'
-    directory: '/'
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
-      interval: 'weekly'
-      day: 'monday'
+      interval: "weekly"
+      day: "monday"
     # Lets reduce the noise from Dependabot PRs (we can decrease/increase it over time)
     open-pull-requests-limit: 0
     # Ignoring transitive dependency
@@ -12,4 +12,4 @@ updates:
       - dependency-type: "direct"
     # Dependency we don't want to alert on
     #ignore:
-      #- dependency-name: '@types/node'
+      #- dependency-name: "@types/node"


### PR DESCRIPTION
Aligning yaml config to what is closer to dependabot config as it is a bit confusing. NPM is apparently used even if pnpm is what is used by the service