### PR TITLE
fix: default makeswift emotion cache key and RootStyleRegistry cacheK…

### DIFF
--- a/.changeset/khaki-bags-lead.md
+++ b/.changeset/khaki-bags-lead.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': minor
+---
+
+Default emotion cache key update and RootStyleRegistry optional prop to set emotion cache key

--- a/.changeset/khaki-bags-lead.md
+++ b/.changeset/khaki-bags-lead.md
@@ -1,5 +1,5 @@
 ---
-'@makeswift/runtime': minor
+'@makeswift/runtime': patch
 ---
 
 Default emotion cache key update and RootStyleRegistry optional prop to set emotion cache key

--- a/examples/bigcommerce-catalyst/app/(default)/[...path]/providers.tsx
+++ b/examples/bigcommerce-catalyst/app/(default)/[...path]/providers.tsx
@@ -22,7 +22,7 @@ export function Providers({ children, bcData }: PropsWithChildren<{ bcData: BcDa
 
   return (
     <ReactRuntimeProvider runtime={runtime}>
-      <RootStyleRegistry cacheKeyPrefix='example-prefix'>
+      <RootStyleRegistry cacheKey='example-cache-key'>
         <QueryClientProvider client={queryClient}>
           <BcDataProvider value={bcData}>
             {children}

--- a/examples/bigcommerce-catalyst/app/(default)/[...path]/providers.tsx
+++ b/examples/bigcommerce-catalyst/app/(default)/[...path]/providers.tsx
@@ -22,7 +22,7 @@ export function Providers({ children, bcData }: PropsWithChildren<{ bcData: BcDa
 
   return (
     <ReactRuntimeProvider runtime={runtime}>
-      <RootStyleRegistry>
+      <RootStyleRegistry cacheKeyPrefix='example-prefix'>
         <QueryClientProvider client={queryClient}>
           <BcDataProvider value={bcData}>
             {children}

--- a/packages/runtime/src/next/root-style-registry.tsx
+++ b/packages/runtime/src/next/root-style-registry.tsx
@@ -7,10 +7,10 @@ import { ReactNode, createContext, useContext, useState } from 'react'
 
 const CacheContext = createContext(cache)
 
-const createRootStyleCache = (cacheKeyPrefix?: string) => {
+const createRootStyleCache = ({ cacheKey }: { cacheKey?: string }) => {
   let key = 'makeswift-css'
 
-  if (typeof cacheKeyPrefix === 'string') key = `${cacheKeyPrefix}-css`
+  if (typeof cacheKey === 'string') key = cacheKey
 
   const cache = createCache({ key })
   cache.compat = true
@@ -35,8 +35,8 @@ const createRootStyleCache = (cacheKeyPrefix?: string) => {
   return { cache, flush }
 }
 
-export function RootStyleRegistry({ children, cacheKeyPrefix }: { children: ReactNode, cacheKeyPrefix?: string }) {
-  const [{ cache, flush }] = useState(() => createRootStyleCache(cacheKeyPrefix))
+export function RootStyleRegistry({ children, cacheKey }: { children: ReactNode, cacheKey?: string }) {
+  const [{ cache, flush }] = useState(() => createRootStyleCache({ cacheKey }))
 
   useServerInsertedHTML(() => {
     const names = flush()

--- a/packages/runtime/src/next/root-style-registry.tsx
+++ b/packages/runtime/src/next/root-style-registry.tsx
@@ -7,11 +7,7 @@ import { ReactNode, createContext, useContext, useState } from 'react'
 
 const CacheContext = createContext(cache)
 
-const createRootStyleCache = ({ cacheKey }: { cacheKey?: string }) => {
-  let key = 'makeswift-css'
-
-  if (typeof cacheKey === 'string') key = cacheKey
-
+const createRootStyleCache = ({ key }: { key: string }) => {
   const cache = createCache({ key })
   cache.compat = true
 
@@ -36,7 +32,7 @@ const createRootStyleCache = ({ cacheKey }: { cacheKey?: string }) => {
 }
 
 export function RootStyleRegistry({ children, cacheKey }: { children: ReactNode, cacheKey?: string }) {
-  const [{ cache, flush }] = useState(() => createRootStyleCache({ cacheKey }))
+  const [{ cache, flush }] = useState(() => createRootStyleCache({ key: cacheKey ?? 'css' }))
 
   useServerInsertedHTML(() => {
     const names = flush()

--- a/packages/runtime/src/next/root-style-registry.tsx
+++ b/packages/runtime/src/next/root-style-registry.tsx
@@ -7,8 +7,12 @@ import { ReactNode, createContext, useContext, useState } from 'react'
 
 const CacheContext = createContext(cache)
 
-const createRootStyleCache = () => {
-  const cache = createCache({ key: 'css' })
+const createRootStyleCache = (cacheKeyPrefix?: string) => {
+  let key = 'makeswift-css'
+
+  if (typeof cacheKeyPrefix === 'string') key = `${cacheKeyPrefix}-css`
+
+  const cache = createCache({ key })
   cache.compat = true
 
   const prevInsert = cache.insert
@@ -31,8 +35,8 @@ const createRootStyleCache = () => {
   return { cache, flush }
 }
 
-export function RootStyleRegistry({ children }: { children: ReactNode }) {
-  const [{ cache, flush }] = useState(() => createRootStyleCache())
+export function RootStyleRegistry({ children, cacheKeyPrefix }: { children: ReactNode, cacheKeyPrefix?: string }) {
+  const [{ cache, flush }] = useState(() => createRootStyleCache(cacheKeyPrefix))
 
   useServerInsertedHTML(() => {
     const names = flush()


### PR DESCRIPTION
Following a suggested update from @agurtovoy, [here](https://github.com/makeswift/makeswift/issues/964#issuecomment-2730518088), I updated the emotion cache key to reduce the chance of conflict with other emotion instances and added an optional prop to [`<RootStyleRegistry />`](https://github.com/makeswift/makeswift/blob/main/packages/runtime/src/next/root-style-registry.tsx#L34) so the cache key prefix can be set as needed.