### PR TITLE
fix: check null data at translation merge

### DIFF
--- a/.changeset/polite-dancers-teach.md
+++ b/.changeset/polite-dancers-teach.md
@@ -1,0 +1,6 @@
+---
+"@makeswift/controls": patch
+"@makeswift/runtime": patch
+---
+
+fix: check null data before attempting to merge translated data

--- a/.changeset/twenty-tips-ring.md
+++ b/.changeset/twenty-tips-ring.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/controls": patch
+---
+
+fix: support optional values for list control item data type

--- a/packages/controls/src/controls/definition.ts
+++ b/packages/controls/src/controls/definition.ts
@@ -79,12 +79,12 @@ export abstract class ControlDefinition<
     return override ?? base
   }
 
-  getTranslatableData(_data: DataType): Data {
+  getTranslatableData(_data: DataType | undefined): Data {
     return null
   }
 
   mergeTranslatedData(
-    data: DataType,
+    data: DataType | undefined,
     _translatedData: Data,
     _context: MergeTranslatableDataContext,
   ): Data {

--- a/packages/controls/src/controls/group/group.test.types.ts
+++ b/packages/controls/src/controls/group/group.test.types.ts
@@ -22,7 +22,7 @@ type ExpectedPropsDataType = {
   list: {
     id: string
     type?: string
-    value:
+    value?:
       | number
       | {
           [ControlDataTypeKey]: 'number::v1'

--- a/packages/controls/src/controls/group/group.ts
+++ b/packages/controls/src/controls/group/group.ts
@@ -248,11 +248,11 @@ class Definition<C extends Config> extends ControlDefinition<
   }
 
   mergeTranslatedData(
-    data: DataType<C>,
+    data: DataType<C> | undefined,
     translatedData: Record<string, DataType<C>>,
     context: MergeTranslatableDataContext,
   ): Data {
-    if (translatedData == null) return data
+    if (data == null || translatedData == null) return data
 
     const propsData = Definition.propsData(data)
 

--- a/packages/controls/src/controls/group/group.ts
+++ b/packages/controls/src/controls/group/group.ts
@@ -237,7 +237,7 @@ class Definition<C extends Config> extends ControlDefinition<
     )
   }
 
-  getTranslatableData(data: DataType<C>): Data {
+  getTranslatableData(data: DataType<C> | undefined): Data {
     if (data == null) return null
 
     const propsData = Definition.propsData(data)

--- a/packages/controls/src/controls/list/list.test.types.ts
+++ b/packages/controls/src/controls/list/list.test.types.ts
@@ -42,7 +42,7 @@ describe('List Types', () => {
         {
           id: string
           type?: string
-          value: {
+          value?: {
             swatchId: string
             alpha: number
             [ControlDataTypeKey]?: 'color::v1'
@@ -93,10 +93,10 @@ describe('List Types', () => {
         {
           id: string
           type?: string
-          value: {
+          value?: {
             id: string
             type?: string
-            value: {
+            value?: {
               swatchId: string
               alpha: number
               [ControlDataTypeKey]?: 'color::v1'

--- a/packages/controls/src/controls/list/list.ts
+++ b/packages/controls/src/controls/list/list.ts
@@ -170,7 +170,7 @@ class Definition<C extends Config> extends ControlDefinition<
     }))
   }
 
-  getTranslatableData(data: DataType<C>): Data {
+  getTranslatableData(data: DataType<C> | undefined): Data {
     if (data == null) return null
     return Object.fromEntries(
       data.map((item) => [

--- a/packages/controls/src/controls/list/list.ts
+++ b/packages/controls/src/controls/list/list.ts
@@ -181,11 +181,11 @@ class Definition<C extends Config> extends ControlDefinition<
   }
 
   mergeTranslatedData(
-    data: DataType<C>,
+    data: DataType<C> | undefined,
     translatedData: Record<string, DataType<C>>,
     context: MergeTranslatableDataContext,
   ): Data {
-    if (translatedData == null) return data
+    if (data == null || translatedData == null) return data
     return data.map((item) => {
       return {
         ...item,

--- a/packages/controls/src/controls/list/list.ts
+++ b/packages/controls/src/controls/list/list.ts
@@ -61,7 +61,7 @@ type ItemType<C extends Config> = C extends Config<infer Item> ? Item : never
 type DataType<C extends Config> = {
   id: string
   type?: string
-  value: DataType_<ItemType<C>>
+  value?: DataType_<ItemType<C>>
 }[]
 
 type ValueType<C extends Config> = ValueType_<ItemType<C>>[]
@@ -127,7 +127,7 @@ class Definition<C extends Config> extends ControlDefinition<
       z.object({
         id: z.string(),
         type: item.type.optional(),
-        value: item.data,
+        value: item.data.optional(),
       }),
     ) as SchemaType<DataType<C>>
 

--- a/packages/controls/src/controls/shape/v1/shape.test.types.ts
+++ b/packages/controls/src/controls/shape/v1/shape.test.types.ts
@@ -48,7 +48,7 @@ describe('Shape Types', () => {
         list: {
           id: string
           type?: string
-          value:
+          value?:
             | number
             | {
                 [ControlDataTypeKey]: 'number::v1'

--- a/packages/controls/src/controls/shape/v1/shape.ts
+++ b/packages/controls/src/controls/shape/v1/shape.ts
@@ -162,11 +162,11 @@ class Definition<C extends Config> extends ControlDefinition<
   }
 
   mergeTranslatedData(
-    data: DataType<C>,
+    data: DataType<C> | undefined,
     translatedData: Record<string, DataType<C>>,
     context: MergeTranslatableDataContext,
   ): Data {
-    if (translatedData == null) return data
+    if (data == null || translatedData == null) return data
     return mapValues(this.keyDefs, (def, key) =>
       def.mergeTranslatedData(data[key], translatedData[key], context),
     )

--- a/packages/controls/src/controls/shape/v1/shape.ts
+++ b/packages/controls/src/controls/shape/v1/shape.ts
@@ -154,7 +154,7 @@ class Definition<C extends Config> extends ControlDefinition<
     ) as DataType<C>
   }
 
-  getTranslatableData(data: DataType<C>): Data {
+  getTranslatableData(data: DataType<C> | undefined): Data {
     if (data == null) return null
     return mapValues(this.keyDefs, (def, key) => {
       return def.getTranslatableData(data[key])

--- a/packages/controls/src/controls/slot/slot.ts
+++ b/packages/controls/src/controls/slot/slot.ts
@@ -140,10 +140,11 @@ abstract class Definition<RuntimeNode> extends ControlDefinition<
   }
 
   mergeTranslatedData(
-    data: DataType,
+    data: DataType | undefined,
     _translatedData: Data,
     context: MergeTranslatableDataContext,
-  ): DataType {
+  ): DataType | undefined {
+    if (data == null) return data
     return {
       ...data,
       elements: data.elements.map((element) =>

--- a/packages/controls/src/controls/text-area/text-area.ts
+++ b/packages/controls/src/controls/text-area/text-area.ts
@@ -163,7 +163,7 @@ class Definition<C extends Config> extends ControlDefinition<
     return data
   }
 
-  getTranslatableData(data: DataType<C>): Data {
+  getTranslatableData(data: DataType<C> | undefined): Data {
     return data
   }
 

--- a/packages/controls/src/controls/text-area/text-area.ts
+++ b/packages/controls/src/controls/text-area/text-area.ts
@@ -168,11 +168,11 @@ class Definition<C extends Config> extends ControlDefinition<
   }
 
   mergeTranslatedData(
-    data: DataType<C>,
+    data: DataType<C> | undefined,
     translatedData: Data,
     _context: MergeTranslatableDataContext,
   ): Data {
-    if (translatedData == null) return data
+    if (data == null || translatedData == null) return data
     return translatedData
   }
 

--- a/packages/controls/src/controls/text-input/text-input.ts
+++ b/packages/controls/src/controls/text-input/text-input.ts
@@ -163,7 +163,7 @@ class Definition<C extends Config> extends ControlDefinition<
     return data
   }
 
-  getTranslatableData(data: DataType<C>): Data {
+  getTranslatableData(data: DataType<C> | undefined): Data {
     return data
   }
 

--- a/packages/controls/src/controls/text-input/text-input.ts
+++ b/packages/controls/src/controls/text-input/text-input.ts
@@ -168,11 +168,11 @@ class Definition<C extends Config> extends ControlDefinition<
   }
 
   mergeTranslatedData(
-    data: DataType<C>,
+    data: DataType<C> | undefined,
     translatedData: Data,
     _context: MergeTranslatableDataContext,
   ): Data {
-    if (translatedData == null) return data
+    if (data == null || translatedData == null) return data
     return translatedData
   }
 

--- a/packages/runtime/src/controls/__tests__/fixtures/list.ts
+++ b/packages/runtime/src/controls/__tests__/fixtures/list.ts
@@ -1,0 +1,38 @@
+import { List, TextInput, type DataType, type TranslationDto } from '@makeswift/controls'
+
+export const componentRegistration = List({
+  type: TextInput(),
+})
+
+type Data = DataType<typeof componentRegistration>
+
+export const translatableComponentData: Data = [
+  { id: 'id-1' },
+  {
+    id: 'id-2',
+    value: {
+      '@@makeswift/type': 'text-input::v1',
+      value: 'Hello',
+    },
+  },
+  { id: 'id-3' },
+]
+
+export const translatedComponentData: Data = [
+  { id: 'id-1' },
+  {
+    id: 'id-2',
+    value: {
+      '@@makeswift/type': 'text-input::v1',
+      value: 'Bonjour',
+    },
+  },
+  { id: 'id-3' },
+]
+
+export const translatedData: TranslationDto = {
+  'id-2': {
+    '@@makeswift/type': 'text-input::v1',
+    value: 'Bonjour',
+  },
+}

--- a/packages/runtime/src/controls/__tests__/translation.test.ts
+++ b/packages/runtime/src/controls/__tests__/translation.test.ts
@@ -1,5 +1,6 @@
 import { mergeTranslatedData } from '../control'
 import * as ShapeFixture from './fixtures/shape'
+import * as ListFixture from './fixtures/list'
 import { Element } from '../../state/modules/read-only-documents'
 
 describe('GIVEN merging translations', () => {
@@ -17,5 +18,21 @@ describe('GIVEN merging translations', () => {
 
     // Assert
     expect(result).toEqual(ShapeFixture.translatedComponentData)
+  })
+
+  test('WHEN merging list control THEN valid translations are applied', () => {
+    // Act
+    const result = mergeTranslatedData(
+      ListFixture.componentRegistration,
+      ListFixture.translatableComponentData,
+      ListFixture.translatedData,
+      {
+        translatedData: ListFixture.translatedData,
+        mergeTranslatedData: (node: Element) => node,
+      },
+    )
+
+    // Assert
+    expect(result).toEqual(ListFixture.translatedComponentData)
   })
 })

--- a/packages/runtime/src/controls/rich-text-v2/rich-text-v2.ts
+++ b/packages/runtime/src/controls/rich-text-v2/rich-text-v2.ts
@@ -142,7 +142,8 @@ class Definition extends BaseRichTextDefinition<ReactNode, Config, InstanceType>
     }
   }
 
-  getTranslatableData(data: DataType): Data {
+  getTranslatableData(data: DataType | undefined): Data {
+    if (data == null) return null
     return getTranslatableData(Definition.dataToNodes(data), this.config.plugins)
   }
 

--- a/packages/runtime/src/controls/rich-text-v2/rich-text-v2.ts
+++ b/packages/runtime/src/controls/rich-text-v2/rich-text-v2.ts
@@ -147,11 +147,11 @@ class Definition extends BaseRichTextDefinition<ReactNode, Config, InstanceType>
   }
 
   mergeTranslatedData(
-    data: DataType,
+    data: DataType | undefined,
     translatedData: Data,
     _context: MergeTranslatableDataContext,
   ): Data {
-    if (translatedData == null) return data as Data
+    if (data == null || translatedData == null) return data as Data
 
     const { descendants, ...rest } = Definition.normalizeData(data)
     return {

--- a/packages/runtime/src/state/__tests__/fixtures/translations.ts
+++ b/packages/runtime/src/state/__tests__/fixtures/translations.ts
@@ -1,0 +1,243 @@
+export const accordionFullTree = {
+  preTranslation: {
+    key: '78f53e7e-ed98-4edd-9dcb-7f02365e73b5',
+    props: {
+      items: [
+        {
+          id: '9a0bc946-c95b-428b-9fea-4b97b55c2c16',
+          value: {
+            title: { '@@makeswift/type': 'text-input::v1', value: 'Apple' },
+            content: {
+              columns: [{ deviceId: 'desktop', value: { count: 12, spans: [[12]] } }],
+              elements: [
+                {
+                  key: 'ae3cdadf-dbe8-481e-a7b0-22fe4e00dbe7',
+                  type: 'button',
+                  props: { children: { '@@makeswift/type': 'text-input::v1', value: 'Hello' } },
+                },
+              ],
+            },
+          },
+        },
+
+        {
+          id: '59ec3631-eaa4-4b37-a6c7-cb462898579c',
+          value: {
+            title: { '@@makeswift/type': 'text-input::v1', value: 'Pear' },
+            content: {
+              columns: [{ deviceId: 'desktop', value: { count: 12, spans: [[12]] } }],
+              elements: [
+                {
+                  key: '35747ea7-7caa-42e7-825b-c09c43ed1558',
+                  type: 'button',
+                  props: { children: { '@@makeswift/type': 'text-input::v1', value: 'Goodbye' } },
+                },
+              ],
+            },
+          },
+        },
+        {
+          id: 'd1d4e7b4-cb6f-487d-84ac-49b3c45ec3e1',
+          value: {
+            title: { '@@makeswift/type': 'text-input::v1', value: 'Orange' },
+            content: {
+              columns: [{ deviceId: 'desktop', value: { count: 12, spans: [[12]] } }],
+              elements: [
+                {
+                  key: '06718dbd-1913-4e15-b277-3d2b8f31a597',
+                  type: 'button',
+                  props: {
+                    children: { '@@makeswift/type': 'text-input::v1', value: 'How are you?' },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ],
+    },
+    type: 'accordion',
+  },
+
+  postTranslation: {
+    key: '78f53e7e-ed98-4edd-9dcb-7f02365e73b5',
+    props: {
+      items: [
+        {
+          id: '9a0bc946-c95b-428b-9fea-4b97b55c2c16',
+          value: {
+            title: { '@@makeswift/type': 'text-input::v1', value: 'Pomme' },
+            content: {
+              columns: [{ deviceId: 'desktop', value: { count: 12, spans: [[12]] } }],
+              elements: [
+                {
+                  key: 'ae3cdadf-dbe8-481e-a7b0-22fe4e00dbe7',
+                  type: 'button',
+                  props: { children: { '@@makeswift/type': 'text-input::v1', value: 'Bonjour' } },
+                },
+              ],
+            },
+          },
+        },
+        {
+          id: '59ec3631-eaa4-4b37-a6c7-cb462898579c',
+          value: {
+            title: { '@@makeswift/type': 'text-input::v1', value: 'Poire' },
+            content: {
+              columns: [{ deviceId: 'desktop', value: { count: 12, spans: [[12]] } }],
+              elements: [
+                {
+                  key: '35747ea7-7caa-42e7-825b-c09c43ed1558',
+                  type: 'button',
+                  props: { children: { '@@makeswift/type': 'text-input::v1', value: 'Au revoir' } },
+                },
+              ],
+            },
+          },
+        },
+        {
+          id: 'd1d4e7b4-cb6f-487d-84ac-49b3c45ec3e1',
+          value: {
+            title: { '@@makeswift/type': 'text-input::v1', value: 'Orange' },
+            content: {
+              columns: [{ deviceId: 'desktop', value: { count: 12, spans: [[12]] } }],
+              elements: [
+                {
+                  key: '06718dbd-1913-4e15-b277-3d2b8f31a597',
+                  type: 'button',
+                  props: {
+                    children: { '@@makeswift/type': 'text-input::v1', value: 'Comment vas-tu?' },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ],
+    },
+    type: 'accordion',
+  },
+
+  translationDto: {
+    '78f53e7e-ed98-4edd-9dcb-7f02365e73b5:items': {
+      '9a0bc946-c95b-428b-9fea-4b97b55c2c16': {
+        title: {
+          '@@makeswift/type': 'text-input::v1',
+          value: 'Pomme',
+        },
+        content: null,
+      },
+      '59ec3631-eaa4-4b37-a6c7-cb462898579c': {
+        title: {
+          '@@makeswift/type': 'text-input::v1',
+          value: 'Poire',
+        },
+        content: null,
+      },
+      'd1d4e7b4-cb6f-487d-84ac-49b3c45ec3e1': {
+        title: {
+          '@@makeswift/type': 'text-input::v1',
+          value: 'Orange',
+        },
+        content: null,
+      },
+    },
+    'ae3cdadf-dbe8-481e-a7b0-22fe4e00dbe7:children': {
+      '@@makeswift/type': 'text-input::v1',
+      value: 'Bonjour',
+    },
+    '35747ea7-7caa-42e7-825b-c09c43ed1558:children': {
+      '@@makeswift/type': 'text-input::v1',
+      value: 'Au revoir',
+    },
+    '06718dbd-1913-4e15-b277-3d2b8f31a597:children': {
+      '@@makeswift/type': 'text-input::v1',
+      value: 'Comment vas-tu?',
+    },
+  },
+}
+
+export const accordionPartialTree = {
+  preTranslation: {
+    key: '1eec4bc0-c83b-4bdc-80df-f52648e2a69e',
+    type: 'slot-list',
+    props: {
+      items: [
+        {
+          id: '625924cd-70c7-40cf-a2f7-22e291f4af1a',
+          value: {
+            columns: [
+              {
+                deviceId: 'desktop',
+                value: {
+                  count: 12,
+                  spans: [[12]],
+                },
+              },
+            ],
+            elements: [
+              {
+                key: '6d5e7984-7042-4ca5-bf09-ad663885de75',
+                type: 'button',
+                props: {
+                  children: {
+                    '@@makeswift/type': 'text-input::v1',
+                    value: 'Hello',
+                  },
+                },
+              },
+            ],
+          },
+        },
+        { id: 'eafe6366-f61a-4f30-84ac-d67750985485' },
+      ],
+    },
+  },
+
+  postTranslation: {
+    key: '1eec4bc0-c83b-4bdc-80df-f52648e2a69e',
+    type: 'slot-list',
+    props: {
+      items: [
+        {
+          id: '625924cd-70c7-40cf-a2f7-22e291f4af1a',
+          value: {
+            columns: [
+              {
+                deviceId: 'desktop',
+                value: {
+                  count: 12,
+                  spans: [[12]],
+                },
+              },
+            ],
+            elements: [
+              {
+                key: '6d5e7984-7042-4ca5-bf09-ad663885de75',
+                type: 'button',
+                props: {
+                  children: {
+                    '@@makeswift/type': 'text-input::v1',
+                    value: 'Bonjour',
+                  },
+                },
+              },
+            ],
+          },
+        },
+        { id: 'eafe6366-f61a-4f30-84ac-d67750985485' },
+      ],
+    },
+  },
+
+  translationDto: {
+    '1eec4bc0-c83b-4bdc-80df-f52648e2a69e:items': {
+      '625924cd-70c7-40cf-a2f7-22e291f4af1a': null,
+      'eafe6366-f61a-4f30-84ac-d67750985485': null,
+    },
+    '6d5e7984-7042-4ca5-bf09-ad663885de75:children': {
+      '@@makeswift/type': 'text-input::v1',
+      value: 'Bonjour',
+    },
+  },
+}

--- a/packages/runtime/src/state/__tests__/react-page.test.tsx
+++ b/packages/runtime/src/state/__tests__/react-page.test.tsx
@@ -1,9 +1,10 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
-import { Slot, TextInput } from '../../controls'
+import { Group, List, Slot, TextInput } from '../../controls'
 
 import { registerComponent } from '../actions'
 import * as ReactPage from '../react-page'
+import * as TranslationFixtures from './fixtures/translations'
 import { ComponentIcon } from '../modules/components-meta'
 
 // @ts-ignore Used by JSX pragma
@@ -22,6 +23,8 @@ function jsx(type: Function, props: Record<string, unknown> = {}, ...children: J
 const ElementType = {
   Box: 'box',
   Button: 'button',
+  Accordion: 'accordion',
+  SlotList: 'slot-list',
 } as const
 
 type ElementType = (typeof ElementType)[keyof typeof ElementType]
@@ -60,6 +63,31 @@ function createTestStore(): ReactPage.Store {
       ElementType.Button,
       { label: 'Button', icon: ComponentIcon.Cube, hidden: false },
       { children: TextInput() },
+    ),
+  )
+
+  store.dispatch(
+    registerComponent(
+      ElementType.Accordion,
+      { label: 'Accordion', icon: ComponentIcon.Cube, hidden: false },
+      {
+        items: List({
+          type: Group({
+            props: {
+              title: TextInput({ defaultValue: 'Default Title' }),
+              content: Slot(),
+            },
+          }),
+        }),
+      },
+    ),
+  )
+
+  store.dispatch(
+    registerComponent(
+      ElementType.SlotList,
+      { label: 'Slot List', icon: ComponentIcon.Cube, hidden: false },
+      { items: List({ type: Slot() }) },
     ),
   )
 
@@ -234,6 +262,32 @@ describe('ReactPage', () => {
 
       // Assert
       expect(result).toEqual(merged)
+    })
+  })
+
+  describe('mergeTranslatedData', () => {
+    test('Translates element tree with composable controls and slots', () => {
+      // Act
+      const result = ReactPage.mergeElementTreeTranslatedData(
+        store.getState(),
+        TranslationFixtures.accordionFullTree.preTranslation,
+        TranslationFixtures.accordionFullTree.translationDto,
+      )
+
+      // Assert
+      expect(result).toEqual(TranslationFixtures.accordionFullTree.postTranslation)
+    })
+
+    test('Translates element trees with partial values (unset list items)', () => {
+      // Act
+      const result = ReactPage.mergeElementTreeTranslatedData(
+        store.getState(),
+        TranslationFixtures.accordionPartialTree.preTranslation,
+        TranslationFixtures.accordionPartialTree.translationDto,
+      )
+
+      // Assert
+      expect(result).toEqual(TranslationFixtures.accordionPartialTree.postTranslation)
     })
   })
 })


### PR DESCRIPTION
Fix a regression introduced in v0.20.0 of the runtime, where we no longer check for null data when merging translated data.