### PR TITLE
tests: built-in `Image` component rendering tests

### DIFF
--- a/packages/runtime/src/next/components/tests/__fixtures__/element-data/image-component.ts
+++ b/packages/runtime/src/next/components/tests/__fixtures__/element-data/image-component.ts
@@ -1,0 +1,162 @@
+import { type ElementData } from '@makeswift/controls'
+
+import { MakeswiftComponentType } from '../../../../../components'
+
+export const imageComponentData = ({
+  htmlId,
+  swatchId,
+  fileId,
+}: {
+  htmlId: string
+  swatchId: string
+  fileId: string
+}): ElementData => ({
+  key: '53d97944-87d4-4337-8260-a11c6bad827b',
+  props: {
+    altText: {
+      '@@makeswift/type': 'prop-controllers::text-input::v1',
+      value: 'Hill chart',
+    },
+    border: {
+      '@@makeswift/type': 'prop-controllers::border::v1',
+      value: [
+        {
+          deviceId: 'desktop',
+          value: {
+            borderBottom: {
+              color: {
+                alpha: 1,
+                swatchId,
+              },
+              style: 'solid',
+              width: 2,
+            },
+            borderLeft: {
+              color: {
+                alpha: 1,
+                swatchId,
+              },
+              style: 'solid',
+              width: 2,
+            },
+            borderRight: {
+              color: {
+                alpha: 1,
+                swatchId,
+              },
+              style: 'solid',
+              width: 2,
+            },
+            borderTop: {
+              color: {
+                alpha: 1,
+                swatchId,
+              },
+              style: 'solid',
+              width: 2,
+            },
+          },
+        },
+      ],
+    },
+    borderRadius: {
+      '@@makeswift/type': 'prop-controllers::border-radius::v1',
+      value: [
+        {
+          deviceId: 'desktop',
+          value: {
+            borderBottomLeftRadius: {
+              unit: 'px',
+              value: 6,
+            },
+            borderBottomRightRadius: {
+              unit: 'px',
+              value: 6,
+            },
+            borderTopLeftRadius: {
+              unit: 'px',
+              value: 6,
+            },
+            borderTopRightRadius: {
+              unit: 'px',
+              value: 6,
+            },
+          },
+        },
+      ],
+    },
+    file: {
+      '@@makeswift/type': 'prop-controllers::image::v2',
+      value: {
+        id: fileId,
+        type: 'makeswift-file',
+        version: 1,
+      },
+    },
+    id: {
+      '@@makeswift/type': 'prop-controllers::element-id::v1',
+      value: htmlId,
+    },
+    margin: {
+      '@@makeswift/type': 'prop-controllers::margin::v1',
+      value: [
+        {
+          deviceId: 'desktop',
+          value: {
+            marginBottom: {
+              unit: 'px',
+              value: 25,
+            },
+            marginTop: {
+              unit: 'px',
+              value: 20,
+            },
+          },
+        },
+      ],
+    },
+    padding: {
+      '@@makeswift/type': 'prop-controllers::padding::v1',
+      value: [
+        {
+          deviceId: 'desktop',
+          value: {
+            paddingBottom: {
+              unit: 'px',
+              value: 5,
+            },
+            paddingLeft: {
+              unit: 'px',
+              value: 5,
+            },
+            paddingRight: {
+              unit: 'px',
+              value: 5,
+            },
+            paddingTop: {
+              unit: 'px',
+              value: 5,
+            },
+          },
+        },
+      ],
+    },
+    priority: {
+      '@@makeswift/type': 'prop-controllers::checkbox::v1',
+      value: true,
+    },
+    width: {
+      '@@makeswift/type': 'prop-controllers::width::v1',
+      value: [
+        {
+          deviceId: 'desktop',
+          value: {
+            unit: '%',
+            value: 90,
+          },
+        },
+      ],
+    },
+  },
+  type: MakeswiftComponentType.Image,
+})

