### PR TITLE
example: Algolia

### DIFF
--- a/examples/algolia/.env.example
+++ b/examples/algolia/.env.example
@@ -1,0 +1,13 @@
+# Makeswift
+MAKESWIFT_SITE_API_KEY=
+
+# Algolia
+NEXT_PUBLIC_ALGOLIA_APP_ID=
+NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY=
+
+# Optional: Algolia site verification (get this after deploying)
+ALGOLIA_SITE_VERIFICATION=placeholder
+
+# Optional: Your deployed site URL for sitemap generation
+# Leave as placeholder during development, update after deploying
+NEXT_PUBLIC_SITE_URL=https://example.com

--- a/examples/algolia/.eslintrc.json
+++ b/examples/algolia/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/examples/algolia/.gitignore
+++ b/examples/algolia/.gitignore
@@ -1,0 +1,39 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# local env files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+.env
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo

--- a/examples/algolia/.npmrc
+++ b/examples/algolia/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/examples/algolia/.prettierrc.json
+++ b/examples/algolia/.prettierrc.json
@@ -1,0 +1,22 @@
+{
+  "plugins": ["@trivago/prettier-plugin-sort-imports", "prettier-plugin-tailwindcss"],
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": false,
+  "singleQuote": true,
+  "quoteProps": "as-needed",
+  "jsxSingleQuote": false,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "jsxBracketSameLine": false,
+  "arrowParens": "avoid",
+  "requirePragma": false,
+  "insertPragma": false,
+  "proseWrap": "preserve",
+  "htmlWhitespaceSensitivity": "css",
+  "endOfLine": "lf",
+  "importOrder": ["^(react*|next*)", "<THIRD_PARTY_MODULES>", "^@/(.*)$", "^[./]"],
+  "importOrderSeparation": true,
+  "importOrderSortSpecifiers": true
+}

