### PR TITLE
chore: bump getPages pagination limit to 100

### DIFF
--- a/.changeset/sharp-bears-notice.md
+++ b/.changeset/sharp-bears-notice.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+change `client.getPages` pagination limit to be 100 by default

--- a/packages/runtime/src/client/index.ts
+++ b/packages/runtime/src/client/index.ts
@@ -89,7 +89,7 @@ const makeswiftGetPagesParamsSchema = z.object({
 })
 
 function getPagesQueryParams({
-  limit = 20,
+  limit = 100,
   after,
   sortBy,
   sortDirection,


### PR DESCRIPTION
Increase the client `getPages` method  default page size from 20 to 100.