### PR TITLE
fix: meta tags for Open Graph / Twitter title

### DIFF
--- a/.changeset/wise-wombats-sing.md
+++ b/.changeset/wise-wombats-sing.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+Render Open Graph and Twitter meta tags for page title in `<Page />` component

--- a/packages/runtime/src/components/page/PageHead.tsx
+++ b/packages/runtime/src/components/page/PageHead.tsx
@@ -85,7 +85,13 @@ export function PageHead({ document: page, metadata = {} }: Props): JSX.Element 
         }
         `}
       </PageStyle>
-      {useTitle && title && <PageTitle>{title}</PageTitle>}
+      {useTitle && title && (
+        <>
+          <PageTitle>{title}</PageTitle>
+          <PageMeta property="og:title" content={title} />
+          <PageMeta name="twitter:title" content={title} />
+        </>
+      )}
       {useFavicon && favicon && (
         <PageLink rel="icon" type={favicon.mimetype} href={favicon.publicUrl} />
       )}

--- a/packages/runtime/src/next/components/tests/__snapshots__/makeswift-page-metadata-rendering.test.tsx.snap
+++ b/packages/runtime/src/next/components/tests/__snapshots__/makeswift-page-metadata-rendering.test.tsx.snap
@@ -85,6 +85,14 @@ exports[`MakeswiftPage metadata and seo tag rendering only renders selective met
     Test Title
   </title>
   <meta
+    content="Test Title"
+    property="og:title"
+  />
+  <meta
+    content="Test Title"
+    name="twitter:title"
+  />
+  <meta
     content="Test Description"
     name="description"
   />
@@ -125,6 +133,14 @@ exports[`MakeswiftPage metadata and seo tag rendering renders all metadata by de
   <title>
     Test Title
   </title>
+  <meta
+    content="Test Title"
+    property="og:title"
+  />
+  <meta
+    content="Test Title"
+    name="twitter:title"
+  />
   <link
     href="https://example.com/favicon.ico"
     rel="icon"
@@ -195,6 +211,14 @@ exports[`MakeswiftPage metadata and seo tag rendering renders all metadata when 
   <title>
     Test Title
   </title>
+  <meta
+    content="Test Title"
+    property="og:title"
+  />
+  <meta
+    content="Test Title"
+    name="twitter:title"
+  />
   <link
     href="https://example.com/favicon.ico"
     rel="icon"
@@ -265,6 +289,14 @@ exports[`MakeswiftPage metadata and seo tag rendering renders all metadata when 
   <title>
     Test Title
   </title>
+  <meta
+    content="Test Title"
+    property="og:title"
+  />
+  <meta
+    content="Test Title"
+    name="twitter:title"
+  />
   <link
     href="https://example.com/favicon.ico"
     rel="icon"


### PR DESCRIPTION
Reintroduces the Open Graph / Twitter Card  meta tags for the `<Page />` component's title.

![CleanShot 2025-07-01 at 11 06 54](https://github.com/user-attachments/assets/f101e03a-9a00-41d7-9f96-ff1da2cac26b)