--- a/packages/runtime/src/next/components/tests/__fixtures__/resources/files.ts
+++ b/packages/runtime/src/next/components/tests/__fixtures__/resources/files.ts
@@ -1,0 +1,14 @@
+import { type File } from '../../../../../api'
+
+export const file1: File = {
+  __typename: 'File',
+  id: 'RmlsZTplMGJlNzVmMC01MjhmLTRiM2EtYTY4YS1kNjhlMTJjODMwZDI=',
+  name: 'Hill Chart',
+  publicUrl:
+    'https://storage.googleapis.com/s.mkswft.com/RmlsZTplMGJlNzVmMC01MjhmLTRiM2EtYTY4YS1kNjhlMTJjODMwZDI=/Hill%20Chart.png',
+  extension: 'png',
+  dimensions: {
+    width: 2700,
+    height: 1119,
+  },
+}

--- a/packages/runtime/src/next/components/tests/__fixtures__/resources/index.ts
+++ b/packages/runtime/src/next/components/tests/__fixtures__/resources/index.ts
@@ -1,0 +1,2 @@
+export * from './swatches'
+export * from './files'

--- a/packages/runtime/src/next/components/tests/__fixtures__/resources/swatches.ts
+++ b/packages/runtime/src/next/components/tests/__fixtures__/resources/swatches.ts
@@ -1,0 +1,9 @@
+import { type Swatch } from '../../../../../api'
+
+export const swatch1: Swatch = {
+  __typename: 'Swatch',
+  id: 'U3dhdGNoOmUyNmQyMGY3LWNlNmEtNDcwMS04N2U2LWU2ZTM2NzlmMDY4Zg==',
+  hue: 360,
+  saturation: 97.873924,
+  lightness: 52.965,
+}

