### PR TITLE
chore: update exit preview query param name

### DIFF
--- a/.changeset/dirty-shoes-juggle.md
+++ b/.changeset/dirty-shoes-juggle.md
@@ -1,0 +1,6 @@
+---
+"@makeswift/next-plugin": patch
+"@makeswift/runtime": patch
+---
+
+Rename query param for clearing preview cookies

--- a/packages/makeswift-next-plugin/index.js
+++ b/packages/makeswift-next-plugin/index.js
@@ -66,7 +66,7 @@ module.exports =
               has: [
                 {
                   type: 'query',
-                  key: 'x-makeswift-redirect-live',
+                  key: 'makeswift-redirect-live',
                   value: '(?<destination>.+)',
                 },
               ],

--- a/packages/runtime/src/api-handler/handlers/redirect-live.ts
+++ b/packages/runtime/src/api-handler/handlers/redirect-live.ts
@@ -2,7 +2,7 @@ import { serialize as serializeCookie } from 'cookie'
 import { type ApiRequest, ApiResponse, searchParams } from '../request-response'
 import { SET_COOKIE_HEADER, cookieSettingOptions } from '../cookies'
 
-const REDIRECT_SEARCH_PARAM = 'x-makeswift-redirect-live'
+const REDIRECT_SEARCH_PARAM = 'makeswift-redirect-live'
 
 export async function redirectLiveHandler(
   req: ApiRequest,

--- a/packages/runtime/src/next/tests/server.api-handler-redirect-live.test.ts
+++ b/packages/runtime/src/next/tests/server.api-handler-redirect-live.test.ts
@@ -32,7 +32,7 @@ describe('MakeswiftApiHandler', () => {
       const { statusCode, headers } = await testApiRequest({
         method: 'GET',
         path: PATH,
-        originalPath: `${ORIGINAL_PATH}?x-makeswift-redirect-live=/next-path`,
+        originalPath: `${ORIGINAL_PATH}?makeswift-redirect-live=/next-path`,
       })
 
       // Assert
@@ -52,7 +52,7 @@ describe('MakeswiftApiHandler', () => {
       const redirectLocation = headers.get('Location')
 
       expect(redirectLocation).toBe('/next-path')
-      expect(redirectLocation?.includes('x-makeswift-redirect-live')).toBe(false)
+      expect(redirectLocation?.includes('makeswift-redirect-live')).toBe(false)
     })
   })
 })

--- a/packages/runtime/src/runtimes/react/components/preview-switcher/preview-toolbar.tsx
+++ b/packages/runtime/src/runtimes/react/components/preview-switcher/preview-toolbar.tsx
@@ -49,7 +49,7 @@ export function PreviewToolbar() {
   const redirectLiveUrl = useMemo(() => {
     const currentUrl = new URL(window.location.href)
     const destination = `${currentUrl.pathname}${currentUrl.search}${currentUrl.hash}`
-    currentUrl.searchParams.set('x-makeswift-redirect-live', encodeURIComponent(destination))
+    currentUrl.searchParams.set('makeswift-redirect-live', encodeURIComponent(destination))
     return currentUrl.toString()
   }, [])
 


### PR DESCRIPTION
Updates the query param to exit preview mode to omit the "x-" prefix convention.