### PR TITLE
fix: only clear typography id when marked for removal

### DIFF
--- a/.changeset/few-hornets-wink.md
+++ b/.changeset/few-hornets-wink.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/controls": patch
+---
+
+Finetune clearing typography data on copy to only clear the resource reference, rather than any data.

--- a/packages/controls/src/controls/rich-text/v1/__snapshots__/copy.test.ts.snap
+++ b/packages/controls/src/controls/rich-text/v1/__snapshots__/copy.test.ts.snap
@@ -23,7 +23,32 @@ exports[`GIVEN copying RichText removes any swatch, typography and page ids mark
                 "marks": [
                   {
                     "data": {
-                      "value": undefined,
+                      "value": {
+                        "id": undefined,
+                        "style": [
+                          {
+                            "value": {
+                              "color": {
+                                "alpha": 1,
+                                "swatchId": null,
+                              },
+                            },
+                          },
+                          {
+                            "value": {
+                              "fontWeight": 500,
+                            },
+                          },
+                          {
+                            "value": {
+                              "color": {
+                                "alpha": 1,
+                                "swatchId": null,
+                              },
+                            },
+                          },
+                        ],
+                      },
                     },
                     "object": "mark",
                     "type": "typography",

--- a/packages/controls/src/controls/rich-text/v2/__snapshots__/rich-text.test.ts.snap
+++ b/packages/controls/src/controls/rich-text/v2/__snapshots__/rich-text.test.ts.snap
@@ -15,7 +15,7 @@ Definition {
 }
 `;
 
-exports[`RichText v2 copyData removes swatch, typographies, and page IDs that are marked for removal 1`] = `
+exports[`RichText v2 copyData removes swatch, typography, and page IDs that are marked for removal 1`] = `
 {
   "descendants": [
     {
@@ -24,7 +24,32 @@ exports[`RichText v2 copyData removes swatch, typographies, and page IDs that ar
           "children": [
             {
               "text": "Credibly implement global synergy, then collaboratively implement goal-oriented sprints. Rapidiously initiate standards compliant clouds. ",
-              "typography": undefined,
+              "typography": {
+                "id": undefined,
+                "style": [
+                  {
+                    "value": {
+                      "color": {
+                        "alpha": 1,
+                        "swatchId": null,
+                      },
+                    },
+                  },
+                  {
+                    "value": {
+                      "fontWeight": 500,
+                    },
+                  },
+                  {
+                    "value": {
+                      "color": {
+                        "alpha": 1,
+                        "swatchId": null,
+                      },
+                    },
+                  },
+                ],
+              },
             },
           ],
           "link": {

--- a/packages/controls/src/controls/rich-text/v2/rich-text.test.ts
+++ b/packages/controls/src/controls/rich-text/v2/rich-text.test.ts
@@ -62,7 +62,7 @@ describe('RichText v2', () => {
     })
   })
 
-  test('copyData removes swatch, typographies, and page IDs that are marked for removal', () => {
+  test('copyData removes swatch, typography, and page IDs that are marked for removal', () => {
     const definition = RichText()
 
     const result = definition.copyData(Fixtures.introspection, {

--- a/packages/controls/src/controls/typography/typography.test.ts
+++ b/packages/controls/src/controls/typography/typography.test.ts
@@ -27,7 +27,7 @@ describe('Typography', () => {
   })
 
   describe('copyData', () => {
-    test('returns `undefined` if typography ID is marked for removal', () => {
+    test('returns `undefined` for `id` if typography ID is marked for removal', () => {
       const data: DataType<unstable_TypographyDefinition> = {
         id: 'typography-id',
         style: [
@@ -52,7 +52,7 @@ describe('Typography', () => {
       })
 
       // Assert
-      expect(copy).toBeUndefined()
+      expect(copy).toEqual({ ...data, id: undefined })
     })
 
     test('removes any swatch IDs marked for removal', () => {

--- a/packages/controls/src/controls/typography/typography.ts
+++ b/packages/controls/src/controls/typography/typography.ts
@@ -124,21 +124,18 @@ class Definition extends ControlDefinition<
       return replaceResourceIfNeeded(ContextResource.Swatch, swatchId, context)
     }
 
-    if (
-      data.id != null &&
-      shouldRemoveResource(ContextResource.Typography, data.id, context)
-    ) {
-      return undefined
+    function replaceTypographyId(id: string | null): string | undefined {
+      if (
+        id == null ||
+        shouldRemoveResource(ContextResource.Typography, id, context)
+      ) {
+        return undefined
+      }
+      return replaceResourceIfNeeded(ContextResource.Typography, id, context)
     }
 
-    const replacementId = data.id != null ? replaceResourceIfNeeded(
-      ContextResource.Typography,
-      data.id,
-      context,
-    ): undefined
-
     return {
-      id: replacementId,
+      id: replaceTypographyId(data.id ?? null),
       style: data.style.map((override) => ({
         ...override,
         value: {


### PR DESCRIPTION
The current behavior for clearing typography data from the copy context is to not return any data altogether. However, since the typography data permits for an undefined ID, we should follow the rule of smallest granularity to only clear the typography ID, rather than the entire data.

https://github.com/user-attachments/assets/c6e5abc6-c371-458f-999e-47dec52508c1