--- a/examples/algolia/README.md
+++ b/examples/algolia/README.md
@@ -1,0 +1,275 @@
+# Makeswift + Algolia Integration
+
+This integration demonstrates how to combine the power of Algolia's search capabilities with Makeswift's visual page building platform. Build visually editable websites with fast, intelligent search powered by Algolia's crawler that automatically indexes your Makeswift pages.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) 20.x or later
+- [Makeswift](https://www.makeswift.com/) account (for visual page building) [Sign up for free](https://app.makeswift.com/signup)
+- [Algolia](https://www.algolia.com/) account (for search indexing) [Sign up for free](https://www.algolia.com/users/sign_up)
+- Basic familiarity with [Next.js App Router](https://nextjs.org/docs/app)
+
+This guide assumes that you're familiar with Makeswift and setting up a custom host. Read here to learn more: https://docs.makeswift.com/developer/app-router/installation
+
+## Project Structure
+
+```
+algolia-demo/
+├── app/                          # Next.js App Router pages
+│   ├── [[...path]]/              # Dynamic Makeswift routes
+│   ├── api/makeswift/            # Makeswift API routes
+│   ├── layout.tsx                # Root layout with Makeswift provider
+│   ├── globals.css               # Global styles
+│   └── sitemap.ts                # Auto-generated sitemap for SEO
+├── components/                   # Makeswift components
+│   ├── AlgoliaSearch/            # Search component (used by Navigation)
+│   │   └── client.tsx            # Main search UI component
+│   └── Navigation/               # Navigation component with search
+├── lib/                          # Utility functions and configs
+│   ├── algolia/                  # Algolia client configuration
+│   ├── makeswift/                # Makeswift runtime & provider setup
+│   └── utils.ts                  # Shared utilities
+├── vibes/soul/                   # Pre-built UI components
+└── env.ts                        # Environment variable validation
+```
+
+## Quick Start
+
+### 1. Set up Algolia
+
+Before cloning the repository, you'll need to set up your Algolia account and get your API credentials:
+
+#### Create an Algolia Account
+
+1. [Sign up for a free Algolia account](https://www.algolia.com/users/sign_up) if you don't have one
+2. If you need to create a new application, go to **Settings** → **Applications** and click **New Application**
+   - You can use an existing application if you already have one
+
+#### Get Your API Credentials
+
+1. In your Algolia dashboard, navigate to **Settings** → **API Keys**
+2. Note down the following credentials (you'll need them when initializing the project):
+   - **Application ID** (`NEXT_PUBLIC_ALGOLIA_APP_ID`) - Found at the top of the API Keys page
+   - **Search API Key** (`NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY`) - Found in the "Your API Keys" section
+
+> **Important**: Use the **Search API Key**, not the Admin API Key. The search key is safe to use in your frontend code.
+
+> **Note**: You don't need to manually create an index yet. When you create your Algolia Crawler in step 8, it will automatically create the necessary indices to store your crawled content.
+
+### 2. Clone the example with the Makeswift CLI
+
+Initialize the project with the Makeswift CLI:
+
+```bash
+npx makeswift@latest init --example=algolia
+```
+
+### 3. Configure environment variables (initial setup)
+
+Here is how your `.env.local` should look once setup is finished:
+
+```
+MAKESWIFT_SITE_API_KEY=your_makeswift_api_key
+NEXT_PUBLIC_ALGOLIA_APP_ID=your_algolia_app_id
+NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY=your_algolia_search_api_key
+ALGOLIA_SITE_VERIFICATION=placeholder
+NEXT_PUBLIC_SITE_URL=https://example.com
+```
+
+**MAKESWIFT_SITE_API_KEY**: Automatically applied, found in your Makeswift site settings
+
+You will be prompted for:
+
+- **NEXT_PUBLIC_ALGOLIA_APP_ID**: Your Algolia Application ID from step 1
+- **NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY**: Your Algolia Search API Key from step 1
+- **ALGOLIA_SITE_VERIFICATION**: Use a placeholder like `placeholder` for now. You'll get the real value in step 5 after deploying
+- **NEXT_PUBLIC_SITE_URL**: Use a placeholder like `https://example.com` for now. Update this with your deployed domain after step 4. This is used for generating the sitemap
+
+The CLI should start up your development environment automatically, but if you need to run the server manually use:
+
+```bash
+npm run dev
+```
+
+### 4. Deploy your site and set up Makeswift host
+
+> **Note**: You need to deploy first to get a domain URL. The Algolia domain verification will be configured after deployment.
+
+1. Deploy your site to Vercel
+   - It's okay that `ALGOLIA_SITE_VERIFICATION` is using a placeholder for now
+   - Copy the generated Vercel URL (e.g., `https://your-site.vercel.app`)
+2. Configure your custom host in Makeswift:
+   - Open the [Makeswift builder](https://app.makeswift.com)
+   - Navigate to **Settings** → **Host** (accessible from the left sidebar)
+   - Set the **Custom host URL** field to your deployed domain (e.g., `https://your-site.vercel.app`)
+   - Save your changes
+3. Create some pages in Makeswift
+   - **Important**: Make sure your pages have a title and description set for them to be properly crawled and indexed by Algolia
+   - **Important**: Add links to your other pages. The Algolia crawler discovers pages by following links from your start URL, so any page you want indexed must be reachable through navigation links
+4. Add links to those new pages within the Navigation component -- it should look something like this:
+   <img width="1710" height="743" alt="Image" src="https://github.com/user-attachments/assets/d3f005de-f3e8-447f-bb63-25b64105371d" />
+
+### 5. Get Algolia domain verification token
+
+Now that you have a deployed domain, you can get the verification token:
+
+1. Navigate to the [Algolia Crawler Getting Started guide](https://www.algolia.com/doc/tools/crawler/getting-started/create-crawler/)
+2. Follow the "Add domains" section to add your deployed domain (e.g., `https://your-site.vercel.app`)
+3. With the **Meta tag** tab selected, copy the token from the meta tag (the value on content=`verification-code`)
+
+### 6. Update environment variables and redeploy
+
+1. Update your **local** `.env.local` with the verification token and your deployed site URL:
+
+   ```bash
+   ALGOLIA_SITE_VERIFICATION=your_actual_verification_token
+   NEXT_PUBLIC_SITE_URL=https://your-actual-site.vercel.app
+   ```
+
+2. Update the `ALGOLIA_SITE_VERIFICATION` and `NEXT_PUBLIC_SITE_URL` environment variables in your Vercel project settings
+
+The verification meta tag is included in `app/layout.tsx`:
+
+```tsx
+export const metadata: Metadata = {
+  other: {
+    'algolia-site-verification': env.ALGOLIA_SITE_VERIFICATION,
+  },
+}
+```
+
+3. **Redeploy your site** so the verification meta tag appears on your live site and the sitemap uses the correct domain
+
+### 7. Verify domain ownership in Algolia
+
+1. Once your site is redeployed with the verification meta tag, return to the Algolia Crawler dashboard under **Data sources**
+2. Click **Verify now** next to your domain
+3. Algolia will confirm ownership by detecting the meta tag on your live site
+
+### 8. Create Algolia Crawler
+
+After your domain is verified, you can create the crawler. **Important**: Creating a crawler automatically creates the associated index. The index name is automatically generated from the crawler name with the following transformations:
+
+- Spaces are converted to underscores
+- `_pages` is appended to the end
+- Example: Crawler name "My Blog" → Index name `my_blog_pages`
+
+1. In your Algolia dashboard, navigate to **Data sources** → **Crawlers** (at the bottom of the left sidebar)
+2. Click **New Crawler**
+3. Enter your crawler configuration:
+   - **Crawler name**: Choose a descriptive name (e.g., "Makeswift Site", "My Blog", or "Production Site")
+   - **Start URL**: Your deployed domain's home page (e.g., `https://your-site.vercel.app`)
+   - **What types of content do you want to crawl?**: Select the content types that match your site:
+     - Check **General web pages** for standard Makeswift pages
+     - Check **Articles** if you have blog posts or article pages
+     - Leave **Products** and **Technical documentation** unchecked unless applicable
+   - **Index prefix**: Leave this field **empty** unless you want an additional prefix
+4. Click **Create** to run the initial test crawl
+   - The crawler will automatically create an index based on your crawler name
+5. Optionally, [configure the sitemap URL](https://www.algolia.com/doc/tools/crawler/apis/configuration/sitemaps) in Algolia's crawler dashboard:
+   - Under **Editor**, find the `sitemaps` array and add your sitemap URL:
+     ```javascript
+     sitemaps: ["https://your-site.vercel.app/sitemap.xml"],
+     ```
+   - Click **Save** to apply your changes
+   - URLs found in sitemaps are treated as start URLs for the crawler, giving the crawler more entry points to discover your pages
+
+> **How the crawler discovers pages**: The crawler starts at your start URLs (including any URLs from sitemaps) and follows links to discover other pages. Make sure all pages you want indexed are either in the sitemap or linked from your home page. Pages that aren't reachable won't be crawled.
+
+The crawler will automatically extract:
+
+- Page titles
+- Meta descriptions
+- Main content text
+- Main image
+- URLs
+
+### 9. Configure Your Index Name in Makeswift
+
+After creating the crawler, configure the index name directly in the Makeswift builder:
+
+1. Check the index name created by your crawler:
+   - In the crawler's **Overview** tab, find the associated index name in the "Indices" card at the bottom (e.g., `makeswift_site_pages`, `my_blog_pages`, etc.)
+
+2. Open the [Makeswift builder](https://app.makeswift.com) and navigate to any page.
+
+3. Select the **Navigation** component at the top of the page.
+
+4. In the component properties panel, find the **Algolia Index Name** field
+
+5. Enter your index name (e.g., `makeswift_site_pages`)
+
+The search feature in the Navigation component will now search that index.
+
+## Search Features
+
+The search functionality is built into the Navigation component. When users click the search icon in the navigation bar, a search overlay appears with the following features:
+
+- **Real-time search**: Results update as users type (debounced for performance)
+- **Keyboard navigation**: Arrow keys to navigate results, Enter to select
+- **Click outside to close**: Intuitive UX for search results
+- **Pagination**: "Show more" button to load additional results
+- **Typo tolerance**: Algolia's built-in typo tolerance for better search experience
+- **Responsive design**: Works on all device sizes
+
+### How the Crawler Discovers Pages
+
+The Algolia crawler discovers pages by **following links** starting from your home page:
+
+1. **Link-Based Discovery**: The crawler starts at your start URL (home page) and follows all links it finds to discover other pages
+2. **Navigation is Key**: Make the links you want crawled are reachable from the home page (i.e. from the Navigation).
+3. **Unreachable Pages Won't Be Indexed**: Any page that isn't reachable through links from the start URL won't be crawled
+
+### Index Population Process
+
+1. **Page Publishing**: When you publish a page in Makeswift, it becomes available at its URL
+2. **Ensure Page is Linked**: Add a link to the new page from your home page or navigation
+3. **Crawler Run**: When the crawler runs, it follows links and discovers the new page
+4. **Content Extraction**: The crawler visits the new page and extracts searchable content
+5. **Index Update**: The extracted content is added to your Algolia search index
+
+> **Note**: The `app/sitemap.ts` file generates a sitemap for SEO purposes, but the Algolia crawler primarily relies on following links rather than the sitemap.
+
+### Content Extraction
+
+The crawler automatically extracts:
+
+- **Page titles** from `<title>` tags and `<h1>` elements
+- **Meta descriptions** from `<meta name="description">` tags
+- **Main content** from page body, excluding navigation and footer
+- **Images** from `<img>` tags and `<meta property="og:image">` tags
+- **URLs** for result navigation
+
+## Troubleshooting
+
+Common issues and solutions:
+
+### Search not working
+
+- **Check environment variables**: Ensure all Algolia credentials are correctly set in `.env.local`
+- **Verify API keys**: Make sure you're using the search API key (not admin key) for client-side usage
+- **Check index name**: Verify the index name matches between your environment variables and Algolia dashboard
+
+### No search results
+
+- **Crawler status**: Check your crawler status in the Algolia dashboard under **Data sources** → **Crawler** → **Your crawler**
+- **Index population**: Ensure the crawler has successfully populated the index (check **Data sources** → **Indices** to see if records exist)
+- **Index name mismatch**: Verify that the **Algolia Index Name** configured on the Navigation component in Makeswift exactly matches the index name shown in your Algolia dashboard
+- **Search attributes**: Verify your pages contain the expected attributes (`title`, `description`, etc.)
+- **Publishing status**: Make sure your Makeswift pages are published and accessible
+
+### Crawler not indexing pages
+
+- **Pages must be linked**: The crawler discovers pages by following links. Make sure your pages are linked from your home page or navigation
+- **Page accessibility**: Check that your pages are publicly accessible (not behind authentication)
+- **Crawler configuration**: Verify the start URL in your crawler settings points to your home page
+
+## Learn More
+
+- [Makeswift Documentation](https://www.makeswift.com/docs/)
+- [Makeswift Runtime GitHub repository](https://github.com/makeswift/makeswift)
+- [Algolia Crawler Documentation](https://www.algolia.com/doc/tools/crawler/)
+- [Algolia Search API Reference](https://www.algolia.com/doc/api-reference/search-api/)
+- [React InstantSearch Documentation](https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/)
+- [VIBES Component Library](https://vibes.site/)
+- [Next.js App Router Documentation](https://nextjs.org/docs/app)

--- a/examples/algolia/app/[[...path]]/page.tsx
+++ b/examples/algolia/app/[[...path]]/page.tsx
@@ -1,0 +1,25 @@
+import { notFound } from 'next/navigation'
+
+import { Page as MakeswiftPage } from '@makeswift/runtime/next'
+import { getSiteVersion } from '@makeswift/runtime/next/server'
+
+import { client } from '@/lib/makeswift/client'
+
+export async function generateStaticParams() {
+  const pages = await client.getPages().toArray()
+
+  return pages.map(page => ({
+    path: page.path.split('/').filter(segment => segment !== ''),
+  }))
+}
+
+export default async function Page({ params }: { params: Promise<{ path?: string[] }> }) {
+  const path = '/' + ((await params)?.path ?? []).join('/')
+  const snapshot = await client.getPageSnapshot(path, {
+    siteVersion: getSiteVersion(),
+  })
+
+  if (snapshot == null) return notFound()
+
+  return <MakeswiftPage snapshot={snapshot} />
+}

--- a/examples/algolia/app/api/makeswift/[...makeswift]/route.ts
+++ b/examples/algolia/app/api/makeswift/[...makeswift]/route.ts
@@ -1,0 +1,29 @@
+import { MakeswiftApiHandler } from '@makeswift/runtime/next/server'
+import { strict } from 'assert'
+
+import '@/lib/makeswift/components'
+import { runtime } from '@/lib/makeswift/runtime'
+
+strict(process.env.MAKESWIFT_SITE_API_KEY, 'MAKESWIFT_SITE_API_KEY is required')
+
+const handler = MakeswiftApiHandler(process.env.MAKESWIFT_SITE_API_KEY, {
+  runtime,
+  getFonts() {
+    return [
+      {
+        family: 'var(--font-inter)',
+        label: 'Inter',
+        variants: [
+          { weight: '300', style: 'normal' },
+          { weight: '300', style: 'italic' },
+          { weight: '400', style: 'normal' },
+          { weight: '400', style: 'italic' },
+          { weight: '700', style: 'normal' },
+          { weight: '800', style: 'normal' },
+        ],
+      },
+    ]
+  },
+})
+
+export { handler as GET, handler as POST }

--- a/examples/algolia/app/globals.css
+++ b/examples/algolia/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/examples/algolia/app/layout.tsx
+++ b/examples/algolia/app/layout.tsx
@@ -1,0 +1,37 @@
+import type { Metadata } from 'next'
+import { Inter } from 'next/font/google'
+
+import { getSiteVersion } from '@makeswift/runtime/next/server'
+
+import { NAVIGATION_COMPONENT_TYPE } from '@/components/Navigation/register'
+import { Component } from '@/lib/makeswift/component'
+import '@/lib/makeswift/components'
+import { MakeswiftProvider } from '@/lib/makeswift/provider'
+
+import { env } from '../env'
+import './globals.css'
+
+const inter = Inter({ subsets: ['latin'] })
+
+export const metadata: Metadata = {
+  other: {
+    'algolia-site-verification': env.ALGOLIA_SITE_VERIFICATION ?? '',
+  },
+}
+
+export default async function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  return (
+    <html lang="en">
+      <body className={inter.className}>
+        <MakeswiftProvider siteVersion={await getSiteVersion()}>
+          <Component type={NAVIGATION_COMPONENT_TYPE} label="Navigation" snapshotId="navigation" />
+          {children}
+        </MakeswiftProvider>
+      </body>
+    </html>
+  )
+}

--- a/examples/algolia/app/sitemap.ts
+++ b/examples/algolia/app/sitemap.ts
@@ -1,0 +1,41 @@
+import { MetadataRoute } from 'next'
+
+import { MakeswiftPage } from '@makeswift/runtime/next'
+
+import { env } from '@/env'
+import { client } from '@/lib/makeswift/client'
+
+type NextSitemapItem = MetadataRoute.Sitemap[number]
+
+const DOMAIN = env.NEXT_PUBLIC_SITE_URL ?? 'https://example.com'
+const DEFAULT_PRIORITY = 0.75
+const DEFAULT_FREQUENCY = 'hourly'
+
+function pageToSitemapEntry(page: MakeswiftPage): NextSitemapItem {
+  const pageUrl = new URL(page.path, DOMAIN)
+  return {
+    url: pageUrl.href,
+    lastModified: page.updatedAt,
+    changeFrequency: page.sitemapFrequency ?? DEFAULT_FREQUENCY,
+    priority: page.sitemapPriority ?? DEFAULT_PRIORITY,
+  }
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const pages: MakeswiftPage[] = []
+  let cursor: string | undefined = undefined
+  let hasMorePages = true
+
+  do {
+    const paginatedResults = await client.getPages({
+      limit: 100, // Maximum allowed limit (1-100)
+      after: cursor,
+    })
+
+    pages.push(...paginatedResults.data)
+    hasMorePages = paginatedResults.hasMore
+    cursor = paginatedResults.data.at(-1)?.id
+  } while (hasMorePages)
+
+  return pages.filter(page => !page.excludedFromSearch).map(page => pageToSitemapEntry(page))
+}

--- a/examples/algolia/components/AlgoliaSearch/client.tsx
+++ b/examples/algolia/components/AlgoliaSearch/client.tsx
@@ -1,0 +1,446 @@
+'use client'
+
+import Image from 'next/image'
+import { useRouter } from 'next/navigation'
+import React, { type KeyboardEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Configure, useHits, useInstantSearch, useSearchBox } from 'react-instantsearch'
+import { InstantSearchNext } from 'react-instantsearch-nextjs'
+
+import clsx from 'clsx'
+import { env } from 'env'
+import debounce from 'lodash.debounce'
+import { Spinner } from 'vibes/soul/primitives/spinner'
+
+import algoliaClient from '@/lib/algolia/client'
+import { useClickOutside } from '@/lib/utils'
+
+interface AlgoliaSearchProps {
+  className?: string
+  placeholder?: string
+  maxResults?: number
+  paginationLimit?: number
+  indexName?: string
+  show?: boolean
+}
+
+type SearchHit = {
+  objectID: string
+  title: string
+  description: string
+  image?: string
+  url: string
+  __position: number
+  __queryID?: string
+} & Record<string, unknown>
+
+interface SearchInputProps {
+  placeholder?: string
+  show?: boolean
+  maxResults?: number
+  paginationLimit?: number
+}
+
+interface HitsProps {
+  className?: string
+  setShowHits: (isFocused: boolean) => void
+  maxResults?: number
+  paginationLimit?: number
+  selectedIndex: number
+  setSelectedIndex: (index: number | ((prev: number) => number)) => void
+  onHitSelect?: (hit: SearchHit) => void
+  shown: number
+  setShown: (value: number | ((prev: number) => number)) => void
+}
+
+// Custom SearchBox component that actually connects to Algolia
+const SearchInput = React.memo(
+  ({ placeholder, show = false, maxResults = 8, paginationLimit = 8 }: SearchInputProps) => {
+    const [showHits, setShowHits] = useState(show)
+    const [selectedIndex, setSelectedIndex] = useState(-1)
+    const [inputValue, setInputValue] = useState('')
+    const [shown, setShown] = useState(maxResults)
+    const { refine, query } = useSearchBox()
+    const { results } = useHits<SearchHit>()
+    const inputRef = useRef<HTMLInputElement | null>(null)
+    const router = useRouter()
+
+    // Reset pagination when query changes
+    useEffect(() => {
+      setShown(maxResults)
+    }, [query, maxResults])
+
+    // Calculate the actual number of visible hits for keyboard navigation
+    const visibleHitsCount = useMemo(() => {
+      if (!results?.hits) return 0
+      return Math.min(shown, results.hits.length)
+    }, [results?.hits, shown])
+
+    // Scroll selected item into view when selectedIndex changes
+    useEffect(() => {
+      if (selectedIndex >= 0 && results?.hits?.[selectedIndex]) {
+        const selectedElement = document.getElementById(
+          `hit-${results.hits[selectedIndex].objectID}`
+        )
+        if (selectedElement) {
+          selectedElement.scrollIntoView({
+            behavior: 'smooth',
+            block: 'nearest',
+          })
+        }
+      }
+    }, [selectedIndex, results?.hits])
+
+    const handleHitSelect = useCallback(
+      (hit: SearchHit) => {
+        setShowHits(false)
+        setSelectedIndex(-1)
+        setInputValue('')
+        if (hit.url) {
+          router.push(hit.url)
+        }
+      },
+      [setShowHits, router]
+    )
+
+    useEffect(() => {
+      if (show && inputRef.current) {
+        inputRef.current.focus()
+        inputRef.current.select()
+      }
+      if (!show) {
+        setShowHits(false)
+        setSelectedIndex(-1)
+        setInputValue('')
+      }
+    }, [show])
+
+    const debouncedRefine = useMemo(
+      () =>
+        debounce((query: string) => {
+          refine(query)
+        }, 250),
+      [refine]
+    )
+
+    useEffect(() => {
+      return () => {
+        debouncedRefine.cancel()
+      }
+    }, [debouncedRefine])
+
+    const handleInputChange = useCallback(
+      (e: React.ChangeEvent<HTMLInputElement>) => {
+        const value = e.target.value
+        setInputValue(value)
+
+        // Reset selected index when typing
+        setSelectedIndex(-1)
+
+        if (value.length > 0) {
+          setShowHits(true)
+        } else {
+          setShowHits(false)
+        }
+
+        debouncedRefine(value)
+      },
+      [debouncedRefine]
+    )
+
+    const handleKeyDown = useCallback(
+      (e: KeyboardEvent<HTMLInputElement>) => {
+        if (!showHits || !results?.hits) return
+
+        switch (e.key) {
+          case 'ArrowDown':
+            e.preventDefault()
+            setSelectedIndex(prev => {
+              if (prev === -1) return 0
+
+              const nextIndex = prev < visibleHitsCount - 1 ? prev + 1 : prev
+              return nextIndex
+            })
+            break
+          case 'ArrowUp':
+            e.preventDefault()
+            setSelectedIndex(prev => {
+              if (prev <= 0) return -1
+
+              return prev - 1
+            })
+            break
+          case 'Enter':
+            e.preventDefault()
+            if (selectedIndex >= 0 && results.hits[selectedIndex]) {
+              handleHitSelect(results.hits[selectedIndex] as SearchHit)
+            }
+            break
+          case 'Escape':
+            e.preventDefault()
+            setShowHits(false)
+            setSelectedIndex(-1)
+            inputRef.current?.blur()
+            break
+          case 'Home':
+            if (visibleHitsCount > 0) {
+              e.preventDefault()
+              setSelectedIndex(0)
+            }
+            break
+          case 'End':
+            if (visibleHitsCount > 0) {
+              e.preventDefault()
+              setSelectedIndex(visibleHitsCount - 1)
+            }
+            break
+        }
+      },
+      [showHits, results?.hits, visibleHitsCount, selectedIndex, handleHitSelect]
+    )
+
+    const handleFocusOrClick = useCallback(() => {
+      if (inputValue.length > 0) {
+        setShowHits(true)
+      }
+    }, [inputValue])
+
+    return (
+      <div className="relative w-full">
+        {/* Search icon */}
+        <div className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400">
+          <svg
+            className="h-5 w-5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+            />
+          </svg>
+        </div>
+
+        <input
+          ref={inputRef}
+          type="search"
+          role="combobox"
+          aria-label="Search"
+          aria-autocomplete="list"
+          aria-expanded={showHits}
+          aria-controls={showHits ? 'search-results' : undefined}
+          aria-activedescendant={
+            showHits && selectedIndex >= 0 && results?.hits?.[selectedIndex]
+              ? `hit-${results.hits[selectedIndex].objectID}`
+              : undefined
+          }
+          className="w-full rounded-xl border border-gray-200 bg-gray-50 py-4 pl-12 pr-4 text-lg text-gray-700 transition-all duration-200 placeholder:text-gray-400 focus:border-transparent focus:bg-white focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          placeholder={placeholder || 'Search...'}
+          spellCheck={false}
+          maxLength={512}
+          value={inputValue}
+          onClick={handleFocusOrClick}
+          onFocus={handleFocusOrClick}
+          onKeyDown={handleKeyDown}
+          onChange={handleInputChange}
+          name="search"
+        />
+
+        {showHits && (
+          <Hits
+            setShowHits={setShowHits}
+            maxResults={maxResults}
+            paginationLimit={paginationLimit}
+            selectedIndex={selectedIndex}
+            setSelectedIndex={setSelectedIndex}
+            onHitSelect={handleHitSelect}
+            shown={shown}
+            setShown={setShown}
+          />
+        )}
+      </div>
+    )
+  }
+)
+
+SearchInput.displayName = 'SearchInput'
+
+const ErrorState = React.memo(({ message }: { message: string }) => {
+  return (
+    <div className="flex w-full justify-center p-10" role="alert">
+      <div className="text-center text-red-600">
+        <p className="font-semibold">Search Error</p>
+        <p className="text-sm">{message}</p>
+      </div>
+    </div>
+  )
+})
+
+ErrorState.displayName = 'ErrorState'
+
+const Hits = React.memo(
+  ({
+    setShowHits,
+    paginationLimit = 8,
+    selectedIndex,
+    setSelectedIndex,
+    onHitSelect,
+    shown,
+    setShown,
+  }: HitsProps) => {
+    const { results, sendEvent } = useHits<SearchHit>()
+    const { query } = useSearchBox()
+    const { status, error } = useInstantSearch({ catchError: true })
+
+    const router = useRouter()
+    const olRef = useRef<HTMLDivElement>(null)
+
+    useClickOutside(
+      olRef,
+      useCallback(() => setShowHits(false), [setShowHits])
+    )
+
+    const hitsToShow = useMemo(() => {
+      if (!results?.hits) return []
+      return results.hits.slice(0, shown)
+    }, [results?.hits, shown])
+
+    const handleHitClick = useCallback(
+      (hit: SearchHit) => {
+        sendEvent('click', hit, 'Hit Clicked')
+        if (onHitSelect) {
+          onHitSelect(hit)
+        } else {
+          setShowHits(false)
+          if (hit.url) {
+            router.push(hit.url)
+          }
+        }
+      },
+      [setShowHits, sendEvent, router, onHitSelect]
+    )
+
+    const handleShowMore = useCallback(() => {
+      setShown(prev => Math.min(prev + paginationLimit, results?.hits?.length || 0))
+    }, [results?.hits?.length, paginationLimit, setShown])
+
+    if (status === 'loading' || status === 'stalled') {
+      return <Spinner />
+    }
+
+    if (error) {
+      return <ErrorState message="Unable to load search results. Please try again later." />
+    }
+
+    if (!results) {
+      return <Spinner />
+    }
+
+    return (
+      <div
+        className="absolute top-full z-50 mt-2 w-full rounded-xl bg-white shadow-xl ring-1 ring-gray-200"
+        ref={olRef}
+        tabIndex={-1}
+      >
+        <ol
+          id="search-results"
+          role="listbox"
+          aria-label="Search results"
+          className="flex w-full flex-col"
+        >
+          {hitsToShow.length === 0 ? (
+            <div className="p-4 text-center text-gray-600" role="status">
+              {query ? `We couldn't find anything for "${query}"` : 'Start typing to search...'}
+            </div>
+          ) : (
+            hitsToShow.map((hit, index) => (
+              <li
+                key={hit.objectID}
+                id={`hit-${hit.objectID}`}
+                role="option"
+                aria-selected={index === selectedIndex}
+                onMouseDown={() => handleHitClick(hit)}
+                onMouseEnter={() => setSelectedIndex(index)}
+                onMouseLeave={() => setSelectedIndex(-1)}
+                className={clsx(
+                  'cursor-pointer border-b border-gray-100 p-4 text-gray-600 duration-200 last:border-b-0',
+                  index === selectedIndex
+                    ? 'bg-blue-50 text-gray-900'
+                    : 'hover:bg-gray-50 hover:text-gray-900'
+                )}
+              >
+                <div className="flex items-start gap-3">
+                  {hit.image && (
+                    <Image src={hit.image} alt="" loading="lazy" width={48} height={48} />
+                  )}
+                  <div className="flex flex-1 flex-col gap-1">
+                    <h3 className="line-clamp-1 font-medium text-blue-600">{hit.title}</h3>
+                    <p className="line-clamp-2 text-sm text-gray-600">{hit.description}</p>
+                    {hit.url && <p className="line-clamp-1 text-xs text-gray-400">{hit.url}</p>}
+                  </div>
+                </div>
+              </li>
+            ))
+          )}
+        </ol>
+
+        {shown < (results?.hits?.length || 0) && (
+          <div className="border-t border-gray-100 px-4 py-2">
+            <button
+              onClick={handleShowMore}
+              className="w-full rounded-md px-4 py-2 text-sm text-blue-600 transition-colors hover:bg-blue-50"
+              type="button"
+            >
+              Show {Math.min(paginationLimit, (results?.hits?.length || 0) - shown)} more results
+            </button>
+          </div>
+        )}
+
+        {hitsToShow.length > 0 && (
+          <div className="border-t border-gray-100 px-4 py-2 text-xs text-gray-500">
+            {results?.hits?.length || 0} result{(results?.hits?.length || 0) !== 1 ? 's' : ''} found
+          </div>
+        )}
+      </div>
+    )
+  }
+)
+
+Hits.displayName = 'Hits'
+
+export default function AlgoliaSearch({
+  className,
+  placeholder = 'Search',
+  maxResults = 8,
+  paginationLimit = 8,
+  indexName,
+  show = false,
+}: AlgoliaSearchProps) {
+  const resolvedIndexName = indexName || env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME
+
+  return (
+    <div className={className}>
+      <InstantSearchNext searchClient={algoliaClient} indexName={resolvedIndexName}>
+        <Configure
+          hitsPerPage={20}
+          attributesToRetrieve={['objectID', 'title', 'description', 'image', 'url']}
+          attributesToHighlight={['title', 'description']}
+          typoTolerance={true}
+          removeWordsIfNoResults="allOptional"
+        />
+        <SearchInput
+          placeholder={placeholder}
+          maxResults={maxResults}
+          paginationLimit={paginationLimit}
+          show={show}
+        />
+      </InstantSearchNext>
+    </div>
+  )
+}

--- a/examples/algolia/components/Navigation/client.tsx
+++ b/examples/algolia/components/Navigation/client.tsx
@@ -1,0 +1,165 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+
+import { CloseIcon, MenuIcon, SearchIcon } from '@/vibes/soul/primitives/icons'
+
+import AlgoliaSearch from '../AlgoliaSearch/client'
+
+interface Props {
+  className?: string
+  links: Array<{
+    label: string
+    link?: { href: string }
+  }>
+  alignment?: 'left' | 'center' | 'right'
+  orientation?: 'horizontal' | 'vertical'
+  searchMaxResults?: number
+  searchPaginationLimit?: number
+  algoliaIndexName?: string
+}
+
+export function Navigation({
+  className = '',
+  links = [],
+  alignment = 'left',
+  orientation = 'horizontal',
+  searchMaxResults = 2,
+  searchPaginationLimit = 2,
+  algoliaIndexName,
+}: Props) {
+  const [isSearchOpen, setIsSearchOpen] = useState(false)
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
+
+  const toggleMobileMenu = () => {
+    setIsMobileMenuOpen(!isMobileMenuOpen)
+  }
+
+  // Close mobile menu when search opens
+  const handleSearchToggle = () => {
+    setIsSearchOpen(!isSearchOpen)
+    if (!isSearchOpen) {
+      setIsMobileMenuOpen(false)
+    }
+  }
+
+  const alignmentClasses = {
+    left: 'justify-start',
+    center: 'justify-center',
+    right: 'justify-end',
+  }
+
+  const orientationClasses = {
+    horizontal: 'flex-row space-x-8',
+    vertical: 'flex-col space-y-4',
+  }
+
+  return (
+    <>
+      <nav className={`relative ${className}`}>
+        <div className="flex items-center justify-between border-b border-gray-100 bg-white/95 px-4 py-4 shadow-sm backdrop-blur-md md:px-6">
+          {/* Navigation Links */}
+          <ul
+            className={`flex items-center ${alignmentClasses[alignment]} ${orientationClasses[orientation]} ${
+              orientation === 'horizontal' ? 'hidden sm:flex' : ''
+            }`}
+          >
+            {links.map((item, i) => (
+              <li key={i}>
+                <Link
+                  href={item.link?.href ?? '#'}
+                  className="relative text-sm font-medium text-gray-700 transition-all duration-300 hover:text-blue-600 md:text-base"
+                >
+                  {item.label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+
+          {/* Mobile Menu Button - Only show on mobile when there are links */}
+          {links.length > 0 && (
+            <button
+              onClick={toggleMobileMenu}
+              className="flex h-10 w-10 items-center justify-center rounded-lg border border-gray-200 bg-gray-50 transition-all duration-300 hover:bg-gray-100 sm:hidden"
+              aria-label={isMobileMenuOpen ? 'Close menu' : 'Open menu'}
+              aria-expanded={isMobileMenuOpen}
+            >
+              {isMobileMenuOpen ? (
+                <CloseIcon className="text-gray-600" />
+              ) : (
+                <MenuIcon className="text-gray-600" />
+              )}
+            </button>
+          )}
+
+          {/* Search Button */}
+          <button
+            onClick={handleSearchToggle}
+            className="group flex h-10 w-10 items-center justify-center rounded-full border border-gray-200 bg-gray-50 transition-all duration-300 hover:border-blue-200 hover:bg-blue-50 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            aria-label="Open search"
+          >
+            <SearchIcon className="text-gray-600 transition-colors duration-300 group-hover:text-blue-600" />
+          </button>
+        </div>
+
+        {/* Mobile Menu - Slides down below the nav bar */}
+        {isMobileMenuOpen && links.length > 0 && (
+          <div className="border-b border-gray-200 bg-white shadow-lg sm:hidden">
+            <ul className="flex flex-col px-4 py-2">
+              {links.map((item, i) => (
+                <li key={i}>
+                  <Link
+                    href={item.link?.href ?? '#'}
+                    onClick={() => setIsMobileMenuOpen(false)}
+                    className="block py-3 text-base font-medium text-gray-700 transition-colors duration-200 hover:text-blue-600"
+                  >
+                    {item.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </nav>
+
+      {/* Search Dropdown Overlay */}
+      {isSearchOpen && (
+        <div
+          className="fixed inset-0 z-50 bg-black/20 backdrop-blur-sm"
+          onClick={() => setIsSearchOpen(false)}
+        >
+          <div
+            className="absolute left-0 right-0 top-0 border-b border-gray-200 bg-white shadow-xl"
+            onClick={e => e.stopPropagation()}
+          >
+            <div className="relative p-4 md:p-6">
+              {/* Close Button */}
+              <button
+                onClick={() => setIsSearchOpen(false)}
+                className="absolute right-4 top-4 flex h-8 w-8 items-center justify-center rounded-full text-gray-400 transition-colors duration-200 hover:bg-gray-100 hover:text-gray-600"
+                aria-label="Close search"
+              >
+                <CloseIcon />
+              </button>
+
+              {/* Search Component */}
+              <div className="mx-auto max-w-4xl">
+                <h2 className="mb-4 pr-8 text-center text-xl font-semibold text-gray-900 md:mb-6 md:text-2xl">
+                  Search
+                </h2>
+                <AlgoliaSearch
+                  placeholder="What are you looking for?"
+                  paginationLimit={searchPaginationLimit}
+                  maxResults={searchMaxResults}
+                  indexName={algoliaIndexName}
+                  show={isSearchOpen}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/examples/algolia/components/Navigation/register.ts
+++ b/examples/algolia/components/Navigation/register.ts
@@ -1,0 +1,74 @@
+import { Group, Link, List, Number, Select, Style, TextInput } from '@makeswift/runtime/controls'
+import { runtime } from 'lib/makeswift/runtime'
+
+import { Navigation } from './client'
+
+export const NAVIGATION_COMPONENT_TYPE = 'makeswift-navigation'
+
+const links = List({
+  label: 'Navigation Links',
+  type: Group({
+    label: 'Link',
+    props: {
+      label: TextInput({ label: 'Text', defaultValue: 'Home' }),
+      link: Link({ label: 'URL' }),
+    },
+  }),
+  getItemLabel: item => item?.label ?? 'Home',
+})
+
+const alignment = Select({
+  label: 'Alignment',
+  options: [
+    { value: 'left', label: 'Left' },
+    { value: 'center', label: 'Center' },
+    { value: 'right', label: 'Right' },
+  ],
+  defaultValue: 'left',
+})
+
+const orientation = Select({
+  label: 'Orientation',
+  options: [
+    { value: 'horizontal', label: 'Horizontal' },
+    { value: 'vertical', label: 'Vertical' },
+  ],
+  defaultValue: 'horizontal',
+})
+
+const searchMaxResults = Number({
+  label: 'Search initial results',
+  defaultValue: 2,
+  min: 1,
+  max: 20,
+  step: 1,
+})
+
+const searchPaginationLimit = Number({
+  label: 'Search results per pagination',
+  defaultValue: 2,
+  min: 1,
+  max: 10,
+  step: 1,
+})
+
+const algoliaIndexName = TextInput({
+  label: 'Algolia Index Name',
+  defaultValue: '',
+})
+
+runtime.registerComponent(Navigation, {
+  type: NAVIGATION_COMPONENT_TYPE,
+  label: 'Navigation',
+  icon: 'navigation',
+  hidden: true,
+  props: {
+    className: Style(),
+    links,
+    alignment,
+    orientation,
+    searchMaxResults,
+    searchPaginationLimit,
+    algoliaIndexName,
+  },
+})

--- a/examples/algolia/env.ts
+++ b/examples/algolia/env.ts
@@ -1,0 +1,23 @@
+import { createEnv } from '@t3-oss/env-nextjs'
+import { z } from 'zod'
+
+export const env = createEnv({
+  server: {
+    MAKESWIFT_SITE_API_KEY: z.string().min(1),
+    ALGOLIA_SITE_VERIFICATION: z.string().optional(),
+  },
+  client: {
+    NEXT_PUBLIC_ALGOLIA_APP_ID: z.string().min(1),
+    NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY: z.string().min(1),
+    NEXT_PUBLIC_ALGOLIA_INDEX_NAME: z.string().optional(),
+    NEXT_PUBLIC_SITE_URL: z.string().url().optional(),
+  },
+  runtimeEnv: {
+    MAKESWIFT_SITE_API_KEY: process.env.MAKESWIFT_SITE_API_KEY,
+    ALGOLIA_SITE_VERIFICATION: process.env.ALGOLIA_SITE_VERIFICATION,
+    NEXT_PUBLIC_ALGOLIA_APP_ID: process.env.NEXT_PUBLIC_ALGOLIA_APP_ID,
+    NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY: process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY,
+    NEXT_PUBLIC_ALGOLIA_INDEX_NAME: process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME,
+    NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,
+  },
+})

--- a/examples/algolia/lib/algolia/client.ts
+++ b/examples/algolia/lib/algolia/client.ts
@@ -1,0 +1,9 @@
+import { liteClient as algoliasearch } from 'algoliasearch/lite'
+import { env } from 'env'
+
+const appId = env.NEXT_PUBLIC_ALGOLIA_APP_ID
+const searchApiKey = env.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY
+
+const client = algoliasearch(appId, searchApiKey)
+
+export default client

--- a/examples/algolia/lib/makeswift/client.ts
+++ b/examples/algolia/lib/makeswift/client.ts
@@ -1,0 +1,10 @@
+import { Makeswift } from '@makeswift/runtime/next'
+import { strict } from 'assert'
+
+import { runtime } from './runtime'
+
+strict(process.env.MAKESWIFT_SITE_API_KEY, 'MAKESWIFT_SITE_API_KEY is required')
+
+export const client = new Makeswift(process.env.MAKESWIFT_SITE_API_KEY, {
+  runtime,
+})

--- a/examples/algolia/lib/makeswift/component.tsx
+++ b/examples/algolia/lib/makeswift/component.tsx
@@ -1,0 +1,20 @@
+import { MakeswiftComponent } from '@makeswift/runtime/next'
+import { getSiteVersion } from '@makeswift/runtime/next/server'
+
+import { client } from './client'
+
+export const Component = async ({
+  snapshotId,
+  label,
+  ...props
+}: {
+  type: string
+  label: string
+  snapshotId: string
+}) => {
+  const snapshot = await client.getComponentSnapshot(snapshotId, {
+    siteVersion: await getSiteVersion(),
+  })
+
+  return <MakeswiftComponent label={label} snapshot={snapshot} {...props} />
+}

--- a/examples/algolia/lib/makeswift/components.ts
+++ b/examples/algolia/lib/makeswift/components.ts
@@ -1,0 +1,1 @@
+import '@/components/Navigation/register'

--- a/examples/algolia/lib/makeswift/provider.tsx
+++ b/examples/algolia/lib/makeswift/provider.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { ReactRuntimeProvider, RootStyleRegistry, SiteVersion } from '@makeswift/runtime/next'
+
+import '@/lib/makeswift/components'
+import { runtime } from '@/lib/makeswift/runtime'
+
+export function MakeswiftProvider({
+  children,
+  siteVersion,
+}: {
+  children: React.ReactNode
+  siteVersion: SiteVersion | null
+}) {
+  return (
+    <ReactRuntimeProvider siteVersion={siteVersion} runtime={runtime}>
+      <RootStyleRegistry enableCssReset={false}>{children}</RootStyleRegistry>
+    </ReactRuntimeProvider>
+  )
+}

--- a/examples/algolia/lib/makeswift/runtime.ts
+++ b/examples/algolia/lib/makeswift/runtime.ts
@@ -1,0 +1,10 @@
+import { ReactRuntime } from '@makeswift/runtime/react'
+
+export const runtime = new ReactRuntime({
+  breakpoints: {
+    mobile: { width: 575, viewport: 390, label: 'Mobile' },
+    tablet: { width: 768, viewport: 765, label: 'Tablet' },
+    laptop: { width: 1024, viewport: 1000, label: 'Laptop' },
+    external: { width: 1280, label: 'External' },
+  },
+})

--- a/examples/algolia/lib/utils.ts
+++ b/examples/algolia/lib/utils.ts
@@ -1,0 +1,20 @@
+import { useEffect } from 'react'
+
+export function useClickOutside<T extends HTMLElement>(
+  ref: React.RefObject<T | null>,
+  callback: () => void
+) {
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        callback()
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [ref, callback])
+}

--- a/examples/algolia/next-env.d.ts
+++ b/examples/algolia/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/algolia/next.config.js
+++ b/examples/algolia/next.config.js
@@ -1,0 +1,19 @@
+const createWithMakeswift = require('@makeswift/runtime/next/plugin')
+
+const withMakeswift = createWithMakeswift()
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '**',
+      },
+    ],
+  },
+}
+
+module.exports = withMakeswift(nextConfig)
+

--- a/examples/algolia/package.json
+++ b/examples/algolia/package.json
@@ -1,0 +1,40 @@
+{
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "icons": "npx @svgr/cli --typescript --replace-attr-values \"#000=currentColor\" --out-dir generated/icons -- public/icons"
+  },
+  "dependencies": {
+    "@makeswift/runtime": "0.26.0",
+    "@radix-ui/react-accordion": "^1.2.3",
+    "@radix-ui/react-tabs": "^1.1.3",
+    "@t3-oss/env-nextjs": "^0.13.8",
+    "algoliasearch": "^5.35.0",
+    "clsx": "^2.1.1",
+    "lodash.debounce": "^4.0.8",
+    "next": "15.2.8",
+    "react": "^19.0.3",
+    "react-dom": "^19.0.0",
+    "react-instantsearch": "^7.16.2",
+    "react-instantsearch-nextjs": "^1.0.1",
+    "zod": "^4.0.15"
+  },
+  "devDependencies": {
+    "@trivago/prettier-plugin-sort-imports": "^5.2.2",
+    "@types/lodash.debounce": "^4.0.9",
+    "@types/node": "^22.13.10",
+    "@types/react": "^19.0.10",
+    "@types/react-dom": "^19.0.4",
+    "autoprefixer": "^10.4.21",
+    "eslint": "^9.22.0",
+    "eslint-config-next": "^15.2.2",
+    "postcss": "^8.5.3",
+    "prettier": "^3.5.3",
+    "prettier-plugin-tailwindcss": "^0.6.11",
+    "tailwindcss": "^3.3.3",
+    "typescript": "^5.8.2"
+  }
+}

--- a/examples/algolia/postcss.config.js
+++ b/examples/algolia/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/examples/algolia/tailwind.config.js
+++ b/examples/algolia/tailwind.config.js
@@ -1,0 +1,35 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx,mdx}',
+    './components/**/*.{js,ts,jsx,tsx,mdx}',
+    './vibes/**/*.{js,ts,jsx,tsx,mdx}',
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['var(--font-inter)', 'sans-serif'],
+      },
+      keyframes: {
+        expand: {
+          from: { height: 0 },
+          to: { height: 'var(--radix-accordion-content-height)' },
+        },
+        collapse: {
+          from: { height: 'var(--radix-accordion-content-height)' },
+          to: { height: 0 },
+        },
+        scrollLeft: {
+          '0%': { transform: 'translateX(0)' },
+          '100%': { transform: 'translateX(-100%)' },
+        },
+      },
+      animation: {
+        expand: 'expand 400ms cubic-bezier(1, 0, 0.25, 1)',
+        collapse: 'collapse 400ms cubic-bezier(1, 0, 0.25, 1)',
+        scrollLeft: 'scrollLeft var(--marquee-duration) linear infinite',
+      },
+    },
+  },
+  plugins: [],
+}

--- a/examples/algolia/tsconfig.json
+++ b/examples/algolia/tsconfig.json
@@ -1,0 +1,33 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/generated/*": ["generated/*"],
+      "@/components/*": ["components/*"],
+      "@/lib/*": ["lib/*"],
+      "@/styles/*": ["styles/*"],
+      "@/vibes/*": ["vibes/*"]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/examples/algolia/vibes/soul/primitives/icons/index.tsx
+++ b/examples/algolia/vibes/soul/primitives/icons/index.tsx
@@ -1,0 +1,71 @@
+import { clsx } from 'clsx'
+
+export interface IconProps {
+  className?: string
+  size?: 'sm' | 'md' | 'lg'
+  strokeWidth?: number
+}
+
+const sizeClasses = {
+  sm: 'h-4 w-4',
+  md: 'h-5 w-5',
+  lg: 'h-6 w-6',
+}
+
+export function CloseIcon({ className, size = 'md', strokeWidth = 2 }: IconProps) {
+  return (
+    <svg
+      className={clsx(sizeClasses[size], className)}
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+        d="M6 18L18 6M6 6l12 12"
+      />
+    </svg>
+  )
+}
+
+export function MenuIcon({ className, size = 'md', strokeWidth = 2 }: IconProps) {
+  return (
+    <svg
+      className={clsx(sizeClasses[size], className)}
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+        d="M4 6h16M4 12h16M4 18h16"
+      />
+    </svg>
+  )
+}
+
+export function SearchIcon({ className, size = 'md', strokeWidth = 2 }: IconProps) {
+  return (
+    <svg
+      className={clsx(sizeClasses[size], className)}
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+        d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+      />
+    </svg>
+  )
+}
+

--- a/examples/algolia/vibes/soul/primitives/spinner/index.tsx
+++ b/examples/algolia/vibes/soul/primitives/spinner/index.tsx
@@ -1,0 +1,35 @@
+import { clsx } from 'clsx'
+
+export interface SpinnerProps {
+  size?: 'xs' | 'sm' | 'md' | 'lg'
+  loadingAriaLabel?: string
+}
+
+/**
+ * This component supports various CSS variables for theming. Here's a comprehensive list, along
+ * with their default values:
+ *
+ * ```css
+ * :root {
+ *   --spinner-base: #e5e7eb;
+ *   --spinner-ring: #3b82f6;
+ * }
+ * ```
+ */
+export function Spinner({ size = 'sm', loadingAriaLabel = 'Loading...' }: SpinnerProps) {
+  return (
+    <span
+      aria-label={loadingAriaLabel}
+      className={clsx(
+        'box-border inline-block animate-spin rounded-full border-gray-200 border-b-blue-500',
+        {
+          xs: 'h-5 w-5 border-2',
+          sm: 'h-6 w-6 border-2',
+          md: 'h-10 w-10 border-[3px]',
+          lg: 'h-14 w-14 border-4',
+        }[size]
+      )}
+      role="status"
+    />
+  )
+}


### PR DESCRIPTION
This project exemplifies the usage of Algolia in Makeswift. It provides a registered component that communicates with the Algolia client configured by the environment variables. This example includes a built-in Navigation component that has the Algolia search component hard-coded. Instructions in the readme show how to use the Algolia crawler with Makeswift pages.


https://github.com/user-attachments/assets/69c62dcb-a93d-40d8-a7bf-c91fa70a1f94

To clarify something unspecified in the video, you're replacing the "placeholder" with the site verification key.

<img width="391" height="500" alt="CleanShot 2025-12-30 at 12 29 32" src="https://github.com/user-attachments/assets/e0682696-8726-4945-8e8d-c30f21fded45" />

This is the finished crawler that I "demonstrated"

EDIT: Since recording, I've specified to include the domain as an environment variable for the sitemap.