### PR TITLE
refactor: generalize Node <-> Fetch API request/response conversion

### DIFF
--- a/packages/runtime/src/api-handler/node-request-response.test.ts
+++ b/packages/runtime/src/api-handler/node-request-response.test.ts
@@ -1,0 +1,156 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+
+import { requestHeaders, pipeResponseTo } from './node-request-response'
+import { ApiResponse } from './request-response'
+
+describe('requestHeaders', () => {
+  test('converts IncomingMessage headers to Fetch API Request headers', () => {
+    // Arrange
+    const incomingHeaders: IncomingMessage['headers'] = {
+      'accept-language': 'en-US',
+      'set-cookie': [
+        'cookie1=oreo; Domain=makeswift.com; Secure; HttpOnly',
+        'cookie2=chocolate-chip; Domain=makeswift.com; Partitioned; Secure; HttpOnly',
+      ],
+      'cache-control': undefined,
+    }
+
+    // Act
+    const headers = requestHeaders(incomingHeaders)
+
+    // Assert
+    expect(headers.get('accept-language')).toBe('en-US')
+    expect(headers.get('set-cookie')).toEqual(
+      [
+        'cookie1=oreo; Domain=makeswift.com; Secure; HttpOnly',
+        'cookie2=chocolate-chip; Domain=makeswift.com; Partitioned; Secure; HttpOnly',
+      ].join(', '),
+    )
+    expect(headers.has('cache-control')).toBe(false)
+  })
+})
+
+describe('pipeResponseTo', () => {
+  const createStream = (chunks: Uint8Array[]) =>
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const c of chunks) controller.enqueue(c)
+        controller.close()
+      },
+    })
+
+  const createFailingStream = () =>
+    new ReadableStream({
+      start(controller) {
+        controller.error(new Error('boom'))
+      },
+    })
+
+  const textChunk = (s: string) => new TextEncoder().encode(s)
+
+  const serverResponseMock = ({
+    headersSent = false,
+  }): Pick<
+    ServerResponse,
+    'statusCode' | 'headersSent' | 'setHeader' | 'write' | 'end' | 'destroy'
+  > => ({
+    statusCode: 500,
+    headersSent,
+    setHeader: jest.fn(),
+    write: jest.fn().mockImplementation(() => {
+      headersSent = true
+    }),
+    end: jest.fn(),
+    destroy: jest.fn(),
+  })
+
+  test('sets headers, statusCode, writes body and ends the response', async () => {
+    // Arrange
+    const headers = new Headers([
+      ['accept-language', 'en-US'],
+      ['set-cookie', 'cookie1=oreo; Domain=makeswift.com; Secure; HttpOnly'],
+      ['set-cookie', 'cookie2=chocolate-chip; Domain=makeswift.com; Partitioned; Secure; HttpOnly'],
+    ])
+
+    const apiResponse = new Response(createStream([textChunk('hello '), textChunk('world')]), {
+      headers,
+      status: 201,
+    })
+
+    const res = serverResponseMock({})
+
+    // Act
+    await pipeResponseTo(apiResponse, res as ServerResponse)
+
+    // Assert
+    expect(res.statusCode).toBe(201)
+    expect(res.setHeader).toHaveBeenCalledWith('accept-language', 'en-US')
+    expect(res.setHeader).toHaveBeenCalledWith('set-cookie', [
+      'cookie1=oreo; Domain=makeswift.com; Secure; HttpOnly',
+      'cookie2=chocolate-chip; Domain=makeswift.com; Partitioned; Secure; HttpOnly',
+    ])
+
+    expect(res.write).toHaveBeenCalledTimes(2)
+    expect(res.write).toHaveBeenNthCalledWith(1, textChunk('hello '))
+    expect(res.write).toHaveBeenNthCalledWith(2, textChunk('world'))
+    expect(res.end).toHaveBeenCalledTimes(1)
+  })
+
+  test('correctly streams API redirect response', async () => {
+    // Arrange
+    const headers = new Headers([
+      ['set-cookie', 'cookie1=oreo; Domain=makeswift.com; Secure; HttpOnly'],
+      ['set-cookie', 'cookie2=chocolate-chip; Domain=makeswift.com; Partitioned; Secure; HttpOnly'],
+    ])
+
+    const res = serverResponseMock({})
+
+    // Act
+    await pipeResponseTo(
+      ApiResponse.redirect('/api/makeswift/exit-preview', { headers }),
+      res as ServerResponse,
+    )
+
+    expect(res.statusCode).toBe(307)
+    expect(res.setHeader).toHaveBeenCalledWith('location', '/api/makeswift/exit-preview')
+    expect(res.setHeader).toHaveBeenCalledWith('set-cookie', [
+      'cookie1=oreo; Domain=makeswift.com; Secure; HttpOnly',
+      'cookie2=chocolate-chip; Domain=makeswift.com; Partitioned; Secure; HttpOnly',
+    ])
+    expect(res.end).toHaveBeenCalledTimes(1)
+  })
+
+  test("responds with 500 on stream error if headers haven't been sent", async () => {
+    // Arrange
+    const apiResponse = new Response(createFailingStream(), {
+      headers: new Headers(),
+      status: 200,
+    })
+
+    const res = serverResponseMock({})
+
+    // Act
+    await pipeResponseTo(apiResponse, res as ServerResponse)
+
+    // Assert
+    expect(res.statusCode).toBe(500)
+    expect(res.end).toHaveBeenCalled()
+  })
+
+  test('aborts the response on stream error after headers have been sent', async () => {
+    // Arrange
+    const apiResponse = new Response(createFailingStream(), {
+      headers: new Headers(),
+      status: 200,
+    })
+
+    const res = serverResponseMock({ headersSent: true })
+
+    // Act
+    await pipeResponseTo(apiResponse, res as ServerResponse)
+
+    // Assert
+    expect(res.destroy).toHaveBeenCalledWith(expect.objectContaining({ message: 'boom' }))
+    expect(res.end).not.toHaveBeenCalled()
+  })
+})

