### PR TITLE
chore: upgrade to the latest TypeScript (5.1.6 -> 5.9.2)

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -225,7 +225,7 @@
     "slate-hyperscript": "^0.77.0",
     "slate-react": "^0.91.7",
     "tsup": "^8.0.1",
-    "typescript": "^5.1.6",
+    "typescript": "^5.9.2",
     "undici": "^6.19.2"
   }
 }

--- a/packages/runtime/src/slate/BlockPlugin/__tests__/clearBlockKeyForDevice.test.tsx
+++ b/packages/runtime/src/slate/BlockPlugin/__tests__/clearBlockKeyForDevice.test.tsx
@@ -2,7 +2,6 @@
 /** @jsx jsx */
 
 import { BlockActions } from '../'
-// @ts-expect-error: 'jsx' is declared but its value is never read.
 import { jsx, Paragraph, Text, Editor, Cursor } from '../../test-helpers'
 
 describe('GIVEN clearBlockKeyForDevice', () => {

--- a/packages/runtime/src/slate/BlockPlugin/__tests__/dedent.test.tsx
+++ b/packages/runtime/src/slate/BlockPlugin/__tests__/dedent.test.tsx
@@ -2,7 +2,6 @@
 /** @jsx jsx */
 
 import { ListActions } from '..'
-// @ts-expect-error: 'jsx' is declared but its value is never read.
 import { Editor, jsx, Cursor, ListItem, ListItemChild, Text, Unordered } from '../../test-helpers'
 
 describe('Dedent List', () => {

--- a/packages/runtime/src/slate/BlockPlugin/__tests__/indent.test.tsx
+++ b/packages/runtime/src/slate/BlockPlugin/__tests__/indent.test.tsx
@@ -3,7 +3,6 @@
 
 import { ListActions } from '..'
 import {
-  // @ts-expect-error: 'jsx' is declared but its value is never read.
   jsx,
   Editor,
   Cursor,

--- a/packages/runtime/src/slate/BlockPlugin/__tests__/normalization.test.tsx
+++ b/packages/runtime/src/slate/BlockPlugin/__tests__/normalization.test.tsx
@@ -2,7 +2,6 @@
 /** @jsx jsx */
 
 import {
-  // @ts-expect-error: 'jsx' is declared but its value is never read.
   jsx,
   Editor,
   ListItem,

--- a/packages/runtime/src/slate/BlockPlugin/__tests__/setBlockKeyForDevice.test.tsx
+++ b/packages/runtime/src/slate/BlockPlugin/__tests__/setBlockKeyForDevice.test.tsx
@@ -3,7 +3,6 @@
 
 import { BlockActions } from '..'
 import { DEFAULT_BREAKPOINTS } from '../../../state/modules/breakpoints'
-// @ts-expect-error: 'jsx' is declared but its value is never read.
 import { jsx, Paragraph, Text, Editor, Cursor, Anchor, Focus, Fragment } from '../../test-helpers'
 
 describe('GIVEN setBlockKeyForDevice', () => {

--- a/packages/runtime/src/slate/BlockPlugin/__tests__/toggleList.test.tsx
+++ b/packages/runtime/src/slate/BlockPlugin/__tests__/toggleList.test.tsx
@@ -2,7 +2,6 @@
 /** @jsx jsx */
 
 import {
-  // @ts-expect-error: 'jsx' is declared but its value is never read.
   jsx,
   Editor,
   Paragraph,

--- a/packages/runtime/src/slate/BlockPlugin/__tests__/unwrapInline.test.tsx
+++ b/packages/runtime/src/slate/BlockPlugin/__tests__/unwrapInline.test.tsx
@@ -3,7 +3,6 @@
 
 import { BlockActions } from '..'
 import { InlineType } from '../..'
-// @ts-expect-error: 'jsx' is declared but its value is never read.
 import { jsx, Paragraph, Code, Text, Editor, Sub, Super } from '../../test-helpers'
 
 describe('GIVEN unwrapInline', () => {

--- a/packages/runtime/src/slate/BlockPlugin/__tests__/unwrapList.test.tsx
+++ b/packages/runtime/src/slate/BlockPlugin/__tests__/unwrapList.test.tsx
@@ -12,7 +12,6 @@ import {
   Focus,
   Fragment,
   Editor,
-  // @ts-expect-error: 'jsx' is declared but its value is never read.
   jsx,
 } from '../../test-helpers'
 import { ListActions } from '..'

--- a/packages/runtime/src/slate/BlockPlugin/__tests__/utils/getSelectedListItems.test.tsx
+++ b/packages/runtime/src/slate/BlockPlugin/__tests__/utils/getSelectedListItems.test.tsx
@@ -4,7 +4,6 @@
 import { getSelectedListItems } from '../../utils/getSelectedListItems'
 import {
   Editor,
-  // @ts-expect-error: 'jsx' is declared but its value is never read.
   jsx,
   Unordered,
   ListItem,

--- a/packages/runtime/src/slate/BlockPlugin/__tests__/wrapInline.test.tsx
+++ b/packages/runtime/src/slate/BlockPlugin/__tests__/wrapInline.test.tsx
@@ -3,7 +3,6 @@
 
 import { BlockActions } from '..'
 import { InlineType } from '../..'
-// @ts-expect-error: 'jsx' is declared but its value is never read.
 import { jsx, Paragraph, Code, Text, Editor, Focus, Anchor } from '../../test-helpers'
 
 describe('GIVEN wrapInline', () => {

--- a/packages/runtime/src/slate/BlockPlugin/__tests__/wrapList.test.tsx
+++ b/packages/runtime/src/slate/BlockPlugin/__tests__/wrapList.test.tsx
@@ -4,7 +4,6 @@
 import { ListActions } from '..'
 import { BlockType } from '../..'
 import {
-  // @ts-expect-error: 'jsx' is declared but its value is never read.
   jsx,
   Editor,
   Paragraph,

--- a/packages/runtime/src/slate/InlineModePlugin/__tests__/inlineMode.test.tsx
+++ b/packages/runtime/src/slate/InlineModePlugin/__tests__/inlineMode.test.tsx
@@ -3,7 +3,6 @@
 
 import { Editor as SlateEditor } from 'slate'
 import {
-  // @ts-expect-error: 'jsxWithV2InlineEditor' is declared but its value is never read.
   jsxWithV2InlineEditor,
   Ordered,
   Paragraph,

--- a/packages/runtime/src/slate/InlinePlugin/__tests__/getValue.test.tsx
+++ b/packages/runtime/src/slate/InlinePlugin/__tests__/getValue.test.tsx
@@ -4,7 +4,6 @@
 import { getValue } from '../getValue'
 import { InlineType } from '../..'
 import {
-  // @ts-expect-error: 'jsx' is declared but its value is never read.
   jsx,
   Paragraph,
   Code,

--- a/packages/runtime/src/slate/InlinePlugin/__tests__/onChange.test.tsx
+++ b/packages/runtime/src/slate/InlinePlugin/__tests__/onChange.test.tsx
@@ -3,7 +3,6 @@
 
 import { onChange } from '../onChange'
 import { InlineType } from '../..'
-// @ts-expect-error: 'jsx' is declared but its value is never read.
 import { jsx, Paragraph, Code, EditorV2, Text, Focus, Anchor, Link } from '../../test-helpers'
 
 describe('GIVEN InlinePlugin.onChange', () => {

--- a/packages/runtime/src/slate/LinkPlugin/__tests__/getValue.test.tsx
+++ b/packages/runtime/src/slate/LinkPlugin/__tests__/getValue.test.tsx
@@ -4,7 +4,6 @@
 import { getValue } from '../getValue'
 import { type DataType } from '@makeswift/controls'
 import { LinkDefinition } from '../../../controls'
-// @ts-expect-error: 'jsx' is declared but its value is never read.
 import { jsx, Paragraph, Text, EditorV2, Focus, Anchor, Link, Code } from '../../test-helpers'
 
 const SCROLL_LINK_DATA: DataType<LinkDefinition> = {

--- a/packages/runtime/src/slate/LinkPlugin/__tests__/onChange.test.tsx
+++ b/packages/runtime/src/slate/LinkPlugin/__tests__/onChange.test.tsx
@@ -4,7 +4,6 @@
 import { onChange } from '../onChange'
 import { type DataType } from '@makeswift/controls'
 import { LinkDefinition } from '../../../controls'
-// @ts-expect-error: 'jsx' is declared but its value is never read.
 import { jsx, Paragraph, Text, EditorV2, Focus, Anchor, Link, Code } from '../../test-helpers'
 
 const initialLinkData: DataType<LinkDefinition> = {

--- a/packages/runtime/src/slate/TextAlignPlugin/__tests__/getValue.test.tsx
+++ b/packages/runtime/src/slate/TextAlignPlugin/__tests__/getValue.test.tsx
@@ -3,7 +3,6 @@
 
 import { Slate } from '@makeswift/controls'
 import { getValue } from '../getValue'
-// @ts-expect-error: 'jsx' is declared but its value is never read.
 import { jsx, Paragraph, Text, EditorV2, Focus, Anchor, Fragment } from '../../test-helpers'
 
 const DESKTOP_LEFT = { deviceId: 'desktop', value: Slate.BlockTextAlignment.Left }

--- a/packages/runtime/src/slate/TypographyPlugin/__tests__/clearActiveTypographyStyle.test.tsx
+++ b/packages/runtime/src/slate/TypographyPlugin/__tests__/clearActiveTypographyStyle.test.tsx
@@ -2,7 +2,6 @@
 /** @jsx jsx */
 
 import { TypographyActions } from '../'
-// @ts-expect-error: 'jsx' is declared but its value is never read.
 import { jsx, Paragraph, Text, Editor, Cursor, Anchor, Focus } from '../../test-helpers'
 
 describe('GIVEN clearActiveTypographyStyle', () => {

--- a/packages/runtime/src/slate/TypographyPlugin/__tests__/clearDeviceActiveTypography.test.tsx
+++ b/packages/runtime/src/slate/TypographyPlugin/__tests__/clearDeviceActiveTypography.test.tsx
@@ -2,7 +2,6 @@
 /** @jsx jsx */
 
 import { TypographyActions } from '../'
-// @ts-expect-error: 'jsx' is declared but its value is never read.
 import { jsx, Cursor, Editor, Paragraph, Text, Anchor, Focus } from '../../test-helpers'
 
 describe('GIVEN clearDeviceActiveTypography', () => {

--- a/packages/runtime/src/slate/TypographyPlugin/__tests__/detachActiveTypography.test.tsx
+++ b/packages/runtime/src/slate/TypographyPlugin/__tests__/detachActiveTypography.test.tsx
@@ -1,7 +1,6 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
 
-// @ts-expect-error: 'jsx' is declared but its value is never read.
 import { Editor, Paragraph, jsx, Text, Cursor, Anchor, Focus } from '../../test-helpers'
 import { TypographyActions } from '../'
 

--- a/packages/runtime/src/slate/TypographyPlugin/__tests__/normalization.test.tsx
+++ b/packages/runtime/src/slate/TypographyPlugin/__tests__/normalization.test.tsx
@@ -2,17 +2,7 @@
 /** @jsx jsx */
 
 import { Editor as SlateEditor } from 'slate'
-import {
-  Text,
-  Cursor,
-  EditorV2,
-  Paragraph,
-  // @ts-expect-error: 'jsx' is declared but its value is never read.
-  jsx,
-  Code,
-  Super,
-  Sub,
-} from '../../test-helpers'
+import { Text, Cursor, EditorV2, Paragraph, jsx, Code, Super, Sub } from '../../test-helpers'
 
 describe('GIVEN normalizing typography', () => {
   describe('GIVEN normalizing neutral', () => {

--- a/packages/runtime/src/slate/TypographyPlugin/__tests__/setActiveTypographyId.test.tsx
+++ b/packages/runtime/src/slate/TypographyPlugin/__tests__/setActiveTypographyId.test.tsx
@@ -2,7 +2,6 @@
 /** @jsx jsx */
 
 import { TypographyActions } from '../'
-// @ts-expect-error: 'jsx' is declared but its value is never read.
 import { jsx, Editor, Paragraph, Text, Cursor, Anchor, Focus } from '../../test-helpers'
 
 describe('GIVEN setActiveTypographyId', () => {

--- a/packages/runtime/src/slate/TypographyPlugin/__tests__/setActiveTypographyStyle.test.tsx
+++ b/packages/runtime/src/slate/TypographyPlugin/__tests__/setActiveTypographyStyle.test.tsx
@@ -3,7 +3,6 @@
 
 import { TypographyActions } from '../'
 import { DEFAULT_BREAKPOINTS } from '../../../state/modules/breakpoints'
-// @ts-expect-error: 'jsx' is declared but its value is never read.
 import { jsx, Editor, Paragraph, Text, Cursor, Focus, Anchor } from '../../test-helpers'
 
 describe('GIVEN setActiveTypographyStyle', () => {

--- a/packages/runtime/src/slate/test-helpers/editor-v1.tsx
+++ b/packages/runtime/src/slate/test-helpers/editor-v1.tsx
@@ -3,7 +3,6 @@
 
 import { ComponentType } from 'react'
 import { Editor as SlateEditor } from 'slate'
-// @ts-expect-error: 'jsx' is declared but its value is never read.
 import { jsx } from './slate-test-helper'
 
 const EditorElement = 'editor' as any as ComponentType<{

--- a/packages/runtime/src/slate/test-helpers/editor-v2-inline.tsx
+++ b/packages/runtime/src/slate/test-helpers/editor-v2-inline.tsx
@@ -3,7 +3,6 @@
 
 import { ComponentType } from 'react'
 import { Editor as SlateEditor } from 'slate'
-// @ts-expect-error: 'jsxWithV2InlineEditor' is declared but its value is never read.Editor,
 import { jsxWithV2InlineEditor } from './slate-test-helper'
 
 const EditorElement = 'editor' as any as ComponentType<{

--- a/packages/runtime/src/slate/test-helpers/editor-v2.tsx
+++ b/packages/runtime/src/slate/test-helpers/editor-v2.tsx
@@ -3,7 +3,6 @@
 
 import { ComponentType } from 'react'
 import { Editor as SlateEditor } from 'slate'
-// @ts-expect-error: 'jsxWithV2InlineEditor' is declared but its value is never read.
 import { jsxWithV2Editor } from './slate-test-helper'
 
 const EditorElement = 'editor' as any as ComponentType<{

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -455,7 +455,7 @@ importers:
         version: 3.1.1(graphql@16.3.0)
       '@graphql-codegen/cli':
         specifier: 2.6.2
-        version: 2.6.2(@types/node@20.14.11)(graphql@16.3.0)(typescript@5.1.6)
+        version: 2.6.2(@types/node@20.14.11)(graphql@16.3.0)(typescript@5.9.2)
       '@graphql-codegen/typescript-document-nodes':
         specifier: ^2.3.12
         version: 2.3.12(graphql@16.3.0)
@@ -470,7 +470,7 @@ importers:
         version: 0.2.36(@swc/core@1.4.15(@swc/helpers@0.5.15))
       '@testing-library/jest-dom':
         specifier: ^6.4.2
-        version: 6.4.2(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.1.6)))
+        version: 6.4.2(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.9.2)))
       '@testing-library/react':
         specifier: ^15.0.2
         version: 15.0.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -512,7 +512,7 @@ importers:
         version: 0.19.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.1.6))
+        version: 29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.9.2))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -524,7 +524,7 @@ importers:
         version: 6.0.0
       msw:
         specifier: ^2.3.1
-        version: 2.3.1(typescript@5.1.6)
+        version: 2.3.1(typescript@5.9.2)
       next:
         specifier: 15.0.2
         version: 15.0.2(@babel/core@7.24.9)(@playwright/test@1.41.1)(babel-plugin-macros@3.1.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -539,10 +539,10 @@ importers:
         version: 18.2.0(react@18.2.0)
       tsup:
         specifier: ^8.0.1
-        version: 8.0.1(@swc/core@1.4.15(@swc/helpers@0.5.15))(postcss@8.4.33)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.1.6))(typescript@5.1.6)
+        version: 8.0.1(@swc/core@1.4.15(@swc/helpers@0.5.15))(postcss@8.4.33)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.9.2))(typescript@5.9.2)
       typescript:
-        specifier: ^5.1.6
-        version: 5.1.6
+        specifier: ^5.9.2
+        version: 5.9.2
       undici:
         specifier: ^6.19.2
         version: 6.19.2
@@ -7687,6 +7687,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@5.9.2:
+    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   ua-parser-js@0.7.31:
     resolution: {integrity: sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==}
 
@@ -9049,12 +9054,12 @@ snapshots:
 
   '@emotion/weak-memoize@0.4.0': {}
 
-  '@endemolshinegroup/cosmiconfig-typescript-loader@3.0.2(cosmiconfig@7.0.1)(typescript@5.1.6)':
+  '@endemolshinegroup/cosmiconfig-typescript-loader@3.0.2(cosmiconfig@7.0.1)(typescript@5.9.2)':
     dependencies:
       cosmiconfig: 7.0.1
       lodash.get: 4.4.2
       make-error: 1.3.6
-      ts-node: 9.1.1(typescript@5.1.6)
+      ts-node: 9.1.1(typescript@5.9.2)
       tslib: 2.6.2
     transitivePeerDependencies:
       - typescript
@@ -9200,7 +9205,7 @@ snapshots:
       graphql: 16.3.0
       tslib: 2.3.1
 
-  '@graphql-codegen/cli@2.6.2(@types/node@20.14.11)(graphql@16.3.0)(typescript@5.1.6)':
+  '@graphql-codegen/cli@2.6.2(@types/node@20.14.11)(graphql@16.3.0)(typescript@5.9.2)':
     dependencies:
       '@graphql-codegen/core': 2.5.1(graphql@16.3.0)
       '@graphql-codegen/plugin-helpers': 2.4.2(graphql@16.3.0)
@@ -9226,7 +9231,7 @@ snapshots:
       glob: 7.2.3
       globby: 11.1.0
       graphql: 16.3.0
-      graphql-config: 4.1.0(@types/node@20.14.11)(graphql@16.3.0)(typescript@5.1.6)
+      graphql-config: 4.1.0(@types/node@20.14.11)(graphql@16.3.0)(typescript@5.9.2)
       inquirer: 8.2.1
       is-glob: 4.0.3
       json-to-pretty-yaml: 1.2.2
@@ -9870,7 +9875,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.1.6))':
+  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.9.2))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -9884,7 +9889,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.1.6))
+      jest-config: 29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.9.2))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -10629,7 +10634,7 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
-  '@testing-library/jest-dom@6.4.2(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.1.6)))':
+  '@testing-library/jest-dom@6.4.2(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.9.2)))':
     dependencies:
       '@adobe/css-tools': 4.3.3
       '@babel/runtime': 7.23.9
@@ -10642,7 +10647,7 @@ snapshots:
     optionalDependencies:
       '@jest/globals': 29.7.0
       '@types/jest': 29.5.12
-      jest: 29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.1.6))
+      jest: 29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.9.2))
 
   '@testing-library/react@15.0.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
@@ -11877,13 +11882,13 @@ snapshots:
       path-type: 4.0.0
       yaml: 1.10.2
 
-  create-jest@29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.1.6)):
+  create-jest@29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.9.2)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.1.6))
+      jest-config: 29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.9.2))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -12555,7 +12560,7 @@ snapshots:
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
@@ -12597,8 +12602,8 @@ snapshots:
       debug: 4.3.5
       enhanced-resolve: 5.14.1
       eslint: 8.56.0
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.15.1
@@ -12626,7 +12631,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -12648,7 +12653,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -12659,7 +12664,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
@@ -12669,7 +12674,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -13353,9 +13358,9 @@ snapshots:
 
   graphemer@1.4.0: {}
 
-  graphql-config@4.1.0(@types/node@20.14.11)(graphql@16.3.0)(typescript@5.1.6):
+  graphql-config@4.1.0(@types/node@20.14.11)(graphql@16.3.0)(typescript@5.9.2):
     dependencies:
-      '@endemolshinegroup/cosmiconfig-typescript-loader': 3.0.2(cosmiconfig@7.0.1)(typescript@5.1.6)
+      '@endemolshinegroup/cosmiconfig-typescript-loader': 3.0.2(cosmiconfig@7.0.1)(typescript@5.9.2)
       '@graphql-tools/graphql-file-loader': 7.3.5(graphql@16.3.0)
       '@graphql-tools/json-file-loader': 7.3.5(graphql@16.3.0)
       '@graphql-tools/load': 7.5.3(graphql@16.3.0)
@@ -14005,16 +14010,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.1.6)):
+  jest-cli@29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.9.2)):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.1.6))
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.9.2))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.1.6))
+      create-jest: 29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.9.2))
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.1.6))
+      jest-config: 29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.9.2))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -14073,7 +14078,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-config@29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.1.6)):
+  jest-config@29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.9.2)):
     dependencies:
       '@babel/core': 7.24.9
       '@jest/test-sequencer': 29.7.0
