### PR TITLE
wip: explicitly provide registered components

### DIFF
--- a/.changeset/brown-boats-divide.md
+++ b/.changeset/brown-boats-divide.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Add a new way to register Makeswift components explicitly via `ReactRuntime` instead of relying on side-effect imports.

--- a/apps/nextjs-app-router/src/app/[lang]/[[...path]]/page.tsx
+++ b/apps/nextjs-app-router/src/app/[lang]/[[...path]]/page.tsx
@@ -1,5 +1,4 @@
 import { client } from '@/makeswift/client'
-import '@/makeswift/components'
 import { getSiteVersion } from '@makeswift/runtime/next/server'
 import { notFound } from 'next/navigation'
 import { Page as MakeswiftPage } from '@makeswift/runtime/next'

--- a/apps/nextjs-app-router/src/app/[lang]/layout.tsx
+++ b/apps/nextjs-app-router/src/app/[lang]/layout.tsx
@@ -3,7 +3,6 @@ import { draftMode } from 'next/headers'
 import { Grenze_Gotisch, Grenze } from 'next/font/google'
 
 import '@/app/global.css'
-import '@/makeswift/components'
 
 type Params = Promise<{ lang: string; path?: string[] }>
 

--- a/apps/nextjs-app-router/src/app/api/makeswift/[...makeswift]/route.ts
+++ b/apps/nextjs-app-router/src/app/api/makeswift/[...makeswift]/route.ts
@@ -3,9 +3,6 @@ import { MakeswiftApiHandler } from '@makeswift/runtime/next/server'
 
 import { runtime } from '@/makeswift/runtime'
 
-// required to make custom components' data available for introspection
-import '@/makeswift/components'
-
 const handler = MakeswiftApiHandler(MAKESWIFT_SITE_API_KEY, {
   runtime,
   apiOrigin: process.env.NEXT_PUBLIC_MAKESWIFT_API_ORIGIN,

--- a/apps/nextjs-app-router/src/components/font-control-demo/font-control-demo.makeswift.ts
+++ b/apps/nextjs-app-router/src/components/font-control-demo/font-control-demo.makeswift.ts
@@ -1,9 +1,9 @@
-import { runtime } from '@/makeswift/runtime'
 import { lazy } from 'react'
 
 import { Style, Font, TextInput } from '@makeswift/runtime/controls'
+import { ReactRuntime } from '@makeswift/runtime/react'
 
-runtime.registerComponent(
+export const MakeswiftFontControlDemo = ReactRuntime.connect(
   lazy(() => import('./font-control-demo')),
   {
     type: 'Font Control Demo',

--- a/apps/nextjs-app-router/src/components/group-demo/group-demo.makeswift.ts
+++ b/apps/nextjs-app-router/src/components/group-demo/group-demo.makeswift.ts
@@ -1,4 +1,3 @@
-import { runtime } from '@/makeswift/runtime'
 import { lazy } from 'react'
 
 import {
@@ -8,8 +7,9 @@ import {
   Checkbox,
   Color,
 } from '@makeswift/runtime/controls'
+import { ReactRuntime } from '@makeswift/runtime/react'
 
-runtime.registerComponent(
+export const MakeswiftGroupDemo = ReactRuntime.connect(
   lazy(() => import('./group-demo')),
   {
     type: 'Group Control Demo',

--- a/apps/nextjs-app-router/src/makeswift/components.ts
+++ b/apps/nextjs-app-router/src/makeswift/components.ts
@@ -1,2 +1,2 @@
-import '@/components/font-control-demo/font-control-demo.makeswift'
-import '@/components/group-demo/group-demo.makeswift'
+export * from '@/components/font-control-demo/font-control-demo.makeswift'
+export * from '@/components/group-demo/group-demo.makeswift'

--- a/apps/nextjs-app-router/src/makeswift/provider.tsx
+++ b/apps/nextjs-app-router/src/makeswift/provider.tsx
@@ -8,8 +8,6 @@ import {
   RootStyleRegistry,
 } from '@makeswift/runtime/next'
 
-import '@/makeswift/components'
-
 export function MakeswiftProvider({
   children,
   locale = undefined,

--- a/apps/nextjs-app-router/src/makeswift/runtime.ts
+++ b/apps/nextjs-app-router/src/makeswift/runtime.ts
@@ -1,6 +1,9 @@
 import { ReactRuntime } from '@makeswift/runtime/react'
 
+import * as MakeswiftComponents from '@/makeswift/components'
+
 export const runtime = new ReactRuntime({
+  components: MakeswiftComponents,
   breakpoints: {
     mobile: { width: 575, viewport: 390, label: 'Mobile' },
     tablet: { width: 768, viewport: 765, label: 'Tablet' },


### PR DESCRIPTION
This PR attempts to show how we can make the dependency of Makeswift components more explicit by adding a `components` option to `ReactRuntime` and thus removing the need for side effects at the module level with `regsiterComponent`.

> [!CAUTION]
> This has not been tested thoroughly!