### PR TITLE
fix: videos do not play correctly in iOS

### DIFF
--- a/.changeset/tiny-items-glow.md
+++ b/.changeset/tiny-items-glow.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+fix: Videos do not play correctly in iOS

--- a/packages/runtime/src/components/shared/BackgroundsContainer/components/BackgroundVideo/index.tsx
+++ b/packages/runtime/src/components/shared/BackgroundsContainer/components/BackgroundVideo/index.tsx
@@ -122,6 +122,7 @@ export default function BackgroundVideo({
           playing
           loop
           muted
+          playsinline={true}
           controls={false}
           onReady={() => setReady(true)}
           style={{


### PR DESCRIPTION
# Summary

This PR fixes the issue when a video content from a Makeswift page does not play or plays in a full-screen mode on iOS.

# Preview

## Before

### Chrome
https://github.com/user-attachments/assets/e08f58b0-1731-4040-b24c-b98caf8ff17f

### Safari 
https://github.com/user-attachments/assets/bde4f436-169e-4c74-ab97-a758c99fbd21


## After

### Chrome
https://github.com/user-attachments/assets/398a3985-e06d-48a9-9a9e-0615e449d5db

### Safari
https://github.com/user-attachments/assets/701d7ada-953b-4bef-93e4-6c2e760ca6e3

