### PR TITLE
chore: decouple `Slot`/`MakeswiftComponent` from Next.js

### DIFF
--- a/packages/runtime/src/components/builtin/Slot/Slot.tsx
+++ b/packages/runtime/src/components/builtin/Slot/Slot.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { ReactNode, useContext } from 'react'
-import { PropsContext } from '../../../next/components/SlotProvider'
+import { PropsContext } from '../../../runtimes/react/components/SlotProvider'
 
 type Props = {
   children: ReactNode

--- a/packages/runtime/src/next/components/tests/controls/page-control-prop-rendering.tsx
+++ b/packages/runtime/src/next/components/tests/controls/page-control-prop-rendering.tsx
@@ -11,7 +11,7 @@ import { type Data, type ValueType, type DataType, ControlDefinition } from '@ma
 import { type CacheData } from '../../../../api/react'
 import { ElementData } from '../../../../state/react-page'
 import { ReactRuntime } from '../../../../react'
-import { MakeswiftComponent } from '../../MakeswiftComponent'
+import { MakeswiftComponent } from '../../../../runtimes/react/components/MakeswiftComponent'
 import { Page } from '../../page'
 import { isServer } from '../../../../utils/is-server'
 import * as Testing from '../../../testing'

--- a/packages/runtime/src/next/components/tests/makeswift-component-rendering.test.tsx
+++ b/packages/runtime/src/next/components/tests/makeswift-component-rendering.test.tsx
@@ -5,7 +5,7 @@ import { act } from 'react-dom/test-utils'
 import { render, screen } from '@testing-library/react'
 import { ReactRuntime } from '../../../react'
 import * as Testing from '../../testing'
-import { MakeswiftComponent } from '../MakeswiftComponent'
+import { MakeswiftComponent } from '../../../runtimes/react/components/MakeswiftComponent'
 import {
   type MakeswiftComponentSnapshotMetadata,
   type MakeswiftComponentDocument,

--- a/packages/runtime/src/next/index.tsx
+++ b/packages/runtime/src/next/index.tsx
@@ -1,7 +1,7 @@
 export type { PageProps } from './components/page'
 export { Page } from './components/page'
-export { MakeswiftComponent } from './components/MakeswiftComponent'
-export { Slot } from './components/Slot'
+export { MakeswiftComponent } from '../runtimes/react/components/MakeswiftComponent'
+export { Slot } from '../runtimes/react/components/Slot'
 export type {
   MakeswiftPage,
   MakeswiftPageDocument,

--- a/packages/runtime/src/runtimes/react/components/MakeswiftComponent.tsx
+++ b/packages/runtime/src/runtimes/react/components/MakeswiftComponent.tsx
@@ -1,10 +1,13 @@
 'use client'
 
 import { memo, Suspense, useMemo } from 'react'
-import { componentDocumentToRootEmbeddedDocument, MakeswiftComponentSnapshot } from '../../client'
-import { DocumentRoot } from '../../runtimes/react/components/DocumentRoot'
-import { useCacheData } from '../../runtimes/react/hooks/use-cache-data'
-import { useRegisterDocument } from '../../runtimes/react/hooks/use-register-document'
+import {
+  componentDocumentToRootEmbeddedDocument,
+  MakeswiftComponentSnapshot,
+} from '../../../client'
+import { DocumentRoot } from './DocumentRoot'
+import { useCacheData } from '../hooks/use-cache-data'
+import { useRegisterDocument } from '../hooks/use-register-document'
 
 type Props = {
   snapshot: MakeswiftComponentSnapshot

--- a/packages/runtime/src/runtimes/react/components/Slot.tsx
+++ b/packages/runtime/src/runtimes/react/components/Slot.tsx
@@ -1,10 +1,11 @@
 'use client'
 
 import { ReactNode, useMemo } from 'react'
-import { MakeswiftComponentSnapshot } from '../../client'
-import { MakeswiftComponentType } from '../../components'
+import { MakeswiftComponentSnapshot } from '../../../client'
+import { MakeswiftComponentType } from '../../../components'
+
 import { MakeswiftComponent } from './MakeswiftComponent'
-import SlotProvider from './SlotProvider'
+import { SlotProvider } from './SlotProvider'
 
 type Props = {
   label: string
@@ -21,5 +22,3 @@ export const Slot = ({ label, snapshot, fallback }: Props) => {
     </SlotProvider>
   )
 }
-
-export default Slot

--- a/packages/runtime/src/runtimes/react/components/SlotProvider.tsx
+++ b/packages/runtime/src/runtimes/react/components/SlotProvider.tsx
@@ -6,7 +6,7 @@ export const PropsContext = createContext<{
   fallback: null,
 })
 
-function SlotProvider({
+export function SlotProvider({
   value,
   children,
 }: {
@@ -15,5 +15,3 @@ function SlotProvider({
 }) {
   return <PropsContext.Provider value={value}>{children}</PropsContext.Provider>
 }
-
-export default SlotProvider


### PR DESCRIPTION
They weren't really coupled to Next.js in the first place, so mostly just moving them under `runtimes/react`. No user-visible changes.