--- a/packages/runtime/src/next/components/tests/components/__snapshots__/image-component-rendering.test.tsx.snap
+++ b/packages/runtime/src/next/components/tests/components/__snapshots__/image-component-rendering.test.tsx.snap
@@ -1,0 +1,173 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`correctly renders image component 1`] = `
+.emotion-0 {
+  line-height: 0;
+  overflow: hidden;
+}
+
+.emotion-1 {
+  max-width: 100%;
+}
+
+@media only screen and (min-width: 769px) {
+  .emotion-1 {
+    width: 90%;
+  }
+}
+
+@media only screen and (min-width: 576px) and (max-width: 768px) {
+  .emotion-1 {
+    width: 90%;
+  }
+}
+
+@media only screen and (max-width: 575px) {
+  .emotion-1 {
+    width: 90%;
+  }
+}
+
+@media only screen and (min-width: 769px) {
+  .emotion-2 {
+    opacity: 1;
+  }
+}
+
+@media only screen and (min-width: 576px) and (max-width: 768px) {
+  .emotion-2 {
+    opacity: 1;
+  }
+}
+
+@media only screen and (max-width: 575px) {
+  .emotion-2 {
+    opacity: 1;
+  }
+}
+
+@media only screen and (min-width: 769px) {
+  .emotion-3 {
+    margin-top: 20px;
+    margin-right: auto;
+    margin-bottom: 25px;
+    margin-left: auto;
+  }
+}
+
+@media only screen and (min-width: 576px) and (max-width: 768px) {
+  .emotion-3 {
+    margin-top: 20px;
+    margin-right: auto;
+    margin-bottom: 25px;
+    margin-left: auto;
+  }
+}
+
+@media only screen and (max-width: 575px) {
+  .emotion-3 {
+    margin-top: 20px;
+    margin-right: auto;
+    margin-bottom: 25px;
+    margin-left: auto;
+  }
+}
+
+@media only screen and (min-width: 769px) {
+  .emotion-4 {
+    padding-top: 5px;
+    padding-right: 5px;
+    padding-bottom: 5px;
+    padding-left: 5px;
+  }
+}
+
+@media only screen and (min-width: 576px) and (max-width: 768px) {
+  .emotion-4 {
+    padding-top: 5px;
+    padding-right: 5px;
+    padding-bottom: 5px;
+    padding-left: 5px;
+  }
+}
+
+@media only screen and (max-width: 575px) {
+  .emotion-4 {
+    padding-top: 5px;
+    padding-right: 5px;
+    padding-bottom: 5px;
+    padding-left: 5px;
+  }
+}
+
+@media only screen and (min-width: 769px) {
+  .emotion-5 {
+    border-top: 2px solid hsla(360,97.873924%,52.965%,1);
+    border-right: 2px solid hsla(360,97.873924%,52.965%,1);
+    border-bottom: 2px solid hsla(360,97.873924%,52.965%,1);
+    border-left: 2px solid hsla(360,97.873924%,52.965%,1);
+  }
+}
+
+@media only screen and (min-width: 576px) and (max-width: 768px) {
+  .emotion-5 {
+    border-top: 2px solid hsla(360,97.873924%,52.965%,1);
+    border-right: 2px solid hsla(360,97.873924%,52.965%,1);
+    border-bottom: 2px solid hsla(360,97.873924%,52.965%,1);
+    border-left: 2px solid hsla(360,97.873924%,52.965%,1);
+  }
+}
+
+@media only screen and (max-width: 575px) {
+  .emotion-5 {
+    border-top: 2px solid hsla(360,97.873924%,52.965%,1);
+    border-right: 2px solid hsla(360,97.873924%,52.965%,1);
+    border-bottom: 2px solid hsla(360,97.873924%,52.965%,1);
+    border-left: 2px solid hsla(360,97.873924%,52.965%,1);
+  }
+}
+
+@media only screen and (min-width: 769px) {
+  .emotion-6 {
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px;
+    border-bottom-right-radius: 6px;
+    border-bottom-left-radius: 6px;
+  }
+}
+
+@media only screen and (min-width: 576px) and (max-width: 768px) {
+  .emotion-6 {
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px;
+    border-bottom-right-radius: 6px;
+    border-bottom-left-radius: 6px;
+  }
+}
+
+@media only screen and (max-width: 575px) {
+  .emotion-6 {
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px;
+    border-bottom-right-radius: 6px;
+    border-bottom-left-radius: 6px;
+  }
+}
+
+<div
+  class="emotion-0 emotion-1 emotion-2 emotion-3 emotion-4 emotion-5 emotion-6 emotion-7"
+  id="test-image"
+>
+  <img
+    alt="Hill chart"
+    data-nimg="1"
+    decoding="async"
+    height="1119"
+    sizes="100vw"
+    src="/_next/image?url=https%3A%2F%2Fstorage.googleapis.com%2Fs.mkswft.com%2FRmlsZTplMGJlNzVmMC01MjhmLTRiM2EtYTY4YS1kNjhlMTJjODMwZDI%3D%2FHill%2520Chart.png&w=3840&q=75"
+    srcset="/_next/image?url=https%3A%2F%2Fstorage.googleapis.com%2Fs.mkswft.com%2FRmlsZTplMGJlNzVmMC01MjhmLTRiM2EtYTY4YS1kNjhlMTJjODMwZDI%3D%2FHill%2520Chart.png&w=640&q=75 640w, /_next/image?url=https%3A%2F%2Fstorage.googleapis.com%2Fs.mkswft.com%2FRmlsZTplMGJlNzVmMC01MjhmLTRiM2EtYTY4YS1kNjhlMTJjODMwZDI%3D%2FHill%2520Chart.png&w=750&q=75 750w, /_next/image?url=https%3A%2F%2Fstorage.googleapis.com%2Fs.mkswft.com%2FRmlsZTplMGJlNzVmMC01MjhmLTRiM2EtYTY4YS1kNjhlMTJjODMwZDI%3D%2FHill%2520Chart.png&w=828&q=75 828w, /_next/image?url=https%3A%2F%2Fstorage.googleapis.com%2Fs.mkswft.com%2FRmlsZTplMGJlNzVmMC01MjhmLTRiM2EtYTY4YS1kNjhlMTJjODMwZDI%3D%2FHill%2520Chart.png&w=1080&q=75 1080w, /_next/image?url=https%3A%2F%2Fstorage.googleapis.com%2Fs.mkswft.com%2FRmlsZTplMGJlNzVmMC01MjhmLTRiM2EtYTY4YS1kNjhlMTJjODMwZDI%3D%2FHill%2520Chart.png&w=1200&q=75 1200w, /_next/image?url=https%3A%2F%2Fstorage.googleapis.com%2Fs.mkswft.com%2FRmlsZTplMGJlNzVmMC01MjhmLTRiM2EtYTY4YS1kNjhlMTJjODMwZDI%3D%2FHill%2520Chart.png&w=1920&q=75 1920w, /_next/image?url=https%3A%2F%2Fstorage.googleapis.com%2Fs.mkswft.com%2FRmlsZTplMGJlNzVmMC01MjhmLTRiM2EtYTY4YS1kNjhlMTJjODMwZDI%3D%2FHill%2520Chart.png&w=2048&q=75 2048w, /_next/image?url=https%3A%2F%2Fstorage.googleapis.com%2Fs.mkswft.com%2FRmlsZTplMGJlNzVmMC01MjhmLTRiM2EtYTY4YS1kNjhlMTJjODMwZDI%3D%2FHill%2520Chart.png&w=3840&q=75 3840w"
+    style="color: transparent; width: 100%; height: auto;"
+    width="2700"
+  />
+</div>
+`;

