### PR TITLE
chore: change `express-react` version from `0.0.0-alpha` to `0.0.1`

### DIFF
--- a/packages/express-react/package.json
+++ b/packages/express-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@makeswift/express-react",
-  "version": "0.0.0-alpha",
+  "version": "0.0.1",
   "license": "MIT",
   "files": [
     "dist",


### PR DESCRIPTION
While `changeset` does support `alpha` releases, the workflow is complicated and they don't recommend creating prereleases from `main`: https://changesets-docs.vercel.app/en/prereleases