### PR TITLE
chore: make API handlers' manifest override optional

### DIFF
--- a/packages/runtime/src/api-handler/handlers/manifest.ts
+++ b/packages/runtime/src/api-handler/handlers/manifest.ts
@@ -20,7 +20,7 @@ export type Manifest = {
 
 export async function manifestHandler(
   req: ApiRequest,
-  { apiKey, manifest }: { apiKey: string; manifest: Partial<Manifest> },
+  { apiKey, manifest }: { apiKey: string; manifest?: Partial<Manifest> },
 ): Promise<ApiResponse<Manifest | ErrorResponseBody>> {
   const secret = searchParams(req).get('secret')
 
@@ -40,6 +40,6 @@ export async function manifestHandler(
     webhook: true,
     localizedPagesOnlineByDefault: true,
     previewToken: true,
-    ...manifest,
+    ...(manifest ?? {}),
   })
 }

--- a/packages/runtime/src/api-handler/index.ts
+++ b/packages/runtime/src/api-handler/index.ts
@@ -39,7 +39,7 @@ export type ApiHandlerUserConfig = {
 
 export type ApiHandlerInternalConfig = {
   client: MakeswiftClient
-  manifest: Partial<Manifest>
+  manifest?: Partial<Manifest>
   revalidationHandler: (path?: string) => Promise<void>
   previewCookieNames: string[]
 }

--- a/packages/runtime/src/next/api-handler/config/app-router.ts
+++ b/packages/runtime/src/next/api-handler/config/app-router.ts
@@ -28,7 +28,6 @@ export async function config({
   return {
     req,
     route: validateApiRoute(await context.params),
-    manifest: {},
     previewCookieNames: [PRERENDER_BYPASS_COOKIE, MAKESWIFT_SITE_VERSION_COOKIE],
     sendResponse: async (res: ApiResponse): Promise<Response | void> => res,
     revalidationHandler: async (path?: string): Promise<void> => {

--- a/packages/runtime/src/next/api-handler/config/pages-router.ts
+++ b/packages/runtime/src/next/api-handler/config/pages-router.ts
@@ -31,7 +31,6 @@ export async function config({
       },
     },
     route: validateApiRoute(await apiRequestParams(req)),
-    manifest: {},
     previewCookieNames: [PRERENDER_BYPASS_COOKIE, PREVIEW_DATA_COOKIE],
     sendResponse: async (apiResponse: ApiResponse): Promise<Response | void> => {
       const headers = responseHeaders(apiResponse.headers)


### PR DESCRIPTION
Our manifest defaults don't require any overrides in most cases.