--- a/packages/runtime/src/next/components/tests/components/image-component-rendering.test.tsx
+++ b/packages/runtime/src/next/components/tests/components/image-component-rendering.test.tsx
@@ -1,0 +1,53 @@
+/** @jest-environment jsdom */
+
+import '@testing-library/jest-dom'
+
+import {
+  createMakeswiftPageSnapshot,
+  testMakeswiftPageRendering,
+  createRootComponent,
+} from '../../../testing'
+
+import { pageDocument } from '../__fixtures__/page-document'
+import { imageComponentData } from '../__fixtures__/element-data/image-component'
+import * as Resources from '../__fixtures__/resources'
+
+const createPageWithImage = (htmlId: string) => {
+  const image = imageComponentData({
+    htmlId,
+    swatchId: Resources.swatch1.id,
+    fileId: Resources.file1.id,
+  })
+
+  return createMakeswiftPageSnapshot(
+    {
+      ...pageDocument,
+      data: createRootComponent([image]),
+    },
+    {
+      cacheData: {
+        apiResources: {
+          Swatch: [
+            {
+              id: Resources.swatch1.id,
+              value: Resources.swatch1,
+            },
+          ],
+          File: [
+            {
+              id: Resources.file1.id,
+              value: Resources.file1,
+            },
+          ],
+        },
+      },
+    },
+  )
+}
+
+test('correctly renders image component', async () => {
+  const htmlId = 'test-image'
+  const snapshot = createPageWithImage(htmlId)
+  const render = await testMakeswiftPageRendering({ snapshot })
+  expect(render.container.querySelector(`#${htmlId}`)).toMatchSnapshot()
+})

--- a/packages/runtime/src/next/testing/page-rendering.tsx
+++ b/packages/runtime/src/next/testing/page-rendering.tsx
@@ -34,3 +34,21 @@ export async function testMakeswiftPageHeadRendering(
     ),
   )
 }
+
+export async function testMakeswiftPageRendering(
+  props: ComponentPropsWithoutRef<typeof MakeswiftPage>,
+  { forcePagesRouter = false }: { forcePagesRouter?: boolean } = {},
+) {
+  const runtime = new ReactRuntime()
+
+  return await act(async () =>
+    render(
+      <ReactProvider runtime={runtime} previewMode={false} forcePagesRouter={forcePagesRouter}>
+        <MakeswiftPage {...props} />
+      </ReactProvider>,
+      {
+        container: document.body.appendChild(document.createElement('div')),
+      },
+    ),
+  )
+}


### PR DESCRIPTION
Basic rendering test for the built-in `Image` component. No semantic changes. Prep for `next/image` decoupling.

See also https://github.com/makeswift/makeswift/pull/1078.