### PR TITLE
fix: null swatch ID for backgrounds prop controller

### DIFF
--- a/.changeset/smart-birds-hang.md
+++ b/.changeset/smart-birds-hang.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/prop-controllers": patch
+---
+
+fix: support null swatch IDs for backgrounds prop controller color data

--- a/packages/prop-controllers/src/backgrounds/backgrounds.test.ts
+++ b/packages/prop-controllers/src/backgrounds/backgrounds.test.ts
@@ -56,6 +56,29 @@ const backgrounds: BackgroundsPropControllerDataV1 = [
         type: 'video',
         payload: { maskColor: { swatchId: '[swatch4]', alpha: 100 } },
       },
+      {
+        id: '4',
+        type: 'color',
+        payload: { swatchId: null, alpha: 0.5 },
+      },
+      {
+        id: '5',
+        type: 'gradient',
+        payload: {
+          stops: [
+            {
+              id: 'stop1',
+              location: 0,
+              color: { swatchId: null, alpha: 0.6 },
+            },
+          ],
+        },
+      },
+      {
+        id: '6',
+        type: 'video',
+        payload: { maskColor: { swatchId: null, alpha: 0.07 } },
+      },
     ],
   },
 ]


### PR DESCRIPTION
Updates the backgrounds prop controller data schema to support null swatch IDs. 

Following up https://github.com/makeswift/makeswift/pull/1066.