@@ -14099,7 +14104,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.14.11
-      ts-node: 10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.1.6)
+      ts-node: 10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.9.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -14568,12 +14573,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.1.6)):
+  jest@29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.9.2)):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.1.6))
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.9.2))
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.1.6))
+      jest-cli: 29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.9.2))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -15091,7 +15096,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.3.1(typescript@5.1.6):
+  msw@2.3.1(typescript@5.9.2):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.0
       '@bundled-es-modules/statuses': 1.0.1
@@ -15111,7 +15116,7 @@ snapshots:
       type-fest: 4.20.1
       yargs: 17.7.2
     optionalDependencies:
-      typescript: 5.1.6
+      typescript: 5.9.2
 
   multipipe@1.0.2:
     dependencies:
@@ -15577,13 +15582,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.4.33
 
-  postcss-load-config@4.0.2(postcss@8.4.33)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.1.6)):
+  postcss-load-config@4.0.2(postcss@8.4.33)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.9.2)):
     dependencies:
       lilconfig: 3.0.0
       yaml: 2.3.4
     optionalDependencies:
       postcss: 8.4.33
-      ts-node: 10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.1.6)
+      ts-node: 10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.9.2)
 
   postcss-load-config@4.0.2(postcss@8.4.33)(ts-node@10.9.2(@swc/core@1.7.0(@swc/helpers@0.5.15))(@types/node@20.11.11)(typescript@5.1.6)):
     dependencies:
