### PR TITLE
fix: kitchen sink apps use public env vars

### DIFF
--- a/apps/nextjs-pages-router/src/pages/api/makeswift/[...makeswift].ts
+++ b/apps/nextjs-pages-router/src/pages/api/makeswift/[...makeswift].ts
@@ -10,8 +10,8 @@ import '@/makeswift/components'
 
 export default MakeswiftApiHandler(MAKESWIFT_SITE_API_KEY, {
   runtime,
-  apiOrigin: process.env.MAKESWIFT_API_ORIGIN,
-  appOrigin: process.env.MAKESWIFT_APP_ORIGIN,
+  apiOrigin: process.env.NEXT_PUBLIC_MAKESWIFT_API_ORIGIN,
+  appOrigin: process.env.NEXT_PUBLIC_MAKESWIFT_APP_ORIGIN,
   getFonts() {
     return [
       {


### PR DESCRIPTION
Configure the pages router kitchen sink app to use NEXT_PUBLIC vars for API origin and app origin.