### PR TITLE
feat: decouple built-in `Button`, et al from `next/link`

### DIFF
--- a/.changeset/famous-queens-decide.md
+++ b/.changeset/famous-queens-decide.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+feat: decouple built-in components from `next/link`

--- a/packages/runtime/src/next/components/framework-provider/index.tsx
+++ b/packages/runtime/src/next/components/framework-provider/index.tsx
@@ -4,10 +4,11 @@ import { type PropsWithChildren, useMemo } from 'react'
 import NextImage from 'next/image'
 
 import { useIsPagesRouter } from '../../hooks/use-is-pages-router'
+import { FrameworkContext } from '../../../runtimes/react/components/framework-context'
 
 import { context as appRouterContext } from './app-router'
 import { context as pagesRouterContext } from './pages-router'
-import { FrameworkContext } from '../../../runtimes/react/components/framework-context'
+import { Link } from './link'
 
 export function FrameworkProvider({
   children,
@@ -18,6 +19,7 @@ export function FrameworkProvider({
     () => ({
       ...(isPagesRouter ? pagesRouterContext : appRouterContext),
       Image: NextImage,
+      Link,
     }),
     [isPagesRouter],
   )

--- a/packages/runtime/src/next/components/framework-provider/link.tsx
+++ b/packages/runtime/src/next/components/framework-provider/link.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { type ComponentPropsWithoutRef, forwardRef } from 'react'
+import NextLink from 'next/link'
+
+import { type FrameworkContext } from '../../../runtimes/react/components/framework-context'
+
+import { useIsPagesRouter } from '../../hooks/use-is-pages-router'
+
+// workaround for https://github.com/vercel/next.js/issues/66650
+const isValidHref = (href: string) => {
+  try {
+    const bases = ['http://n', 'https://n']
+    // - if `href` is a relative path, it will be resolved relative to the base URL
+    // - if `href` is a full URL, the base URL will be ignored, even if there is a mismatch of protocols
+    // - if `href` is an incomplete, protocol-only URL with a protocol that
+    //   conflicts with one of the base URL, this will throw
+    bases.forEach(base => new URL(href, base))
+  } catch (_) {
+    return false
+  }
+  return true
+}
+
+export const Link = forwardRef<HTMLAnchorElement>(function Link(
+  { linkType, href, ...props }: ComponentPropsWithoutRef<FrameworkContext['Link']>,
+  ref,
+) {
+  const useNextLink =
+    href != null && (linkType === 'OPEN_PAGE' || (linkType === 'OPEN_URL' && isValidHref(href)))
+
+  const isPagesRouter = useIsPagesRouter()
+
+  if (useNextLink) {
+    return (
+      <NextLink
+        {...props}
+        ref={ref}
+        href={href}
+        {...(isPagesRouter ? { locale: false } : {})}
+        // Next.js v12 has legacyBehavior set to true by default
+        legacyBehavior={false}
+      />
+    )
+  }
+
+  return <a {...props} ref={ref} href={href} />
+})

--- a/packages/runtime/src/runtimes/react/components/framework-context.tsx
+++ b/packages/runtime/src/runtimes/react/components/framework-context.tsx
@@ -1,4 +1,16 @@
-import { createContext, type ReactNode, type PropsWithChildren, type CSSProperties } from 'react'
+import {
+  createContext,
+  type ReactNode,
+  type PropsWithChildren,
+  type CSSProperties,
+  type ComponentPropsWithoutRef,
+  type MouseEvent,
+  type ForwardRefExoticComponent,
+  type RefAttributes,
+  forwardRef,
+} from 'react'
+
+import { type LinkData } from '@makeswift/prop-controllers'
 
 import { type Snippet } from '../../../client'
 
@@ -17,10 +29,18 @@ type ImageComponent = (props: {
   style?: CSSProperties
 }) => ReactNode
 
+type LinkProps = Omit<ComponentPropsWithoutRef<'a'>, 'onClick'> & {
+  linkType?: LinkData['type']
+  onClick?: (event: MouseEvent<HTMLAnchorElement>) => unknown
+}
+
+type LinkComponent = ForwardRefExoticComponent<RefAttributes<HTMLAnchorElement> & LinkProps>
+
 export type FrameworkContext = {
   Head: HeadComponent
   HeadSnippet: HeadSnippet
   Image: ImageComponent
+  Link: LinkComponent
 }
 
 // React 19 automatically hoists metadata tags to the <head>
@@ -43,8 +63,13 @@ export const DefaultImage: ImageComponent = ({ priority, fill, style, ...props }
   />
 )
 
+export const DefaultLink: LinkComponent = forwardRef<HTMLAnchorElement, LinkProps>(
+  ({ linkType, ...props }, ref) => <a {...props} ref={ref} />,
+)
+
 export const FrameworkContext = createContext<FrameworkContext>({
   Head: DefaultHead,
   HeadSnippet: BaseHeadSnippet,
   Image: DefaultImage,
+  Link: DefaultLink,
 })


### PR DESCRIPTION
Tests were added in https://github.com/makeswift/makeswift/pull/1081