### PR TITLE
refactor: encapsulate Emotion style tag creation

### DIFF
--- a/packages/runtime/src/next/root-style-registry.tsx
+++ b/packages/runtime/src/next/root-style-registry.tsx
@@ -6,6 +6,7 @@ import { useServerInsertedHTML } from 'next/navigation'
 import {
   createRootStyleCache,
   RootStyleRegistry as ReactRootStyleRegistry,
+  StyleTagSSR,
   type RootStyleProps,
 } from '../runtimes/react/root-style-registry'
 
@@ -20,12 +21,7 @@ export function NextRootStyleRegistry({
     const { classNames, css } = cache.flush()
 
     return classNames.length > 0 ? (
-      <style
-        data-emotion={`${cache.key} ${classNames.join(' ')}`}
-        dangerouslySetInnerHTML={{
-          __html: css,
-        }}
-      />
+      <StyleTagSSR key={cache.key} classNames={classNames} css={css} />
     ) : null
   })
 

--- a/packages/runtime/src/runtimes/react/root-style-registry.tsx
+++ b/packages/runtime/src/runtimes/react/root-style-registry.tsx
@@ -51,6 +51,24 @@ export const createRootStyleCache = ({ key }: { key?: string } = {}): StyleCache
   }
 }
 
+type StyleTagProps = {
+  key: string
+  classNames: string[]
+  css: string
+}
+
+export const StyleTagSSR = ({ key, classNames, css }: StyleTagProps) => (
+  <style
+    data-emotion={`${key} ${classNames.join(' ')}`}
+    dangerouslySetInnerHTML={{
+      __html: css,
+    }}
+  />
+)
+
+export const styleTagHtml = ({ key, classNames, css }: StyleTagProps): string =>
+  `<style data-emotion="${key} ${classNames.join(' ')}">${css}</style>`
+
 export type RootStyleProps = {
   /**
    * The key used to prefix generated class names.


### PR DESCRIPTION
Code outside of the `runtimes/react` dir should not have knowledge / depend on the fact that we're using Emotion.