--- a/packages/runtime/src/api-handler/node-request-response.ts
+++ b/packages/runtime/src/api-handler/node-request-response.ts
@@ -1,0 +1,77 @@
+import { type IncomingMessage, type ServerResponse } from 'node:http'
+import { type ApiRequest, type ApiResponse } from '../api-handler/request-response'
+
+export function requestHeaders(headers: IncomingMessage['headers']): Headers {
+  const result = new Headers()
+  for (const [key, value] of Object.entries(headers)) {
+    if (value != null) {
+      if (Array.isArray(value)) {
+        value.forEach(v => result.append(key, v))
+      } else {
+        result.append(key, value)
+      }
+    }
+  }
+
+  return result
+}
+
+export function toApiRequest(req: IncomingMessage & { body: any }): ApiRequest {
+  return {
+    headers: requestHeaders(req.headers),
+    method: req.method ?? 'GET',
+    url: req.url ?? '',
+    json() {
+      return req.body
+    },
+  }
+}
+
+export async function pipeResponseTo(apiResponse: ApiResponse, res: ServerResponse): Promise<void> {
+  const headers = responseHeaders(apiResponse.headers)
+  Object.entries(headers).forEach(([key, value]) => {
+    res.setHeader(key, value)
+  })
+
+  res.statusCode = apiResponse.status
+
+  try {
+    if (apiResponse.body) {
+      await pipeTo(apiResponse.body, res)
+    }
+
+    res.end()
+  } catch (error) {
+    if (!res.headersSent) {
+      res.statusCode = 500
+      res.end()
+    } else {
+      res.destroy(error instanceof Error ? error : new Error(`${error}`))
+    }
+  }
+}
+
+function responseHeaders(headers: Headers): Record<string, string | string[]> {
+  return [...headers.entries()].reduce<Record<string, string | string[]>>((acc, [key, value]) => {
+    if (key in acc) {
+      const existingValue = acc[key]
+      if (Array.isArray(existingValue)) {
+        existingValue.push(value)
+      } else {
+        acc[key] = [existingValue, value]
+      }
+    } else {
+      acc[key] = value
+    }
+    return acc
+  }, {})
+}
+
+async function pipeTo(stream: ReadableStream<Uint8Array>, res: ServerResponse): Promise<void> {
+  const reader = stream.getReader()
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    res.write(value)
+  }
+}

