### PR TITLE
chore: export preview-related symbols for internal consumption

### DIFF
--- a/packages/runtime/src/api-handler/handlers/redirect-live.ts
+++ b/packages/runtime/src/api-handler/handlers/redirect-live.ts
@@ -2,7 +2,7 @@ import { serialize as serializeCookie } from 'cookie'
 import { type ApiRequest, ApiResponse, searchParams } from '../request-response'
 import { SET_COOKIE_HEADER, cookieSettingOptions } from '../cookies'
 
-const REDIRECT_SEARCH_PARAM = 'makeswift-redirect-live'
+export const REDIRECT_SEARCH_PARAM = 'makeswift-redirect-live'
 
 export async function redirectLiveHandler(
   req: ApiRequest,

--- a/packages/runtime/src/api-handler/preview.ts
+++ b/packages/runtime/src/api-handler/preview.ts
@@ -1,0 +1,5 @@
+export const MAKESWIFT_SITE_VERSION_COOKIE = 'makeswift-site-version'
+
+export const SearchParams = {
+  PreviewToken: 'makeswift-preview-token',
+} as const

--- a/packages/runtime/src/next/api-handler/preview.ts
+++ b/packages/runtime/src/next/api-handler/preview.ts
@@ -1,11 +1,7 @@
+export { MAKESWIFT_SITE_VERSION_COOKIE, SearchParams } from '../../api-handler/preview'
+
 export const PRERENDER_BYPASS_COOKIE = '__prerender_bypass'
 export const PREVIEW_DATA_COOKIE = '__next_preview_data'
-
-export const MAKESWIFT_SITE_VERSION_COOKIE = 'makeswift-site-version'
-
-export const SearchParams = {
-  PreviewToken: 'makeswift-preview-token',
-} as const
 
 // When there's a rewrite rule match, the matching values are included as query
 // parameters in the request URL, where the parameter name is the expression


### PR DESCRIPTION
See inline comments.