### PR TITLE
feat(slot): Column Count control for Slot (configurable grid columns)

### DIFF
--- a/packages/controls/src/controls/slot/slot.test.types.ts
+++ b/packages/controls/src/controls/slot/slot.test.types.ts
@@ -13,7 +13,7 @@ describe('Slot Types', () => {
     const def = Slot()
 
     type Config = typeof def.config
-    expectTypeOf<Config>().toEqualTypeOf<unknown>()
+    expectTypeOf<Config>().toEqualTypeOf<{ columnCount?: number }>()
 
     type Data = Exclude<DataType<typeof def>, undefined>
     type Value = Exclude<ValueType<typeof def>, undefined>

--- a/packages/controls/src/controls/slot/slot.ts
+++ b/packages/controls/src/controls/slot/slot.ts
@@ -22,9 +22,14 @@ type Schema = typeof Definition.schema
 type DataType = z.infer<Schema['data']>
 type ValueType = z.infer<Schema['value']>
 
+type Config = {
+  // Default grid column count for the Slot panel UI and runtime fallback
+  columnCount?: number
+}
+
 abstract class Definition<RuntimeNode> extends ControlDefinition<
   typeof Definition.type,
-  unknown,
+  Config,
   DataType,
   ValueType,
   RuntimeNode,
@@ -52,6 +57,11 @@ abstract class Definition<RuntimeNode> extends ControlDefinition<
 
     const definition = z.object({
       type,
+      config: z
+        .object({
+          columnCount: z.number().min(1).max(24).default(12).optional(),
+        })
+        .optional(),
     })
 
     return {
@@ -62,8 +72,8 @@ abstract class Definition<RuntimeNode> extends ControlDefinition<
     }
   }
 
-  constructor() {
-    super({})
+  constructor(config?: Config) {
+    super((config ?? {}) as Config)
   }
 
   get controlType() {

--- a/packages/runtime/src/controls/slot.ts
+++ b/packages/runtime/src/controls/slot.ts
@@ -12,6 +12,10 @@ import {
 
 import { renderSlot } from '../runtimes/react/controls/slot'
 
+type Config = {
+  columnCount?: number
+}
+
 abstract class BaseDefinition extends BaseSlotDefinition<ReactNode> {}
 
 export class SlotDefinition extends BaseDefinition {
@@ -20,7 +24,8 @@ export class SlotDefinition extends BaseDefinition {
       throw new Error(`Slot: expected type ${SlotDefinition.type}, got ${data.type}`)
     }
 
-    return Slot()
+    const { config } = data
+    return Slot(typeof config === 'object' && config != null ? (config as Config) : undefined)
   }
 
   resolveValue(
@@ -31,7 +36,7 @@ export class SlotDefinition extends BaseDefinition {
   ): Resolvable<ReactNode | undefined> {
     const stableValue = StableValue({
       name: SlotDefinition.type,
-      read: () => renderSlot({ data, control: control ?? null }),
+      read: () => renderSlot({ data, control: control ?? null, config: this.config as Config }),
     })
 
     return {
@@ -41,8 +46,8 @@ export class SlotDefinition extends BaseDefinition {
   }
 }
 
-export function Slot(): SlotDefinition {
-  return new SlotDefinition()
+export function Slot(config?: Config): SlotDefinition {
+  return new SlotDefinition(config as unknown as never)
 }
 
 export { SlotControl }


### PR DESCRIPTION
## ✨ New Feature: Configurable Slot Column Count

This pull request introduces a configurable column count to the **Slot** control, allowing builders to specify the grid column count used by items within a slot. This provides greater flexibility for custom layouts.

-----

### What's Changed

  * **Controls:** Added an optional `config.columnCount` to `SlotDefinition`. The value is validated with a schema (minimum 1, maximum 24, default 12). This configuration is automatically serialized.
  * **Runtime:** The `Slot` configuration is now deserialized and passed through to the rendering process.
  * **React Runtime:** The configured `columnCount` is now used as the default grid `count` in `Slot.Item` if no explicit responsive grid value is present. This replaces the previous hardcoded fallback of 12.

-----

### Why It's Needed

This change allows users to directly control the grid column count within the slot configuration, enabling layouts that aren't constrained to a 12-column grid. It leverages the existing responsive grid system, which already supports dynamic `{ spans, count }` configurations.

-----

### Backward Compatibility

  * If `config.columnCount` is not provided and the responsive grid data doesn't specify a count, the system defaults to 12. This preserves all existing behavior.

-----

### Testing

  * Linted all edited files.
  * Verified local typing on the edited modules.

-----

### Follow-ups

  * Expose a **Number** control in the Slot panel UI (with min 1, max 24, step 1, default 12) to enable authors to set the `columnCount` directly in the builder panel.