--- a/packages/runtime/src/next/api-handler/config/pages-router.ts
+++ b/packages/runtime/src/next/api-handler/config/pages-router.ts
@@ -2,6 +2,7 @@ import { P } from 'ts-pattern'
 import { NextApiRequest, NextApiResponse } from 'next'
 
 import { type ApiResponse } from '../../../api-handler/request-response'
+import { toApiRequest, pipeResponseTo } from '../../../api-handler/node-request-response'
 
 import { pagesRouterRedirectPreviewHandler } from '../handlers/pages-router-redirect-preview'
 import { PRERENDER_BYPASS_COOKIE, PREVIEW_DATA_COOKIE } from '../preview'
@@ -22,30 +23,13 @@ export async function config({
   client: MakeswiftClient
 }): Promise<ApiHandlerConfig> {
   return {
-    req: {
-      headers: requestHeaders(req.headers),
-      method: req.method ?? 'GET',
-      url: req.url ?? '',
-      json() {
-        return req.body
-      },
-    },
+    req: toApiRequest(req),
     route: validateApiRoute(await apiRequestParams(req)),
     previewCookieNames: [PRERENDER_BYPASS_COOKIE, PREVIEW_DATA_COOKIE],
-    sendResponse: async (apiResponse: ApiResponse): Promise<Response | void> => {
-      const headers = responseHeaders(apiResponse.headers)
-      Object.entries(headers).forEach(([key, value]) => {
-        res.setHeader(key, value)
-      })
 
-      res.status(apiResponse.status)
+    sendResponse: (apiResponse: ApiResponse): Promise<Response | void> =>
+      pipeResponseTo(apiResponse, res),
 
-      if (apiResponse.body) {
-        await pipeTo(apiResponse.body, res)
-      }
-
-      res.end()
-    },
     revalidationHandler: async (path?: string): Promise<void> => {
       if (path != null) {
         res.revalidate(path)
@@ -53,6 +37,7 @@ export async function config({
         // No-op, Pages Router does not support tag-based revalidation
       }
     },
+
     customRoutes: async (route: string) => {
       if (route === '/redirect-preview') {
         return { res: await pagesRouterRedirectPreviewHandler(req, res, client) }
@@ -67,48 +52,4 @@ function apiRequestParams(request: NextApiRequest): Promise<NextApiRequest['quer
   // `NextApiRequest.query` prop became async in Next.js 15, but it's not reflected in the type definition;
   // force-casting it to a `Promise` manually
   return Promise.resolve(request.query)
-}
-
-function requestHeaders(headers: NextApiRequest['headers']): Headers {
-  const result = new Headers()
-  for (const [key, value] of Object.entries(headers)) {
-    if (value != null) {
-      if (Array.isArray(value)) {
-        value.forEach(v => result.append(key, v))
-      } else {
-        result.append(key, value)
-      }
-    }
-  }
-
-  return result
-}
-
-function responseHeaders(headers: Headers): Record<string, string | string[]> {
-  return [...headers.entries()].reduce<Record<string, string | string[]>>((acc, [key, value]) => {
-    if (key in acc) {
-      const existingValue = acc[key]
-      if (Array.isArray(existingValue)) {
-        existingValue.push(value)
-      } else {
-        acc[key] = [existingValue, value]
-      }
-    } else {
-      acc[key] = value
-    }
-    return acc
-  }, {})
-}
-
-async function pipeTo(stream: ReadableStream<Uint8Array>, res: NextApiResponse): Promise<void> {
-  try {
-    const reader = stream.getReader()
-    while (true) {
-      const { done, value } = await reader.read()
-      if (done) break
-      res.write(value)
-    }
-  } catch (error) {
-    res.destroy(error instanceof Error ? error : new Error(`${error}`))
-  }
 }


### PR DESCRIPTION
Generalize request/response conversion routines from the Pages Router to use in other Node-based contexts.