### PR TITLE
tests: built-in`Button` component rendering, `Image` with a link

### DIFF
--- a/apps/nextjs-app-router/src/app/[lang]/[[...path]]/page.tsx
+++ b/apps/nextjs-app-router/src/app/[lang]/[[...path]]/page.tsx
@@ -33,6 +33,7 @@ export default async function Page(props: { params: ParsedUrlQuery }) {
     locale: params.lang,
   })
 
+  console.log('Rendering page:', JSON.stringify(snapshot, null, 2))
   if (snapshot == null) return notFound()
 
   return <MakeswiftPage snapshot={snapshot} />

--- a/packages/runtime/src/next/components/tests/__fixtures__/element-data/button-component.ts
+++ b/packages/runtime/src/next/components/tests/__fixtures__/element-data/button-component.ts
@@ -1,0 +1,84 @@
+import { type ElementData } from '@makeswift/controls'
+import { LinkData } from '@makeswift/prop-controllers'
+
+import { MakeswiftComponentType } from '../../../../../components'
+
+export const buttonComponentData = ({
+  htmlId,
+  linkData,
+}: {
+  htmlId: string
+  linkData: LinkData
+}): ElementData => ({
+  key: '3dda7ade-3dcb-4776-a2f5-2f7e04e34ec2',
+  props: {
+    id: {
+      '@@makeswift/type': 'prop-controllers::element-id::v1',
+      value: htmlId,
+    },
+    link: {
+      '@@makeswift/type': 'prop-controllers::link::v1',
+      value: linkData,
+    },
+    margin: {
+      '@@makeswift/type': 'prop-controllers::margin::v1',
+      value: [
+        {
+          deviceId: 'desktop',
+          value: {
+            marginBottom: {
+              unit: 'px',
+              value: 80,
+            },
+            marginTop: {
+              unit: 'px',
+              value: 60,
+            },
+          },
+        },
+      ],
+    },
+  },
+  type: MakeswiftComponentType.Button,
+})
+
+export const linkData: Record<string, LinkData> = {
+  page: {
+    payload: {
+      openInNewTab: false,
+      pageId: 'UGFnZTozOWZkNDcyZS03N2QxLTRjZDItOGE3Yi02ZTQ2MDU3ODgxNzM=',
+    },
+    type: 'OPEN_PAGE',
+  },
+  url: {
+    payload: {
+      openInNewTab: false,
+      url: 'https://www.makeswift.com/',
+    },
+    type: 'OPEN_URL',
+  },
+  email: {
+    payload: {
+      body: '',
+      subject: 'Buttons',
+      to: 'alan@makeswift.com',
+    },
+    type: 'SEND_EMAIL',
+  },
+  phone: {
+    payload: {
+      phoneNumber: '15551234567',
+    },
+    type: 'CALL_PHONE',
+  },
+  element: {
+    payload: {
+      block: 'start',
+      elementIdConfig: {
+        elementKey: '3dda7ade-3dcb-4776-a2f5-2f7e04e34ec2',
+        propName: 'id',
+      },
+    },
+    type: 'SCROLL_TO_ELEMENT',
+  },
+}