@@ -16787,7 +16792,7 @@ snapshots:
 
   ts-log@2.2.4: {}
 
-  ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.1.6):
+  ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.9.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -16801,7 +16806,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.1.6
+      typescript: 5.9.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
@@ -16850,14 +16855,14 @@ snapshots:
       '@swc/core': 1.7.0(@swc/helpers@0.5.15)
     optional: true
 
-  ts-node@9.1.1(typescript@5.1.6):
+  ts-node@9.1.1(typescript@5.9.2):
     dependencies:
       arg: 4.1.3
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
       source-map-support: 0.5.21
-      typescript: 5.1.6
+      typescript: 5.9.2
       yn: 3.1.1
 
   ts-pattern@5.0.5: {}
@@ -16888,7 +16893,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.0.1(@swc/core@1.4.15(@swc/helpers@0.5.15))(postcss@8.4.33)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.1.6))(typescript@5.1.6):
+  tsup@8.0.1(@swc/core@1.4.15(@swc/helpers@0.5.15))(postcss@8.4.33)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.9.2))(typescript@5.9.2):
     dependencies:
       bundle-require: 4.0.2(esbuild@0.19.12)
       cac: 6.7.14
@@ -16898,7 +16903,7 @@ snapshots:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.2(postcss@8.4.33)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.1.6))
+      postcss-load-config: 4.0.2(postcss@8.4.33)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.9.2))
       resolve-from: 5.0.0
       rollup: 4.9.6
       source-map: 0.8.0-beta.0
@@ -16907,7 +16912,7 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.4.15(@swc/helpers@0.5.15)
       postcss: 8.4.33
-      typescript: 5.1.6
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
       - ts-node
@@ -17074,6 +17079,8 @@ snapshots:
   typescript@4.9.5: {}
 
   typescript@5.1.6: {}
+
+  typescript@5.9.2: {}
 
   ua-parser-js@0.7.31: {}
 


### PR DESCRIPTION
Upgrading to get the improved type inlining / [declaration tracking for dependencies](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-5.html). No usage of any newer TS features is being introduced, so this should be a no-op from the user’s standpoint.

Prep for https://github.com/makeswift/makeswift/pull/1090.