### PR TITLE
feat: framework-independent host API client

### DIFF
--- a/.changeset/curvy-teachers-rhyme.md
+++ b/.changeset/curvy-teachers-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+feat: framework-independent host API client

--- a/packages/runtime/src/api/react.ts
+++ b/packages/runtime/src/api/react.ts
@@ -19,7 +19,6 @@ import {
   CreateTableRecordMutationResult,
   CreateTableRecordMutationVariables,
 } from './graphql/generated/types'
-import { MakeswiftSiteVersion } from './site-version'
 
 export type CacheData = MakeswiftApiClient.SerializedState
 
@@ -52,19 +51,19 @@ export const CacheData = {
  * snapshot for use in the builder, not the lives pages.
  */
 export class MakeswiftHostApiClient {
-  siteVersion: MakeswiftSiteVersion
   graphqlClient: GraphQLClient
   makeswiftApiClient: MakeswiftApiClient.Store
   subscribe: MakeswiftApiClient.Store['subscribe']
+  fetch: MakeswiftApiClient.HttpFetch
 
   constructor({
     uri,
-    siteVersion,
+    fetch,
     cacheData,
     locale,
   }: {
     uri: string
-    siteVersion: MakeswiftSiteVersion
+    fetch: MakeswiftApiClient.HttpFetch
     cacheData?: CacheData
     locale?: string
   }) {
@@ -73,7 +72,7 @@ export class MakeswiftHostApiClient {
       serializedState: cacheData,
       defaultLocale: locale,
     })
-    this.siteVersion = siteVersion
+    this.fetch = fetch
     this.subscribe = this.makeswiftApiClient.subscribe
   }
 
@@ -87,7 +86,7 @@ export class MakeswiftHostApiClient {
 
   async fetchSwatch(swatchId: string): Promise<Swatch | null> {
     return await this.makeswiftApiClient.dispatch(
-      MakeswiftApiClient.fetchAPIResource(APIResourceType.Swatch, swatchId, this.siteVersion),
+      MakeswiftApiClient.fetchAPIResource(APIResourceType.Swatch, swatchId, this.fetch),
     )
   }
 
@@ -109,7 +108,7 @@ export class MakeswiftHostApiClient {
 
   async fetchFile(fileId: string): Promise<File | null> {
     return await this.makeswiftApiClient.dispatch(
-      MakeswiftApiClient.fetchAPIResource(APIResourceType.File, fileId, this.siteVersion),
+      MakeswiftApiClient.fetchAPIResource(APIResourceType.File, fileId, this.fetch),
     )
   }
 
@@ -131,11 +130,7 @@ export class MakeswiftHostApiClient {
 
   async fetchTypography(typographyId: string): Promise<Typography | null> {
     return await this.makeswiftApiClient.dispatch(
-      MakeswiftApiClient.fetchAPIResource(
-        APIResourceType.Typography,
-        typographyId,
-        this.siteVersion,
-      ),
+      MakeswiftApiClient.fetchAPIResource(APIResourceType.Typography, typographyId, this.fetch),
     )
   }
 
@@ -160,7 +155,7 @@ export class MakeswiftHostApiClient {
       MakeswiftApiClient.fetchAPIResource(
         APIResourceType.GlobalElement,
         globalElementId,
-        this.siteVersion,
+        this.fetch,
       ),
     )
   }
@@ -191,7 +186,7 @@ export class MakeswiftHostApiClient {
       MakeswiftApiClient.fetchAPIResource(
         APIResourceType.LocalizedGlobalElement,
         globalElementId,
-        this.siteVersion,
+        this.fetch,
         locale,
       ),
     )
@@ -223,7 +218,7 @@ export class MakeswiftHostApiClient {
       MakeswiftApiClient.fetchAPIResource(
         APIResourceType.PagePathnameSlice,
         pageId,
-        this.siteVersion,
+        this.fetch,
         locale,
       ),
     )
@@ -278,7 +273,7 @@ export class MakeswiftHostApiClient {
 
   async fetchTable(tableId: string): Promise<Table | null> {
     return await this.makeswiftApiClient.dispatch(
-      MakeswiftApiClient.fetchAPIResource(APIResourceType.Table, tableId, this.siteVersion),
+      MakeswiftApiClient.fetchAPIResource(APIResourceType.Table, tableId, this.fetch),
     )
   }
 

--- a/packages/runtime/src/next/components/framework-provider/index.tsx
+++ b/packages/runtime/src/next/components/framework-provider/index.tsx
@@ -4,7 +4,13 @@ import { type PropsWithChildren, useMemo } from 'react'
 import NextImage from 'next/image'
 
 import { useIsPagesRouter } from '../../hooks/use-is-pages-router'
-import { FrameworkContext } from '../../../runtimes/react/components/framework-context'
+import {
+  FrameworkContext,
+  versionedFetch,
+} from '../../../runtimes/react/components/framework-context'
+
+import { MakeswiftSiteVersion } from '../../../api/site-version'
+import { MAKESWIFT_CACHE_TAG } from '../../cache'
 
 import { context as appRouterContext } from './app-router'
 import { context as pagesRouterContext } from './pages-router'
@@ -15,11 +21,13 @@ export function FrameworkProvider({
   forcePagesRouter,
 }: PropsWithChildren<{ forcePagesRouter?: boolean }>) {
   const isPagesRouter = useIsPagesRouter() || forcePagesRouter
-  const context = useMemo(
+  const context = useMemo<FrameworkContext>(
     () => ({
       ...(isPagesRouter ? pagesRouterContext : appRouterContext),
       Image: NextImage,
       Link,
+      versionedFetch: (siteVersion: MakeswiftSiteVersion) => (url, init) =>
+        versionedFetch(siteVersion)(url, { ...init, next: { tags: [MAKESWIFT_CACHE_TAG] } }),
     }),
     [isPagesRouter],
   )

--- a/packages/runtime/src/runtimes/react/components/RuntimeProvider.tsx
+++ b/packages/runtime/src/runtimes/react/components/RuntimeProvider.tsx
@@ -9,6 +9,7 @@ import { MakeswiftHostApiClientProvider } from '../host-api-client'
 import { MakeswiftSiteVersion } from '../../../api/site-version'
 import { DraftSwitcher } from './draft-switcher/draft-switcher'
 import { useBuilderConnectionPing } from './hooks/use-builder-connection-ping'
+import { useFrameworkContext } from './hooks/use-framework-context'
 
 const LiveProvider = lazy(() => import('./LiveProvider'))
 const PreviewProvider = lazy(() => import('./PreviewProvider'))
@@ -28,14 +29,18 @@ export function RuntimeProvider({
   appOrigin?: string
   locale?: string
 }) {
+  const { versionedFetch } = useFrameworkContext()
+
   const client = useMemo(
     () =>
       new MakeswiftHostApiClient({
         uri: new URL('graphql', apiOrigin).href,
         locale,
-        siteVersion: previewMode ? MakeswiftSiteVersion.Working : MakeswiftSiteVersion.Live,
+        fetch: versionedFetch(
+          previewMode ? MakeswiftSiteVersion.Working : MakeswiftSiteVersion.Live,
+        ),
       }),
-    [apiOrigin, locale, previewMode],
+    [apiOrigin, locale, previewMode, versionedFetch],
   )
 
   const StoreProvider = previewMode ? PreviewProvider : LiveProvider

--- a/packages/runtime/src/runtimes/react/components/framework-context.tsx
+++ b/packages/runtime/src/runtimes/react/components/framework-context.tsx
@@ -13,6 +13,8 @@ import {
 import { type LinkData } from '@makeswift/prop-controllers'
 
 import { type Snippet } from '../../../client'
+import { type HttpFetch } from '../../../state/makeswift-api-client'
+import { API_HANDLER_SITE_VERSION_HEADER, MakeswiftSiteVersion } from '../../../api/site-version'
 
 import { BaseHeadSnippet } from './page/HeadSnippet'
 
@@ -41,6 +43,7 @@ export type FrameworkContext = {
   HeadSnippet: HeadSnippet
   Image: ImageComponent
   Link: LinkComponent
+  versionedFetch: (siteVersion: MakeswiftSiteVersion) => HttpFetch
 }
 
 // React 19 automatically hoists metadata tags to the <head>
@@ -67,9 +70,19 @@ export const DefaultLink: LinkComponent = forwardRef<HTMLAnchorElement, LinkProp
   ({ linkType, ...props }, ref) => <a {...props} ref={ref} />,
 )
 
+export const versionedFetch: FrameworkContext['versionedFetch'] = siteVersion => (url, init) =>
+  fetch(url, {
+    ...init,
+    headers: {
+      ...init?.headers,
+      [API_HANDLER_SITE_VERSION_HEADER]: siteVersion,
+    },
+  })
+
 export const FrameworkContext = createContext<FrameworkContext>({
   Head: DefaultHead,
   HeadSnippet: BaseHeadSnippet,
   Image: DefaultImage,
   Link: DefaultLink,
+  versionedFetch,
 })

--- a/packages/runtime/src/runtimes/react/host-api-client.tsx
+++ b/packages/runtime/src/runtimes/react/host-api-client.tsx
@@ -2,12 +2,17 @@
 
 import { ReactNode, createContext, useContext } from 'react'
 import { MakeswiftHostApiClient } from '../../api/react'
-import { MakeswiftSiteVersion } from '../../api/site-version'
 
 const Context = createContext(
   new MakeswiftHostApiClient({
     uri: 'https://api.makeswift.com/graphql',
-    siteVersion: MakeswiftSiteVersion.Live,
+    fetch: async (url, init) => {
+      console.warn(
+        'Using fallback `fetch` implementation, resource revalidation may not work as expected.',
+        { url },
+      )
+      return fetch(url, init)
+    },
   }),
 )
 


### PR DESCRIPTION
Decouple host API client's resource fetching from Next.js-specific request tagging.