### PR TITLE
feat: framework-independent `RootStyleRegistry` implementation

### DIFF
--- a/.changeset/stale-lemons-wonder.md
+++ b/.changeset/stale-lemons-wonder.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+feat: framework-independent `RootStyleRegistry` implementation

--- a/packages/runtime/src/next/index.tsx
+++ b/packages/runtime/src/next/index.tsx
@@ -10,5 +10,5 @@ export type {
 } from '../client'
 export { Makeswift } from './client'
 export type { MakeswiftPreviewData } from './preview-mode'
-export { RootStyleRegistry } from './root-style-registry'
+export { NextRootStyleRegistry as RootStyleRegistry } from './root-style-registry'
 export { NextRuntimeProvider as ReactRuntimeProvider } from './runtime-provider'

--- a/packages/runtime/src/next/root-style-registry.tsx
+++ b/packages/runtime/src/next/root-style-registry.tsx
@@ -1,38 +1,14 @@
 'use client'
 
-import createCache, { EmotionCache } from '@emotion/cache'
-import { cache } from '@emotion/css'
+import { type ReactNode, useState } from 'react'
 import { useServerInsertedHTML } from 'next/navigation'
-import { ReactNode, createContext, useContext, useState } from 'react'
 
-const CacheContext = createContext(cache)
+import {
+  createRootStyleCache,
+  RootStyleRegistry as ReactRootStyleRegistry,
+} from '../runtimes/react/root-style-registry'
 
-const DEFAULT_CSS_RESET_ENABLED = true
-const CSSResetEnabledContext = createContext(DEFAULT_CSS_RESET_ENABLED)
-
-const createRootStyleCache = ({ key }: { key: string }) => {
-  const cache = createCache({ key })
-  cache.compat = true
-
-  const prevInsert = cache.insert
-  let inserted: string[] = []
-
-  cache.insert = (...args) => {
-    const serialized = args[1]
-    if (cache.inserted[serialized.name] === undefined) {
-      inserted.push(serialized.name)
-    }
-    return prevInsert(...args)
-  }
-
-  const flush = () => {
-    const prevInserted = inserted
-    inserted = []
-    return prevInserted
-  }
-
-  return { cache, flush }
-}
+export { useCache, useCSSResetEnabled } from '../runtimes/react/root-style-registry'
 
 type Props = {
   children: ReactNode
@@ -44,12 +20,8 @@ type Props = {
   enableCssReset?: boolean
 }
 
-export function RootStyleRegistry({
-  children,
-  cacheKey,
-  enableCssReset = DEFAULT_CSS_RESET_ENABLED,
-}: Props) {
-  const [{ cache, flush }] = useState(() => createRootStyleCache({ key: cacheKey ?? 'mswft' }))
+export function NextRootStyleRegistry({ children, cacheKey, enableCssReset }: Props) {
+  const [{ cache, flush }] = useState(() => createRootStyleCache({ key: cacheKey }))
 
   useServerInsertedHTML(() => {
     const names = flush()
@@ -70,18 +42,8 @@ export function RootStyleRegistry({
   })
 
   return (
-    <CacheContext.Provider value={cache}>
-      <CSSResetEnabledContext.Provider value={enableCssReset}>
-        {children}
-      </CSSResetEnabledContext.Provider>
-    </CacheContext.Provider>
+    <ReactRootStyleRegistry cache={cache} enableCssReset={enableCssReset}>
+      {children}
+    </ReactRootStyleRegistry>
   )
-}
-
-export function useCache(): EmotionCache {
-  return useContext(CacheContext)
-}
-
-export function useCSSResetEnabled(): boolean {
-  return useContext(CSSResetEnabledContext)
 }

--- a/packages/runtime/src/next/testing/react-provider.tsx
+++ b/packages/runtime/src/next/testing/react-provider.tsx
@@ -2,7 +2,7 @@ import { ReactRuntime } from '../../runtimes/react/react-runtime'
 import { RuntimeProvider } from '../../runtimes/react/components/RuntimeProvider'
 
 import { FrameworkProvider } from '../components/framework-provider'
-import { RootStyleRegistry } from '../root-style-registry'
+import { NextRootStyleRegistry } from '../root-style-registry'
 
 export function ReactProvider({
   children,
@@ -18,7 +18,7 @@ export function ReactProvider({
   return (
     <FrameworkProvider forcePagesRouter={forcePagesRouter}>
       <RuntimeProvider previewMode={previewMode} runtime={runtime}>
-        <RootStyleRegistry>{children}</RootStyleRegistry>
+        <NextRootStyleRegistry>{children}</NextRootStyleRegistry>
       </RuntimeProvider>
     </FrameworkProvider>
   )

--- a/packages/runtime/src/runtimes/react/root-style-registry.tsx
+++ b/packages/runtime/src/runtimes/react/root-style-registry.tsx
@@ -1,0 +1,60 @@
+import createCache, { EmotionCache } from '@emotion/cache'
+import { cache } from '@emotion/css'
+import { ReactNode, createContext, useContext } from 'react'
+
+const CacheContext = createContext(cache)
+
+const DEFAULT_CSS_RESET_ENABLED = true
+const CSSResetEnabledContext = createContext(DEFAULT_CSS_RESET_ENABLED)
+
+export const createRootStyleCache = ({ key }: { key?: string } = {}) => {
+  const cache = createCache({ key: key ?? 'mswft' })
+  cache.compat = true
+
+  const prevInsert = cache.insert
+  let inserted: string[] = []
+
+  cache.insert = (...args) => {
+    const serialized = args[1]
+    if (cache.inserted[serialized.name] === undefined) {
+      inserted.push(serialized.name)
+    }
+    return prevInsert(...args)
+  }
+
+  const flush = () => {
+    const prevInserted = inserted
+    inserted = []
+    return prevInserted
+  }
+
+  return { cache, flush }
+}
+
+type Props = {
+  children: ReactNode
+  cache: EmotionCache
+  /**
+   * Toggle the built-in CSS reset.
+   * Set to `false` when using `@layer`-based CSS frameworks like Tailwind.
+   */
+  enableCssReset?: boolean
+}
+
+export function RootStyleRegistry({ children, cache, enableCssReset }: Props) {
+  return (
+    <CacheContext.Provider value={cache}>
+      <CSSResetEnabledContext.Provider value={enableCssReset ?? DEFAULT_CSS_RESET_ENABLED}>
+        {children}
+      </CSSResetEnabledContext.Provider>
+    </CacheContext.Provider>
+  )
+}
+
+export function useCache(): EmotionCache {
+  return useContext(CacheContext)
+}
+
+export function useCSSResetEnabled(): boolean {
+  return useContext(CSSResetEnabledContext)
+}


### PR DESCRIPTION
Decouple core `RootStyleRegistry` implementation from Next.js. No additional tests as we already have extensive test coverage for this.