### PR TITLE
feat: add `enableCssReset` option to `RootStyleRegistry` to support Tailwind v4 and other `@layer`-based CSS framework

### DIFF
--- a/.changeset/shy-actors-grow.md
+++ b/.changeset/shy-actors-grow.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Add `enableCssReset` prop to `RootStyleRegistry` (default `true`). Set it to `false` when using a `@layer`-based CSS framework such as Tailwind v4.

--- a/packages/runtime/src/components/builtin/Root/Root.tsx
+++ b/packages/runtime/src/components/builtin/Root/Root.tsx
@@ -8,6 +8,7 @@ import { useGlobalStyle } from '../../../runtimes/react/use-global-style'
 import { GridItem } from '../../shared/grid-item'
 import { useStyle } from '../../../runtimes/react/use-style'
 import { GridData, ResponsiveBackgroundsData, ResponsiveGapData } from '@makeswift/prop-controllers'
+import { useCSSResetEnabled } from '../../../next/root-style-registry'
 
 type Props = {
   children?: GridData
@@ -20,16 +21,16 @@ const Root = forwardRef(function Page(
   { children, backgrounds, rowGap, columnGap }: Props,
   ref: Ref<HTMLDivElement>,
 ) {
-  useGlobalStyle({
-    html: {
-      boxSizing: 'border-box',
-    },
-    '*, *::before, *::after': {
-      boxSizing: 'inherit',
-    },
-  })
+  const cssResetEnabled = useCSSResetEnabled()
 
-  useGlobalStyle(normalize())
+  useGlobalStyle(
+    cssResetEnabled
+      ? [
+          { html: { boxSizing: 'border-box' }, '*, *::before, *::after': { boxSizing: 'inherit' } },
+          normalize(),
+        ]
+      : [],
+  )
 
   return (
     <BackgroundsContainer ref={ref} style={{ background: 'white' }} backgrounds={backgrounds}>


### PR DESCRIPTION
## What happened?

[Tailwind v4 use @layer](https://tailwindcss.com/blog/tailwindcss-v4#designed-for-the-modern-web). This caused the CSS reset to override the Tailwind styles.
<img width="638" alt="Screenshot 2025-04-24 at 19 40 09" src="https://github.com/user-attachments/assets/c4559189-20a2-4766-8fee-5bb6b241754c" />
[source](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer)

## Fix

Add `enableCssReset` option to `RootStyleRegistry` to disable the CSS reset.

## Proof

https://github.com/user-attachments/assets/73bb766e-600f-4c14-b124-76fefd686081


