### PR TITLE
fix: `<script>` tag error in the console when a site is loaded in the builder

### DIFF
--- a/.changeset/large-dryers-sleep.md
+++ b/.changeset/large-dryers-sleep.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+fix: `<script>` tag error in the console when a site is loaded in the builder

--- a/packages/runtime/src/next/components/tests/__snapshots__/makeswift-page-metadata-rendering.test.tsx.snap
+++ b/packages/runtime/src/next/components/tests/__snapshots__/makeswift-page-metadata-rendering.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`MakeswiftPage metadata and seo tag rendering does NOT render any metadata when passing all options as false 1`] = `
+exports[`MakeswiftPage metadata and seo tag rendering does NOT render any page metadata when passing all options as false 1`] = `
 <head>
   <style
     href="makeswift-base-styles"
@@ -15,10 +15,14 @@ exports[`MakeswiftPage metadata and seo tag rendering does NOT render any metada
         }
         
   </style>
+  <meta
+    content="{"draft":false,"inBuilder":false}"
+    name="makeswift-draft-info"
+  />
 </head>
 `;
 
-exports[`MakeswiftPage metadata and seo tag rendering does NOT render any metadata when passing empty options 1`] = `
+exports[`MakeswiftPage metadata and seo tag rendering does NOT render any page metadata when passing empty options 1`] = `
 <head>
   <style
     href="makeswift-base-styles"
@@ -33,10 +37,14 @@ exports[`MakeswiftPage metadata and seo tag rendering does NOT render any metada
         }
         
   </style>
+  <meta
+    content="{"draft":false,"inBuilder":false}"
+    name="makeswift-draft-info"
+  />
 </head>
 `;
 
-exports[`MakeswiftPage metadata and seo tag rendering does NOT render any metadata when passing false 1`] = `
+exports[`MakeswiftPage metadata and seo tag rendering does NOT render any page metadata when passing false 1`] = `
 <head>
   <style
     href="makeswift-base-styles"
@@ -51,6 +59,10 @@ exports[`MakeswiftPage metadata and seo tag rendering does NOT render any metada
         }
         
   </style>
+  <meta
+    content="{"draft":false,"inBuilder":false}"
+    name="makeswift-draft-info"
+  />
 </head>
 `;
 
@@ -87,6 +99,10 @@ exports[`MakeswiftPage metadata and seo tag rendering only renders selective met
   <meta
     content="test, keywords"
     name="keywords"
+  />
+  <meta
+    content="{"draft":false,"inBuilder":false}"
+    name="makeswift-draft-info"
   />
 </head>
 `;
@@ -154,6 +170,10 @@ exports[`MakeswiftPage metadata and seo tag rendering renders all metadata by de
     content="summary_large_image"
     name="twitter:card"
   />
+  <meta
+    content="{"draft":false,"inBuilder":false}"
+    name="makeswift-draft-info"
+  />
 </head>
 `;
 
@@ -220,6 +240,10 @@ exports[`MakeswiftPage metadata and seo tag rendering renders all metadata when 
     content="summary_large_image"
     name="twitter:card"
   />
+  <meta
+    content="{"draft":false,"inBuilder":false}"
+    name="makeswift-draft-info"
+  />
 </head>
 `;
 
@@ -285,6 +309,10 @@ exports[`MakeswiftPage metadata and seo tag rendering renders all metadata when 
   <meta
     content="summary_large_image"
     name="twitter:card"
+  />
+  <meta
+    content="{"draft":false,"inBuilder":false}"
+    name="makeswift-draft-info"
   />
 </head>
 `;

--- a/packages/runtime/src/next/components/tests/makeswift-page-metadata-rendering.test.tsx
+++ b/packages/runtime/src/next/components/tests/makeswift-page-metadata-rendering.test.tsx
@@ -86,6 +86,13 @@ async function testMakeswiftPageMetadataRendering(
   )
 }
 
+function getPageMetaTags(
+  container: HTMLElement,
+): { name: string; content: string }[] {
+  const metaTags = container.getElementsByTagName('meta')
+  return Array.from(metaTags).filter(({ name }) => name !== 'makeswift-draft-info')
+}
+
 describe('MakeswiftPage', () => {
   describe('metadata and seo tag rendering', () => {
     test('renders all metadata by default (without passing prop)', async () => {
@@ -134,12 +141,12 @@ describe('MakeswiftPage', () => {
           indexingBlocked: false,
         },
       },
-    ])(`does NOT render any metadata when passing $label`, async ({ metadata }) => {
+    ])(`does NOT render any page metadata when passing $label`, async ({ metadata }) => {
       const snapshot = createMakeswiftPageSnapshot(pageDocumentFixture)
 
       const render = await testMakeswiftPageMetadataRendering({ snapshot, metadata })
       expect(render.container).toMatchSnapshot()
-      expect(render.container.getElementsByTagName('meta').length).toBe(0)
+      expect(getPageMetaTags(render.container).length).toBe(0)
       expect(render.container.getElementsByTagName('link').length).toBe(0)
     })
 

--- a/packages/runtime/src/runtimes/react/components/draft-switcher/draft-switcher.tsx
+++ b/packages/runtime/src/runtimes/react/components/draft-switcher/draft-switcher.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 
+import { PageMeta } from '../../../../next/components/head-tags'
 import { useIsInBuilder } from '../../hooks/use-is-in-builder'
 import { DraftToolbar } from './draft-toolbar'
 
@@ -35,8 +36,6 @@ export function DraftSwitcher({ isDraft }: { isDraft: boolean }) {
     }
   }, [showToolbar, shadowRoot, setShadowRoot])
 
-  if (!showToolbar) return null
-
   return (
     <>
       {showToolbar && (
@@ -46,13 +45,11 @@ export function DraftSwitcher({ isDraft }: { isDraft: boolean }) {
             : null}
         </span>
       )}
-      <script
-        type="application/json"
-        id="makeswift-draft-info"
-        dangerouslySetInnerHTML={{
-          __html: JSON.stringify({ draft: isDraft, inBuilder: isInBuilder }),
-        }}
-      />
+      {/* Insert draft mode information into the DOM to make it easier to debug draft mode-related 
+          issues on production sites */}
+      <PageMeta
+        name="makeswift-draft-info"
+        content={JSON.stringify({ draft: isDraft, inBuilder: isInBuilder })} />
     </>
   )
 }


### PR DESCRIPTION
Fix `Cannot render a sync or defer <script> outside of the main document` console error in the App Router sites.

Verified for both App and Pages Router.