### PR TITLE
feat: localized pages are online by default, fallback to the base locale

### DIFF
--- a/.changeset/lemon-ravens-divide.md
+++ b/.changeset/lemon-ravens-divide.md
@@ -1,0 +1,19 @@
+---
+'@makeswift/runtime': minor
+---
+
+BREAKING: Upgrading to this runtime version will opt your site into the new localized pages behavior, both in the builder and on the live site.
+
+Localized pages are no longer silently created when navigated to in the builder. Instead, they now automatically fall back to the base locale by default. To create a localized page, users must take explicit action in the builder.
+
+Localized pages that are explicitly marked as Offline will remain offline.
+
+You can disable fallback behavior on a per-page basis by passing `allowLocaleFallback: false` to the `client.getPageSnapshot` call:
+
+```typescript
+const snapshot = await client.getPageSnapshot(path, {
+  siteVersion: await getSiteVersion(),
+  locale,
+  allowLocaleFallback: false,
+})
+```

--- a/packages/runtime/src/next/api-handler/handlers/manifest.ts
+++ b/packages/runtime/src/next/api-handler/handlers/manifest.ts
@@ -15,6 +15,7 @@ export type Manifest = {
   unstable_siteVersions: boolean
   localizedPageSSR: boolean
   webhook: boolean
+  localizedPagesOnlineByDefault: boolean
 }
 
 type ManifestError = { message: string }
@@ -85,6 +86,7 @@ export default async function handler(
     unstable_siteVersions: true,
     localizedPageSSR: true,
     webhook: supportsWebhook,
+    localizedPagesOnlineByDefault: true,
   }
 
   return match(args)

