### PR TITLE
fix: surround elements with error boundaries

### DIFF
--- a/.changeset/fair-crabs-deny.md
+++ b/.changeset/fair-crabs-deny.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+Surround all elements with an error boundary to prevent rendering errors from causing page-wide failures.

--- a/packages/runtime/src/components/shared/ErrorBoundary.tsx
+++ b/packages/runtime/src/components/shared/ErrorBoundary.tsx
@@ -1,0 +1,26 @@
+import { Component, ElementType, ReactNode } from 'react'
+
+type ErrorProps = {
+  FallbackComponent: ElementType
+  children: ReactNode
+}
+
+type State = {
+  hasError: boolean
+}
+
+export class ErrorBoundary extends Component<ErrorProps, State> {
+  static getDerivedStateFromError() {
+    return { hasError: true }
+  }
+
+  state = { hasError: false }
+
+  render() {
+    const { FallbackComponent } = this.props
+
+    if (this.state.hasError) return FallbackComponent ? <FallbackComponent /> : null
+
+    return this.props.children
+  }
+}

--- a/packages/runtime/src/runtimes/react/components/Element.tsx
+++ b/packages/runtime/src/runtimes/react/components/Element.tsx
@@ -7,6 +7,8 @@ import { ElementReference } from './ElementReference'
 import { ElementData } from './ElementData'
 import { ElementImperativeHandle } from '../element-imperative-handle'
 import { FindDomNode } from '../find-dom-node'
+import { FallbackComponent } from '../../../components/shared/FallbackComponent'
+import { ErrorBoundary } from '../../../components/shared/ErrorBoundary'
 
 type Props = {
   element: ElementDataOrRef
@@ -37,17 +39,23 @@ export const Element = memo(
     return (
       <ElementRegistration componentHandle={imperativeHandleRef.current} elementKey={element.key}>
         <FindDomNode ref={findDomNodeCallbackRef}>
-          {isElementReference(element) ? (
-            <ElementReference
-              key={element.key}
-              ref={elementCallbackRef}
-              elementReference={element}
-            />
-          ) : (
-            <ElementData key={element.key} ref={elementCallbackRef} elementData={element} />
-          )}
+          <ErrorBoundary FallbackComponent={ErrorFallback}>
+            {isElementReference(element) ? (
+              <ElementReference
+                key={element.key}
+                ref={elementCallbackRef}
+                elementReference={element}
+              />
+            ) : (
+              <ElementData key={element.key} ref={elementCallbackRef} elementData={element} />
+            )}
+          </ErrorBoundary>
         </FindDomNode>
       </ElementRegistration>
     )
   }),
 )
+
+function ErrorFallback() {
+  return <FallbackComponent text={`Error rendering component`} />
+}


### PR DESCRIPTION
Prevent rendering errors from breaking entire pages by surrounding each element component with an error boundary. This allows the user to delete any erroring elements.

Before:

https://github.com/user-attachments/assets/1401174b-436e-4001-a401-034ac87d345c

After:

https://github.com/user-attachments/assets/2ce0af18-a508-47c8-8ccd-4e6a689a397c
