### PR TITLE
fix(pages router): localized pages redirect to the base locale in the builder

### DIFF
--- a/.changeset/beige-emus-knock.md
+++ b/.changeset/beige-emus-knock.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+fix: Pages Router regression, localized pages redirect to the base locale in the builder

--- a/packages/makeswift-next-plugin/index.js
+++ b/packages/makeswift-next-plugin/index.js
@@ -70,6 +70,7 @@ module.exports =
                 },
               ],
               destination: '/api/makeswift/preview',
+              locale: false,
             },
           ]
           return {


### PR DESCRIPTION
Fixes a regression introduced in 0.24.0 when we removed [this code](https://github.com/makeswift/makeswift/blob/a645d1e83bc0fb4422ff14387738b3aa93c91c60/packages/runtime/src/next/api-handler/handlers/proxy-preview-mode.ts#L92).

https://github.com/user-attachments/assets/da1dfb57-8bd6-4648-b3fb-144e771eeca8

