### PR TITLE
hotfix/runtime 0.23.14

### DIFF
--- a/.changeset/cold-cars-check.md
+++ b/.changeset/cold-cars-check.md
@@ -1,5 +1,0 @@
----
-"@makeswift/runtime": patch
----
-
-fix: remove transitive `revalidateTag` import in the Makeswift client; resolves Next.js 15.3.1 error on attempt to render a page.

--- a/.changeset/cold-cars-check.md
+++ b/.changeset/cold-cars-check.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+fix: remove transitive `revalidateTag` import in the Makeswift client; resolves Next.js 15.3.1 error on attempt to render a page.

--- a/.changeset/hip-deer-rescue.md
+++ b/.changeset/hip-deer-rescue.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+fix: Box background videos do not play correctly in iOS

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -105,6 +105,12 @@
 - Updated dependencies [8241d49]
   - @makeswift/next-plugin@0.4.0
 
+## 0.23.14
+
+### Patch Changes
+
+- fix: Box background videos do not play correctly in iOS
+
 ## 0.23.13
 
 ### Patch Changes

--- a/packages/runtime/src/components/shared/BackgroundsContainer/components/BackgroundVideo/index.tsx
+++ b/packages/runtime/src/components/shared/BackgroundsContainer/components/BackgroundVideo/index.tsx
@@ -122,6 +122,7 @@ export default function BackgroundVideo({
           playing
           loop
           muted
+          playsinline={true}
           controls={false}
           onReady={() => setReady(true)}
           style={{


### PR DESCRIPTION
# Summary

This PR fixes the issue when a video content from a Makeswift page does not play or plays in a full-screen mode on iOS.

# Preview

## Before

### Chrome
https://github.com/user-attachments/assets/e08f58b0-1731-4040-b24c-b98caf8ff17f

### Safari 
https://github.com/user-attachments/assets/bde4f436-169e-4c74-ab97-a758c99fbd21


## After

### Chrome
https://github.com/user-attachments/assets/398a3985-e06d-48a9-9a9e-0615e449d5db

### Safari
https://github.com/user-attachments/assets/701d7ada-953b-4bef-93e4-6c2e760ca6e3

