### PR TITLE
fix: avoid document context rerenders

### DIFF
--- a/.changeset/calm-apples-smell.md
+++ b/.changeset/calm-apples-smell.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+Fixes a prop editing performance regression introduced in `v0.23.0`.

--- a/packages/runtime/src/runtimes/react/components/Document.tsx
+++ b/packages/runtime/src/runtimes/react/components/Document.tsx
@@ -1,7 +1,7 @@
 import { Ref, forwardRef, memo } from 'react'
 import { type Document as ReactPageDocument, getRootElement } from '../../../state/react-page'
 import { ElementImperativeHandle } from '../element-imperative-handle'
-import { DocumentContext } from '../hooks/use-document-context'
+import { DocumentKeyContext, DocumentLocaleContext } from '../hooks/use-document-context'
 import { Element } from './Element'
 
 type DocumentProps = {
@@ -14,9 +14,11 @@ export const Document = memo(
     ref: Ref<ElementImperativeHandle>,
   ): JSX.Element {
     return (
-      <DocumentContext.Provider value={document}>
-        <Element ref={ref} element={getRootElement(document)} />
-      </DocumentContext.Provider>
+      <DocumentKeyContext.Provider value={document.key}>
+        <DocumentLocaleContext.Provider value={document.locale}>
+          <Element ref={ref} element={getRootElement(document)} />
+        </DocumentLocaleContext.Provider>
+      </DocumentKeyContext.Provider>
     )
   }),
 )

--- a/packages/runtime/src/runtimes/react/hooks/use-document-context.ts
+++ b/packages/runtime/src/runtimes/react/hooks/use-document-context.ts
@@ -2,24 +2,13 @@
 
 import { createContext, useContext } from 'react'
 
-type ContextValue = {
-  key: string | null
-  locale: string | null
-}
-
-export const DocumentContext = createContext<ContextValue>({
-  key: null,
-  locale: null,
-})
-
-export function useDocumentContext(): ContextValue {
-  return useContext(DocumentContext)
-}
+export const DocumentKeyContext = createContext<string | null>(null)
+export const DocumentLocaleContext = createContext<string | null>(null)
 
 export function useDocumentKey(): string | null {
-  return useDocumentContext().key
+  return useContext(DocumentKeyContext)
 }
 
 export function useDocumentLocale(): string | null {
-  return useDocumentContext().locale
+  return useContext(DocumentLocaleContext)
 }

--- a/packages/runtime/src/runtimes/react/hooks/use-resource-resolver.ts
+++ b/packages/runtime/src/runtimes/react/hooks/use-resource-resolver.ts
@@ -4,12 +4,14 @@ import { type ResourceResolver } from '@makeswift/controls'
 import * as ReactPage from '../../../state/react-page'
 import { useMakeswiftHostApiClient } from '../host-api-client'
 import { useStore } from './use-store'
-import { useDocumentContext } from './use-document-context'
+import { useDocumentKey, useDocumentLocale } from './use-document-context'
 
 export function useResourceResolver(): ResourceResolver {
   const store = useStore()
   const client = useMakeswiftHostApiClient()
-  const { key: documentKey, locale } = useDocumentContext()
+
+  const documentKey = useDocumentKey()
+  const locale = useDocumentLocale()
 
   return useMemo<ResourceResolver>(() => {
     return {


### PR DESCRIPTION
As part of the document context, we were passing the document root element. This means that every edit would result in the context value changing, resulting in all children rerendering. For larger element trees, this means that all props in the document would be re-resolved for any prop change. This fix only passes the necessary fields for the document (key and locale).

## Demos

Before:

https://github.com/user-attachments/assets/8504cd9e-d4be-489f-98b8-6fdad4e9a450

After:

https://github.com/user-attachments/assets/aeba54cb-2725-4975-9e49-0fdca7db4847

## Measured Evidence (Rendering Profiling):

All measurements were taken on the same element tree by modifying the same prop.

Before regression, runtime `v0.22.3`  (7.2ms per render):

![pre-regression-profile-data](https://github.com/user-attachments/assets/1a7a4b09-1f9e-4c70-a623-8a30f5c15781)

Regression (71.8ms per render, order of magnitude higher than before):

![regression-profile-data](https://github.com/user-attachments/assets/f4be38a2-4309-4032-bed6-425d8ccf5b5e)

With Fix (5.2ms per render)

![post-fix-profile-data](https://github.com/user-attachments/assets/95fc457a-e5cf-42d2-8053-84d8ea4e84fd)
