### PR TITLE
fix: `Invalid URL` error on attempt to open a reverse-proxied site in the builder

### DIFF
--- a/.changeset/strange-colts-arrive.md
+++ b/.changeset/strange-colts-arrive.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+fix: `Invalid URL` error on attempt to open a reverse-proxied site in the builder

--- a/packages/runtime/src/next/api-handler/handlers/redirect-draft.test.ts
+++ b/packages/runtime/src/next/api-handler/handlers/redirect-draft.test.ts
@@ -1,0 +1,18 @@
+import { NextRequest } from 'next/server'
+import { originalRequestProtocol } from './redirect-draft'
+
+describe('redirectDraftRouteHandler', () => {
+  describe('correctly extracts original request protocol from the \'x-forwarded-proto\' header', () => {
+    test.each([
+      [undefined, null],
+      ['https', 'https'],
+      ['http,https', 'http'],
+      ['https, http', 'https'],
+      ['https, https,http', 'https'],
+      ['https,   https,  http', 'https'],
+    ])(`%s -> %s`, (header, expected) => {
+      const request = new NextRequest('https://api.makeswift.com', { headers: header != null ? { 'x-forwarded-proto': header } : {} })
+      expect(originalRequestProtocol(request)).toEqual(expected)
+    })
+  })
+})


### PR DESCRIPTION
Add support for comma-separated list of values in the `x-forwarded-proto` header.