--- a/packages/runtime/src/next/components/tests/__fixtures__/element-data/image-component.ts
+++ b/packages/runtime/src/next/components/tests/__fixtures__/element-data/image-component.ts
@@ -97,6 +97,16 @@ export const imageComponentData = ({
       '@@makeswift/type': 'prop-controllers::element-id::v1',
       value: htmlId,
     },
+    link: {
+      '@@makeswift/type': 'prop-controllers::link::v1',
+      value: {
+        payload: {
+          openInNewTab: false,
+          url: 'https://www.makeswift.com/',
+        },
+        type: 'OPEN_URL',
+      },
+    },
     margin: {
       '@@makeswift/type': 'prop-controllers::margin::v1',
       value: [

--- a/packages/runtime/src/next/components/tests/__fixtures__/resources/index.ts
+++ b/packages/runtime/src/next/components/tests/__fixtures__/resources/index.ts
@@ -1,2 +1,3 @@
 export * from './swatches'
 export * from './files'
+export * from './page-pathname-slices'

--- a/packages/runtime/src/next/components/tests/__fixtures__/resources/page-pathname-slices.ts
+++ b/packages/runtime/src/next/components/tests/__fixtures__/resources/page-pathname-slices.ts
@@ -1,0 +1,7 @@
+import { type PagePathnameSlice } from '../../../../../api'
+
+export const pagePathnameSlice1: PagePathnameSlice = {
+  __typename: 'PagePathnameSlice',
+  id: 'UGFnZTozOWZkNDcyZS03N2QxLTRjZDItOGE3Yi02ZTQ2MDU3ODgxNzM=',
+  pathname: 'about',
+}

--- a/packages/runtime/src/next/components/tests/components/__snapshots__/button-component-rendering.test.tsx.snap
+++ b/packages/runtime/src/next/components/tests/components/__snapshots__/button-component-rendering.test.tsx.snap
@@ -1,0 +1,191 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`correctly renders button component with CALL_PHONE link 1`] = `
+<a
+  class="[redacted]"
+  href="tel:15551234567"
+  id="test-button"
+>
+  Button Text
+</a>
+`;
+
+exports[`correctly renders button component with OPEN_PAGE link 1`] = `
+<a
+  class="[redacted]"
+  href="/about"
+  id="test-button"
+  target="_self"
+>
+  Button Text
+</a>
+`;
+
+exports[`correctly renders button component with OPEN_URL link 1`] = `
+<a
+  class="[redacted]"
+  href="https://www.makeswift.com/"
+  id="test-button"
+  target="_self"
+>
+  Button Text
+</a>
+`;
+
+exports[`correctly renders button component with SCROLL_TO_ELEMENT link 1`] = `
+<a
+  class="[redacted]"
+  href="#test-button"
+  id="test-button"
+>
+  Button Text
+</a>
+`;
+
+exports[`correctly renders button component with SEND_EMAIL link 1`] = `
+<a
+  class="[redacted]"
+  href="mailto:alan@makeswift.com?subject=Buttons&body="
+  id="test-button"
+>
+  Button Text
+</a>
+`;
+
+exports[`correctly renders button component with link 1`] = `
+.emotion-0 {
+  display: table;
+  border: 0;
+  outline: 0;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  cursor: pointer;
+  font-family: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-align: center;
+}
+
+.emotion-1 {
+  max-width: 100%;
+}
+
+@media only screen and (min-width: 769px) {
+  .emotion-1 {
+    width: auto;
+  }
+}
+
+@media only screen and (min-width: 576px) and (max-width: 768px) {
+  .emotion-1 {
+    width: auto;
+  }
+}
+
+@media only screen and (max-width: 575px) {
+  .emotion-1 {
+    width: auto;
+  }
+}
+
+@media only screen and (min-width: 769px) {
+  .emotion-2 {
+    margin-top: 60px;
+    margin-right: auto;
+    margin-bottom: 80px;
+    margin-left: auto;
+  }
+}
+
+@media only screen and (min-width: 576px) and (max-width: 768px) {
+  .emotion-2 {
+    margin-top: 60px;
+    margin-right: auto;
+    margin-bottom: 80px;
+    margin-left: auto;
+  }
+}
+
+@media only screen and (max-width: 575px) {
+  .emotion-2 {
+    margin-top: 60px;
+    margin-right: auto;
+    margin-bottom: 80px;
+    margin-left: auto;
+  }
+}
+
+@media only screen and (min-width: 769px) {
+  .emotion-3 {
+    color: hsla(0,0%,100%,1);
+    border-radius: 4px;
+    padding: 12px 16px;
+    font-size: 14px;
+    background: hsla(0,0%,0%,1);
+    border: none;
+    -webkit-transition: color 0.15s ease-in-out,background 0.15s ease-in-out,border 0.15s ease-in-out,box-shadow 0.15s ease-in-out;
+    transition: color 0.15s ease-in-out,background 0.15s ease-in-out,border 0.15s ease-in-out,box-shadow 0.15s ease-in-out;
+  }
+
+  .emotion-3:hover {
+    background: #000000;
+  }
+
+  .emotion-3:active {
+    background: #000000;
+  }
+}
+
+@media only screen and (min-width: 576px) and (max-width: 768px) {
+  .emotion-3 {
+    color: hsla(0,0%,100%,1);
+    border-radius: 4px;
+    padding: 12px 16px;
+    font-size: 14px;
+    background: hsla(0,0%,0%,1);
+    border: none;
+    -webkit-transition: color 0.15s ease-in-out,background 0.15s ease-in-out,border 0.15s ease-in-out,box-shadow 0.15s ease-in-out;
+    transition: color 0.15s ease-in-out,background 0.15s ease-in-out,border 0.15s ease-in-out,box-shadow 0.15s ease-in-out;
+  }
+
+  .emotion-3:hover {
+    background: #000000;
+  }
+
+  .emotion-3:active {
+    background: #000000;
+  }
+}
+
+@media only screen and (max-width: 575px) {
+  .emotion-3 {
+    color: hsla(0,0%,100%,1);
+    border-radius: 4px;
+    padding: 12px 16px;
+    font-size: 14px;
+    background: hsla(0,0%,0%,1);
+    border: none;
+    -webkit-transition: color 0.15s ease-in-out,background 0.15s ease-in-out,border 0.15s ease-in-out,box-shadow 0.15s ease-in-out;
+    transition: color 0.15s ease-in-out,background 0.15s ease-in-out,border 0.15s ease-in-out,box-shadow 0.15s ease-in-out;
+  }
+
+  .emotion-3:hover {
+    background: #000000;
+  }
+
+  .emotion-3:active {
+    background: #000000;
+  }
+}
+
+<a
+  class="emotion-0 emotion-1 emotion-2 emotion-3 emotion-4"
+  href="https://www.makeswift.com/"
+  id="test-button"
+  target="_self"
+>
+  Button Text
+</a>
+`;

--- a/packages/runtime/src/next/components/tests/components/__snapshots__/image-component-rendering.test.tsx.snap
+++ b/packages/runtime/src/next/components/tests/components/__snapshots__/image-component-rendering.test.tsx.snap
@@ -154,9 +154,11 @@ exports[`correctly renders image component 1`] = `
   }
 }
 
-<div
+<a
   class="emotion-0 emotion-1 emotion-2 emotion-3 emotion-4 emotion-5 emotion-6 emotion-7"
+  href="https://www.makeswift.com/"
   id="test-image"
+  target="_self"
 >
   <img
     alt="Hill chart"
@@ -169,5 +171,5 @@ exports[`correctly renders image component 1`] = `
     style="color: transparent; width: 100%; height: auto;"
     width="2700"
   />
-</div>
+</a>
 `;

--- a/packages/runtime/src/next/components/tests/components/button-component-rendering.test.tsx
+++ b/packages/runtime/src/next/components/tests/components/button-component-rendering.test.tsx
@@ -1,0 +1,66 @@
+/** @jest-environment jsdom */
+
+import '@testing-library/jest-dom'
+
+import {
+  createMakeswiftPageSnapshot,
+  testMakeswiftPageRendering,
+  createRootComponent,
+} from '../../../testing'
+
+import { pageDocument } from '../__fixtures__/page-document'
+import { buttonComponentData, linkData } from '../__fixtures__/element-data/button-component'
+import * as Resources from '../__fixtures__/resources'
+
+const createPageWithButton = (...args: Parameters<typeof buttonComponentData>) => {
+  const button = buttonComponentData(...args)
+
+  return createMakeswiftPageSnapshot(
+    {
+      ...pageDocument,
+      data: createRootComponent([button]),
+    },
+    {
+      cacheData: {
+        apiResources: {
+          PagePathnameSlice: [
+            {
+              id: Resources.pagePathnameSlice1.id,
+              value: Resources.pagePathnameSlice1,
+            },
+          ],
+        },
+      },
+    },
+  )
+}
+
+describe('correctly renders button component', () => {
+  const htmlId = 'test-button'
+
+  test('with link', async () => {
+    const snapshot = createPageWithButton({
+      htmlId,
+      linkData: linkData.url,
+    })
+
+    const render = await testMakeswiftPageRendering({ snapshot })
+    expect(render.container.querySelector(`#${htmlId}`)).toMatchSnapshot()
+  })
+
+  test.each([linkData.page, linkData.url, linkData.email, linkData.phone, linkData.element])(
+    'with $type link',
+    async linkData => {
+      const snapshot = createPageWithButton({
+        htmlId,
+        linkData,
+      })
+
+      const render = await testMakeswiftPageRendering({ snapshot })
+      const button = render.container.querySelector(`#${htmlId}`)
+      button?.setAttribute('class', '[redacted]')
+      expect(button).toMatchSnapshot()
+      // expect(render.container.querySelector(`#${htmlId}`)?.getAttribute('href')).toMatchSnapshot()
+    },
+  )
+})


### PR DESCRIPTION
Basic rendering test for the built-in `Button`, `Image` with a link. No semantic changes. Prep for `next/link` decoupling.