--- a/packages/runtime/src/next/client.ts
+++ b/packages/runtime/src/next/client.ts
@@ -662,16 +662,23 @@ export class Makeswift {
     {
       siteVersion: siteVersionPromise,
       locale,
-    }: { siteVersion: MakeswiftSiteVersion | Promise<MakeswiftSiteVersion>; locale?: string },
+      allowLocaleFallback = true,
+    }: {
+      siteVersion: MakeswiftSiteVersion | Promise<MakeswiftSiteVersion>
+      locale?: string
+      allowLocaleFallback?: boolean
+    },
   ): Promise<MakeswiftPageSnapshot | null> {
-    const searchParams = new URLSearchParams()
-    if (locale) {
-      searchParams.set('locale', locale)
+    const queryParams = (): string => {
+      const params = new URLSearchParams()
+      if (locale) params.set('locale', locale)
+      if (allowLocaleFallback != null) params.set('allowLocaleFallback', `${allowLocaleFallback}`)
+      return params.toString()
     }
 
     const siteVersion = await siteVersionPromise
     const response = await this.fetch(
-      `v3/pages/${encodeURIComponent(pathname)}/document?${searchParams.toString()}`,
+      `v3/pages/${encodeURIComponent(pathname)}/document?${queryParams()}`,
       siteVersion,
     )
 

--- a/packages/runtime/src/next/tests/__snapshots__/client.get-page-snapshot.test.ts.snap
+++ b/packages/runtime/src/next/tests/__snapshots__/client.get-page-snapshot.test.ts.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getPageSnapshot correctly passes \`locale\` parameter (es-MX) 1`] = `
+{
+  "apiResources": {
+    "File": [],
+    "GlobalElement": [],
+    "LocalizedGlobalElement": [],
+    "PagePathnameSlice": [],
+    "Swatch": [],
+    "Table": [],
+    "Typography": [],
+  },
+  "localizedResourcesMap": {
+    "es-MX": {},
+  },
+}
+`;
+
+exports[`getPageSnapshot correctly passes \`locale\` parameter (fr) 1`] = `
+{
+  "apiResources": {
+    "File": [],
+    "GlobalElement": [],
+    "LocalizedGlobalElement": [],
+    "PagePathnameSlice": [],
+    "Swatch": [],
+    "Table": [],
+    "Typography": [],
+  },
+  "localizedResourcesMap": {
+    "fr": {},
+  },
+}
+`;
+
+exports[`getPageSnapshot correctly passes \`locale\` parameter (undefined) 1`] = `
+{
+  "apiResources": {
+    "File": [],
+    "GlobalElement": [],
+    "LocalizedGlobalElement": [],
+    "PagePathnameSlice": [],
+    "Swatch": [],
+    "Table": [],
+    "Typography": [],
+  },
+  "localizedResourcesMap": {},
+}
+`;

--- a/packages/runtime/src/next/tests/client.get-page-snapshot.test.ts
+++ b/packages/runtime/src/next/tests/client.get-page-snapshot.test.ts
@@ -1,4 +1,4 @@
-import { Makeswift } from '../client'
+import { Makeswift, type MakeswiftPageDocument } from '../client'
 import { http, HttpResponse } from 'msw'
 
 import { ReactRuntime } from '../../runtimes/react'
@@ -16,6 +16,24 @@ function createTestClient() {
 
 let consoleErrorSpy: jest.SpyInstance
 
+const pageDocument: MakeswiftPageDocument = {
+  id: '[page-id]',
+  site: {
+    id: '[site-id]',
+  },
+  data: {
+    type: '[element-type]',
+    key: '[element-key]',
+    props: {},
+  },
+  snippets: [],
+  fonts: [],
+  meta: {},
+  seo: {},
+  localizedPages: [],
+  locale: null,
+}
+
 beforeEach(() => {
   consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
 })
@@ -27,7 +45,94 @@ afterEach(() => {
 describe('getPageSnapshot', () => {
   const pathname = 'blog/hello-world'
   const snapshotUrl = `${apiOrigin}/v3/pages/${encodeURIComponent(pathname)}/document`
+  const graphqlUrl = `${apiOrigin}/graphql`
   const locale = 'es-MX'
+
+  test.each([undefined, 'fr', 'es-MX'])(
+    'correctly passes `locale` parameter (%s)',
+    async locale => {
+      // Arrange
+      const client = createTestClient()
+
+      server.use(
+        // page snapshot request
+        http.get(
+          snapshotUrl,
+          ({ request }) => {
+            const url = new URL(request.url)
+            return HttpResponse.json(
+              { ...pageDocument, locale: url.searchParams.get('locale') },
+              { status: 200 },
+            )
+          },
+          {
+            once: true,
+          },
+        ),
+        // introspection query
+        http.post(graphqlUrl, () => HttpResponse.json({}, { status: 200 }), {
+          once: true,
+        }),
+      )
+
+      // Act
+      const result = await client.getPageSnapshot(pathname, {
+        locale,
+        siteVersion: MakeswiftSiteVersion.Working,
+      })
+
+      // Assert
+      expect(result?.cacheData).toMatchSnapshot()
+      expect(result?.document.locale).toEqual(locale ?? null)
+    },
+  )
+
+  test.each([
+    [undefined, '[fallback-page-id]'],
+    [true, '[fallback-page-id]'],
+    [false, '[page-id]'],
+  ])(
+    'correctly passes `allowLocaleFallback` parameter (%s)',
+    async (allowLocaleFallback, expectedPageId) => {
+      // Arrange
+      const client = createTestClient()
+
+      server.use(
+        // page snapshot request
+        http.get(
+          snapshotUrl,
+          ({ request }) => {
+            const url = new URL(request.url)
+            const allowFallback = url.searchParams.get('allowLocaleFallback') === 'true'
+            return HttpResponse.json(
+              {
+                ...pageDocument,
+                id: allowFallback ? '[fallback-page-id]' : '[page-id]',
+              },
+              { status: 200 },
+            )
+          },
+          {
+            once: true,
+          },
+        ),
+        // introspection query
+        http.post(graphqlUrl, () => HttpResponse.json({}, { status: 200 }), {
+          once: true,
+        }),
+      )
+
+      // Act
+      const result = await client.getPageSnapshot(pathname, {
+        locale,
+        allowLocaleFallback,
+        siteVersion: MakeswiftSiteVersion.Working,
+      })
+
+      // Assert
+      expect(result?.document.id).toEqual(expectedPageId)
+    },
+  )
 
   test('returns null on 404', async () => {
     // Arrange


### PR DESCRIPTION
Last piece of [ENG-7803](https://linear.app/makeswift/issue/ENG-7803/make-localized-pages-online-by-default).