### PR TITLE
chore(runtime): fix Prettier formatting issues, no semantic changes

### DIFF
--- a/packages/runtime/.prettierignore
+++ b/packages/runtime/.prettierignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+CHANGELOG.md

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -120,7 +120,9 @@
     "test": "jest",
     "test:updateSnapshot": "jest --updateSnapshot",
     "test:watch": "jest --watch",
-    "madge": "madge --circular --warning --extensions ts,tsx src/ --exclude \"dist/.+\""
+    "madge": "madge --circular --warning --extensions ts,tsx src/ --exclude \"dist/.+\"",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "peerDependencies": {
     "@types/react": "^18.0.0 || ^19.0.0",

--- a/packages/runtime/src/builder/serialization/controls/types.ts
+++ b/packages/runtime/src/builder/serialization/controls/types.ts
@@ -5,11 +5,12 @@ type AnyFunction = (...args: any[]) => any
 export type Serialize<T> = T extends AnyFunction
   ? SerializedFunction<T>
   : T extends Record<string, unknown>
-  ? { [K in keyof T]: Serialize<T[K]> }
-  : T
+    ? { [K in keyof T]: Serialize<T[K]> }
+    : T
 
-export type Deserialize<T> = T extends SerializedFunction<infer U>
-  ? DeserializedFunction<U>
-  : T extends Record<string, unknown>
-  ? { [K in keyof T]: Deserialize<T[K]> }
-  : T
+export type Deserialize<T> =
+  T extends SerializedFunction<infer U>
+    ? DeserializedFunction<U>
+    : T extends Record<string, unknown>
+      ? { [K in keyof T]: Deserialize<T[K]> }
+      : T

--- a/packages/runtime/src/builder/unstructured-introspection/unstructured-introspection.test.ts
+++ b/packages/runtime/src/builder/unstructured-introspection/unstructured-introspection.test.ts
@@ -9,17 +9,17 @@ describe('Unstructured Introspection', () => {
     expect(introspectedResourceIds).toMatchSnapshot('Resources relevant to cross-site copy/paste')
   })
   test('recognizes node ID that has colons in its value', () => {
-    const typeName = "Swatch"
-    const value = "a:b::c"
+    const typeName = 'Swatch'
+    const value = 'a:b::c'
     const nodeId = Buffer.from(`${typeName}:${value}`).toString('base64')
     const element = {
-      "key": "00000000-0000-0000-0000-000000000000",
-      "props": {
-        "testProp": {
-          "swatchId": nodeId,
+      key: '00000000-0000-0000-0000-000000000000',
+      props: {
+        testProp: {
+          swatchId: nodeId,
         },
       },
-      "type": "test"
+      type: 'test',
     }
     const introspectedResourceIds = unstructuredIntrospection(element)
     expect(Array.from(introspectedResourceIds.swatchIds)).toEqual([nodeId])

--- a/packages/runtime/src/client/index.ts
+++ b/packages/runtime/src/client/index.ts
@@ -323,8 +323,8 @@ export class MakeswiftClient {
     if (typeof apiKey !== 'string') {
       throw new Error(
         'The Makeswift client must be passed a valid Makeswift site API key: ' +
-        "`new Makeswift('<makeswift_site_api_key>')`\n" +
-        `Received "${apiKey}" instead.`,
+          "`new Makeswift('<makeswift_site_api_key>')`\n" +
+          `Received "${apiKey}" instead.`,
       )
     }
 
@@ -342,10 +342,7 @@ export class MakeswiftClient {
     this.runtime = runtime
   }
 
-  private async fetch(
-    path: string,
-    siteVersion: MakeswiftSiteVersion,
-  ): Promise<Response> {
+  private async fetch(path: string, siteVersion: MakeswiftSiteVersion): Promise<Response> {
     const response = await fetch(new URL(path, this.apiOrigin).toString(), {
       headers: {
         ['X-API-Key']: this.apiKey,
@@ -362,9 +359,7 @@ export class MakeswiftClient {
   /**
    * Override this method to provide additional fetch options, e.g. revalidation, cache tags, etc.
    */
-  fetchOptions(
-    _siteVersion: MakeswiftSiteVersion,
-  ): Record<string, unknown> {
+  fetchOptions(_siteVersion: MakeswiftSiteVersion): Record<string, unknown> {
     return {}
   }
 

--- a/packages/runtime/src/components/builtin/SocialLinks/options.tsx
+++ b/packages/runtime/src/components/builtin/SocialLinks/options.tsx
@@ -52,4 +52,4 @@ export const SocialLinksOptions = [
   { type: 'youtube', label: 'YouTube', icon: <LogoYoutube20 />, brandColor: '#ff0000' },
 ] as const
 
-export type SocialLinksOptionType = typeof SocialLinksOptions[number]['type']
+export type SocialLinksOptionType = (typeof SocialLinksOptions)[number]['type']

--- a/packages/runtime/src/components/hooks/useRouterLocaleSync.ts
+++ b/packages/runtime/src/components/hooks/useRouterLocaleSync.ts
@@ -11,7 +11,7 @@ function useRouter() {
 
     return router
   } catch (e) {
-    return;
+    return
   }
 }
 

--- a/packages/runtime/src/components/shared/BackgroundsContainer/components/Backgrounds/index.tsx
+++ b/packages/runtime/src/components/shared/BackgroundsContainer/components/Backgrounds/index.tsx
@@ -121,7 +121,7 @@ const ImageBackgroundRepeat = {
   Repeat: 'repeat',
 } as const
 
-type ImageBackgroundRepeat = typeof ImageBackgroundRepeat[keyof typeof ImageBackgroundRepeat]
+type ImageBackgroundRepeat = (typeof ImageBackgroundRepeat)[keyof typeof ImageBackgroundRepeat]
 
 const ImageBackgroundSize = {
   Cover: 'cover',
@@ -129,7 +129,7 @@ const ImageBackgroundSize = {
   Auto: 'auto',
 } as const
 
-type ImageBackgroundSize = typeof ImageBackgroundSize[keyof typeof ImageBackgroundSize]
+type ImageBackgroundSize = (typeof ImageBackgroundSize)[keyof typeof ImageBackgroundSize]
 
 type ImageBackgroundProps = {
   publicUrl?: string
@@ -234,7 +234,7 @@ const BackgroundVideoAspectRatio = {
 } as const
 
 type BackgroundVideoAspectRatio =
-  typeof BackgroundVideoAspectRatio[keyof typeof BackgroundVideoAspectRatio]
+  (typeof BackgroundVideoAspectRatio)[keyof typeof BackgroundVideoAspectRatio]
 
 function getAspectRatio(aspectRatio: BackgroundVideoAspectRatio | null | undefined): number {
   switch (aspectRatio) {

--- a/packages/runtime/src/next/api-handler/handlers/redirect-draft.test.ts
+++ b/packages/runtime/src/next/api-handler/handlers/redirect-draft.test.ts
@@ -2,7 +2,7 @@ import { NextRequest } from 'next/server'
 import { originalRequestProtocol } from './redirect-draft'
 
 describe('redirectDraftRouteHandler', () => {
-  describe('correctly extracts original request protocol from the \'x-forwarded-proto\' header', () => {
+  describe("correctly extracts original request protocol from the 'x-forwarded-proto' header", () => {
     test.each([
       [undefined, null],
       ['https', 'https'],
@@ -11,7 +11,9 @@ describe('redirectDraftRouteHandler', () => {
       ['https, https,http', 'https'],
       ['https,   https,  http', 'https'],
     ])(`%s -> %s`, (header, expected) => {
-      const request = new NextRequest('https://api.makeswift.com', { headers: header != null ? { 'x-forwarded-proto': header } : {} })
+      const request = new NextRequest('https://api.makeswift.com', {
+        headers: header != null ? { 'x-forwarded-proto': header } : {},
+      })
       expect(originalRequestProtocol(request)).toEqual(expected)
     })
   })

--- a/packages/runtime/src/next/api-handler/handlers/redirect-draft.ts
+++ b/packages/runtime/src/next/api-handler/handlers/redirect-draft.ts
@@ -116,7 +116,7 @@ async function redirectDraftRouteHandler(
 async function redirectDraftApiRouteHandler(
   _req: NextApiRequest,
   res: NextApiResponse<RedirectDraftResponse>,
-  { }: { apiKey: string },
+  {}: { apiKey: string },
 ): Promise<void> {
   const message =
     'Cannot request draft endpoint from an API handler registered in `pages`. Move your Makeswift API handler to the `app` directory'

--- a/packages/runtime/src/next/api-handler/handlers/redirect-preview.ts
+++ b/packages/runtime/src/next/api-handler/handlers/redirect-preview.ts
@@ -51,14 +51,13 @@ export default async function redirectPreviewHandler(
 async function redirectPreviewRouteHandler(
   _request: NextRequest,
   _context: Context,
-  { }: { apiKey: string },
+  {}: { apiKey: string },
 ): Promise<NextResponse<RedirectPreviewResponse>> {
   const message =
     'Cannot request preview endpoint from an API handler registered in `app`. Move your Makeswift API handler to the `pages/api` directory'
   console.error(message)
   return NextResponse.json(message, { status: 500 })
 }
-
 
 async function redirectPreviewApiRouteHandler(
   req: NextApiRequest,
@@ -81,7 +80,9 @@ async function redirectPreviewApiRouteHandler(
   }
 
   if (pathname == null) {
-    return res.status(400).send('Bad request: incoming request does not have an associated pathname')
+    return res
+      .status(400)
+      .send('Bad request: incoming request does not have an associated pathname')
   }
 
   const setCookie = res

--- a/packages/runtime/src/next/api-handler/handlers/webhook/index.ts
+++ b/packages/runtime/src/next/api-handler/handlers/webhook/index.ts
@@ -13,8 +13,8 @@ import {
 type Context = { params: { [key: string]: string | string[] } }
 
 type WebhookParams = {
-  apiKey: string,
-  events?: { onPublish?: OnPublish },
+  apiKey: string
+  events?: { onPublish?: OnPublish }
 }
 
 export type WebhookHandlerArgs =
@@ -74,7 +74,9 @@ export default async function handler(
   }
 
   const result = await match(payload.type)
-    .with(WebhookEventType.SITE_PUBLISHED, () => handleSitePublished(payload, { onPublish: events?.onPublish }))
+    .with(WebhookEventType.SITE_PUBLISHED, () =>
+      handleSitePublished(payload, { onPublish: events?.onPublish }),
+    )
     .exhaustive()
 
   return respond(args, result.body, result.status)

--- a/packages/runtime/src/next/client.ts
+++ b/packages/runtime/src/next/client.ts
@@ -7,7 +7,6 @@ import { MakeswiftClient } from '../client'
 import { MAKESWIFT_CACHE_TAG } from './cache'
 
 export class Makeswift extends MakeswiftClient {
-
   static getSiteVersion(previewData: PreviewData): MakeswiftSiteVersion {
     return getMakeswiftSiteVersion(previewData) ?? MakeswiftSiteVersion.Live
   }
@@ -16,9 +15,7 @@ export class Makeswift extends MakeswiftClient {
     return getMakeswiftSiteVersion(previewData) === MakeswiftSiteVersion.Working
   }
 
-  fetchOptions(
-    _siteVersion: MakeswiftSiteVersion,
-  ): Record<string, unknown> {
+  fetchOptions(_siteVersion: MakeswiftSiteVersion): Record<string, unknown> {
     return {
       next: {
         tags: [MAKESWIFT_CACHE_TAG],

--- a/packages/runtime/src/next/components/tests/makeswift-page-metadata-rendering.test.tsx
+++ b/packages/runtime/src/next/components/tests/makeswift-page-metadata-rendering.test.tsx
@@ -86,9 +86,7 @@ async function testMakeswiftPageMetadataRendering(
   )
 }
 
-function getPageMetaTags(
-  container: HTMLElement,
-): { name: string; content: string }[] {
+function getPageMetaTags(container: HTMLElement): { name: string; content: string }[] {
   const metaTags = container.getElementsByTagName('meta')
   return Array.from(metaTags).filter(({ name }) => name !== 'makeswift-draft-info')
 }

--- a/packages/runtime/src/next/index.tsx
+++ b/packages/runtime/src/next/index.tsx
@@ -2,7 +2,12 @@ export type { PageProps } from './components/page'
 export { Page } from './components/page'
 export { MakeswiftComponent } from './components/MakeswiftComponent'
 export { Slot } from './components/Slot'
-export type { MakeswiftPage, MakeswiftPageDocument, MakeswiftPageSnapshot, Sitemap } from '../client'
+export type {
+  MakeswiftPage,
+  MakeswiftPageDocument,
+  MakeswiftPageSnapshot,
+  Sitemap,
+} from '../client'
 export { Makeswift } from './client'
 export type { MakeswiftPreviewData } from './preview-mode'
 export { RootStyleRegistry } from './root-style-registry'

--- a/packages/runtime/src/next/tests/server.makeswift-api-handler.test.ts
+++ b/packages/runtime/src/next/tests/server.makeswift-api-handler.test.ts
@@ -1,11 +1,11 @@
-import { createResponse } from "node-mocks-http"
-import { randomUUID } from "crypto"
+import { createResponse } from 'node-mocks-http'
+import { randomUUID } from 'crypto'
 import * as nextCache from 'next/cache'
 
-import { MakeswiftApiHandler } from "../api-handler"
+import { MakeswiftApiHandler } from '../api-handler'
 import { NextApiResponse } from 'next'
-import { ReactRuntime } from "../../react"
-import { createNextApiRequest } from "./test-utils"
+import { ReactRuntime } from '../../react'
+import { createNextApiRequest } from './test-utils'
 
 const apiKey = 'fake-api-key'
 
@@ -33,8 +33,8 @@ describe('MakeswiftApiHandler', () => {
   let consoleErrorSpy: jest.SpyInstance
 
   beforeEach(() => {
-    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
-  });
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+  })
 
   describe('/api/makeswift/revalidate', () => {
     function revalidateResponse({ revalidate }: { revalidate: (path: string) => Promise<void> }) {
@@ -57,7 +57,7 @@ describe('MakeswiftApiHandler', () => {
       // Act
       await handler(
         createNextApiRequest({ method: 'GET', path: '/makeswift/revalidate' }),
-        response
+        response,
       )
 
       // Assert
@@ -86,7 +86,10 @@ describe('MakeswiftApiHandler', () => {
 
       // Act
       await handler(
-        createNextApiRequest({ method: 'GET', path: `/makeswift/revalidate?secret=${apiKey}&path=/some-path` }),
+        createNextApiRequest({
+          method: 'GET',
+          path: `/makeswift/revalidate?secret=${apiKey}&path=/some-path`,
+        }),
         response,
       )
 
@@ -98,14 +101,15 @@ describe('MakeswiftApiHandler', () => {
 
   describe('/api/makeswift/webhook', () => {
     const webhookPayload = {
-      type: 'site.published', data: {
+      type: 'site.published',
+      data: {
         siteId: randomUUID(),
         publish: {
           from: null,
           to: randomUUID(),
         },
         at: 1234567890,
-      }
+      },
     }
 
     function createWebhookFixture(args: MakeswiftApiHandlerArgs = {}) {
@@ -122,7 +126,7 @@ describe('MakeswiftApiHandler', () => {
       // Act
       await handler(
         createNextApiRequest({ method: 'POST', path: '/makeswift/webhook', body: webhookPayload }),
-        response
+        response,
       )
 
       // Assert
@@ -140,7 +144,7 @@ describe('MakeswiftApiHandler', () => {
         createNextApiRequest({
           method: 'POST',
           path: `/makeswift/webhook?secret=${apiKey}`,
-          body: { type: 'invalid.type' }
+          body: { type: 'invalid.type' },
         }),
         response,
       )
@@ -150,9 +154,11 @@ describe('MakeswiftApiHandler', () => {
       expect(response._getJSONData()).toEqual({ message: 'Invalid request body' })
       expect(nextCache.revalidateTag).not.toHaveBeenCalled()
 
-      expect(consoleErrorSpy).toHaveBeenCalledWith(expect.objectContaining({
-        message: expect.stringContaining('Invalid literal value')
-      }))
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('Invalid literal value'),
+        }),
+      )
     })
 
     test('200s and calls user-provided onPublish callback', async () => {
@@ -165,7 +171,7 @@ describe('MakeswiftApiHandler', () => {
         createNextApiRequest({
           method: 'POST',
           path: `/makeswift/webhook?secret=${apiKey}`,
-          body: webhookPayload
+          body: webhookPayload,
         }),
         response,
       )
@@ -177,7 +183,9 @@ describe('MakeswiftApiHandler', () => {
 
     test('200s and calls revalidateTag when user-provided onPublish callback fails', async () => {
       // Arrange
-      const onPublish = jest.fn(() => { throw new Error('Failed in user-provided onPublish') })
+      const onPublish = jest.fn(() => {
+        throw new Error('Failed in user-provided onPublish')
+      })
       const { handler, response } = createWebhookFixture({ events: { onPublish } })
 
       // Act
@@ -185,7 +193,7 @@ describe('MakeswiftApiHandler', () => {
         createNextApiRequest({
           method: 'POST',
           path: `/makeswift/webhook?secret=${apiKey}`,
-          body: webhookPayload
+          body: webhookPayload,
         }),
         response,
       )
@@ -195,9 +203,10 @@ describe('MakeswiftApiHandler', () => {
       expect(nextCache.revalidateTag).toHaveBeenCalledWith('@@makeswift')
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        "Unhandled exception in the 'onPublish' callback:", expect.objectContaining({
+        "Unhandled exception in the 'onPublish' callback:",
+        expect.objectContaining({
           message: 'Failed in user-provided onPublish',
-        })
+        }),
       )
     })
   })

--- a/packages/runtime/src/next/tests/test-utils.ts
+++ b/packages/runtime/src/next/tests/test-utils.ts
@@ -1,5 +1,5 @@
-import { NextApiRequest } from "next"
-import { createRequest, RequestMethod } from "node-mocks-http"
+import { NextApiRequest } from 'next'
+import { createRequest, RequestMethod } from 'node-mocks-http'
 
 type Query = { [key: string]: Query } | string[]
 
@@ -21,16 +21,14 @@ function urlToQuery(url: URL): Query {
 
   return {
     ...structure,
-    ...Object.fromEntries(
-      url.searchParams.entries(),
-    ),
+    ...Object.fromEntries(url.searchParams.entries()),
   }
 }
 
 export function createNextApiRequest({
   method,
   path,
-  body
+  body,
 }: {
   method: RequestMethod
   path: string
@@ -40,6 +38,6 @@ export function createNextApiRequest({
     method,
     url: path,
     query: urlToQuery(new URL(path, 'http://localhost')),
-    body
+    body,
   })
 }

--- a/packages/runtime/src/runtimes/react/components/PageProvider.tsx
+++ b/packages/runtime/src/runtimes/react/components/PageProvider.tsx
@@ -3,7 +3,7 @@ import { PageContext } from '../hooks/use-page-id'
 
 type PageProviderProps = {
   id: string
-  children: ComponentPropsWithoutRef<typeof PageContext['Provider']>['children']
+  children: ComponentPropsWithoutRef<(typeof PageContext)['Provider']>['children']
 }
 
 export function PageProvider({ id, children }: PageProviderProps) {

--- a/packages/runtime/src/runtimes/react/components/draft-switcher/draft-switcher.tsx
+++ b/packages/runtime/src/runtimes/react/components/draft-switcher/draft-switcher.tsx
@@ -49,7 +49,8 @@ export function DraftSwitcher({ isDraft }: { isDraft: boolean }) {
           issues on production sites */}
       <PageMeta
         name="makeswift-draft-info"
-        content={JSON.stringify({ draft: isDraft, inBuilder: isInBuilder })} />
+        content={JSON.stringify({ draft: isDraft, inBuilder: isInBuilder })}
+      />
     </>
   )
 }

--- a/packages/runtime/src/runtimes/react/element-imperative-handle.ts
+++ b/packages/runtime/src/runtimes/react/element-imperative-handle.ts
@@ -8,8 +8,9 @@ import {
 } from '../../state/modules/prop-controller-handles'
 
 export class ElementImperativeHandle<
-  T extends Record<string, Descriptor> = Record<string, Descriptor>,
-> implements BoxModelHandle, PropControllersHandle<T>
+    T extends Record<string, Descriptor> = Record<string, Descriptor>,
+  >
+  implements BoxModelHandle, PropControllersHandle<T>
 {
   private getCurrent: () => unknown = () => null
   private lastPropControllers: DescriptorsPropControllers<T> | null = null

--- a/packages/runtime/src/runtimes/react/hooks/use-register-document.ts
+++ b/packages/runtime/src/runtimes/react/hooks/use-register-document.ts
@@ -2,7 +2,11 @@ import { useEffect } from 'react'
 import { type Document } from '../../../state/react-page'
 import { useDispatch } from './use-dispatch'
 import { useIsInBuilder } from './use-is-in-builder'
-import { registerBuilderDocumentsEffect, registerDocument, registerDocumentsEffect } from '../../../state/actions'
+import {
+  registerBuilderDocumentsEffect,
+  registerDocument,
+  registerDocumentsEffect,
+} from '../../../state/actions'
 import { isServer } from '../../../utils/is-server'
 import { useIsomorphicLayoutEffect } from '../../../components/hooks/useIsomorphicLayoutEffect'
 

--- a/packages/runtime/src/state/modules/builder-edit-mode.ts
+++ b/packages/runtime/src/state/modules/builder-edit-mode.ts
@@ -6,7 +6,7 @@ export const BuilderEditMode = {
   INTERACT: 'interact',
 } as const
 
-export type BuilderEditMode = typeof BuilderEditMode[keyof typeof BuilderEditMode]
+export type BuilderEditMode = (typeof BuilderEditMode)[keyof typeof BuilderEditMode]
 
 export type State = BuilderEditMode | null
 

--- a/packages/runtime/src/state/modules/components-meta.ts
+++ b/packages/runtime/src/state/modules/components-meta.ts
@@ -25,7 +25,7 @@ export const ComponentIcon = {
   Video: 'video',
 } as const
 
-export type ComponentIcon = typeof ComponentIcon[keyof typeof ComponentIcon]
+export type ComponentIcon = (typeof ComponentIcon)[keyof typeof ComponentIcon]
 
 export type ComponentMeta = { label: string; icon: ComponentIcon; hidden: boolean }
 

--- a/packages/runtime/src/utils/intersection.ts
+++ b/packages/runtime/src/utils/intersection.ts
@@ -8,10 +8,13 @@ export default function intersection<A extends Record<string, unknown>, B extend
 ): { [K in keyof A]: A[K] | null } {
   const allKeys = [...new Set([...keys(a), ...keys(b)])] as (keyof A)[]
 
-  return allKeys.reduce((acc, k) => {
-    if (isEqual(a[k], b[k])) acc[k] = a[k]
-    else acc[k] = null
+  return allKeys.reduce(
+    (acc, k) => {
+      if (isEqual(a[k], b[k])) acc[k] = a[k]
+      else acc[k] = null
 
-    return acc
-  }, {} as { [K in keyof A]: A[K] | null })
+      return acc
+    },
+    {} as { [K in keyof A]: A[K] | null },
+  )
 }

--- a/packages/runtime/src/utils/pagination.ts
+++ b/packages/runtime/src/utils/pagination.ts
@@ -9,9 +9,10 @@ type PaginationFunction<Options, R extends { id: any }> = Options extends {
   ? (options: Options) => Promise<PaginationResult<R>>
   : never
 
-type IterableMethod<Options, R> = Partial<Options> extends Options
-  ? (options?: Options) => IterablePaginationResult<R>
-  : (options: Options) => IterablePaginationResult<R>
+type IterableMethod<Options, R> =
+  Partial<Options> extends Options
+    ? (options?: Options) => IterablePaginationResult<R>
+    : (options: Options) => IterablePaginationResult<R>
 
 export function toIterablePaginationResult<Options, R extends { id: string }>(
   fn: PaginationFunction<Options, R>,


### PR DESCRIPTION
Note that we have multiple different Prettier configurations across the `controls` and `runtime` packages, as well as at the root of the repository, and unifying them is outside the scope of this PR. This change simply brings the `runtime` package in line with its own Prettier configuration.