### PR TITLE
chore: pass app origin as named param in connection hooks

### DIFF
--- a/.changeset/happy-pandas-give.md
+++ b/.changeset/happy-pandas-give.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+chore: pass app origin as named param in builder connection hooks

--- a/packages/runtime/src/runtimes/react/components/hooks/use-builder-connection-ping.ts
+++ b/packages/runtime/src/runtimes/react/components/hooks/use-builder-connection-ping.ts
@@ -9,7 +9,10 @@ export function useBuilderConnectionPing({ appOrigin }: { appOrigin: string }) {
 
     if (window.parent !== window) {
       window.addEventListener('message', messageHandler)
-      window.parent.postMessage({ type: ActionTypes.MAKESWIFT_CONNECTION_INIT }, appOrigin)
+      window.parent.postMessage(
+        { type: ActionTypes.MAKESWIFT_CONNECTION_INIT },
+        { targetOrigin: appOrigin },
+      )
     }
 
     return () => {
@@ -33,7 +36,7 @@ export function useBuilderConnectionPing({ appOrigin }: { appOrigin: string }) {
               type: ActionTypes.MAKESWIFT_CONNECTION_CHECK,
               payload: { currentUrl: window.location.href },
             },
-            appOrigin,
+            { targetOrigin: appOrigin },
           )
         }, CONNECTION_PING_INTERVAL_MS)
       }


### PR DESCRIPTION
Pass the app origin as the `targetOrigin` for all `postMessage` calls for explicitness.