### PR TITLE
fix: match Request and NextRequest in API handler

### DIFF
--- a/.changeset/young-ravens-greet.md
+++ b/.changeset/young-ravens-greet.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+fix: support matching Requests in API handler for Next.js versions < 15.5.0


### PR DESCRIPTION
Fixes a regression in ba2e9de where the API handler does not match vanilla Requests. In older versions of Next (prior to 15.5.0), the inbound request is a Request. In newer versions, the request is a NextRequest. To maintain compatibility with all Next.js versions, we match against both.