### PR TITLE
fix: extract API key from context

### DIFF
--- a/.changeset/pink-fishes-raise.md
+++ b/.changeset/pink-fishes-raise.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/hono-react": patch
+---
+
+fix: extract API key from context

--- a/packages/hono-react/src/server/env.ts
+++ b/packages/hono-react/src/server/env.ts
@@ -1,0 +1,6 @@
+export type Env = {
+  Bindings: {
+    MAKESWIFT_SITE_API_KEY: string
+  }
+  Variables: {}
+}


### PR DESCRIPTION
Adjust middleware to not require an API key on middleware creation.