### PR TITLE
Fix copying typography data - allow undefined id in output

### DIFF
--- a/.changeset/stupid-seas-deny.md
+++ b/.changeset/stupid-seas-deny.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/controls": patch
+---
+
+Allow tree data from copying a typography to include an undefined id

--- a/packages/controls/src/controls/typography/__fixtures__/index.ts
+++ b/packages/controls/src/controls/typography/__fixtures__/index.ts
@@ -1,0 +1,1 @@
+export * from './typography-without-id'

--- a/packages/controls/src/controls/typography/__fixtures__/typography-without-id.ts
+++ b/packages/controls/src/controls/typography/__fixtures__/typography-without-id.ts
@@ -1,0 +1,16 @@
+export const typographyWithoutId = {
+  "style": [
+      {
+          "deviceId": "desktop",
+          "value": {
+              "fontFamily": "Nanum Gothic Coding",
+              "fontSize": {
+                  "unit": "px",
+                  "value": 18
+              },
+              "fontWeight": 400,
+              "lineHeight": 1.5
+          }
+      }
+  ]
+}

--- a/packages/controls/src/controls/typography/__snapshots__/copy.test.ts.snap
+++ b/packages/controls/src/controls/typography/__snapshots__/copy.test.ts.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Copying Typography allows for undefined id: Output data from copying a typography without an id 1`] = `
+{
+  "id": undefined,
+  "style": [
+    {
+      "deviceId": "desktop",
+      "value": {
+        "fontFamily": "Nanum Gothic Coding",
+        "fontSize": {
+          "unit": "px",
+          "value": 18,
+        },
+        "fontWeight": 400,
+        "lineHeight": 1.5,
+      },
+    },
+  ],
+}
+`;

--- a/packages/controls/src/controls/typography/copy.test.ts
+++ b/packages/controls/src/controls/typography/copy.test.ts
@@ -1,0 +1,14 @@
+import { createReplacementContext } from "../../context"
+import { typographyWithoutId } from "./__fixtures__/typography-without-id"
+import { unstable_Typography } from "./typography"
+
+describe('Copying Typography', () => {
+  test('allows for undefined id', () => {
+    const result = unstable_Typography().copyData(typographyWithoutId, {
+      replacementContext: createReplacementContext(),
+      copyElement: (e) => e,
+    })
+
+    expect(result).toMatchSnapshot('Output data from copying a typography without an id')
+  })
+})

--- a/packages/controls/src/controls/typography/typography.ts
+++ b/packages/controls/src/controls/typography/typography.ts
@@ -131,12 +131,14 @@ class Definition extends ControlDefinition<
       return undefined
     }
 
+    const replacementId = data.id != null ? replaceResourceIfNeeded(
+      ContextResource.Typography,
+      data.id,
+      context,
+    ): undefined
+
     return {
-      id: replaceResourceIfNeeded(
-        ContextResource.Typography,
-        data.id ?? '',
-        context,
-      ),
+      id: replacementId,
       style: data.style.map((override) => ({
         ...override,
         value: {


### PR DESCRIPTION
After demo: https://linear.app/makeswift/issue/ENG-8876/consistent-error-on-getting-typographies-in-catalyst#comment-29d82f07 