### PR TITLE
Experimental React Server Components (RSCs) Support

### DIFF
--- a/apps/next-rsc/.eslintrc.json
+++ b/apps/next-rsc/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/apps/next-rsc/.gitignore
+++ b/apps/next-rsc/.gitignore
@@ -1,0 +1,36 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+.yarn/install-state.gz
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env*.local
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/apps/next-rsc/EXAMPLE.md
+++ b/apps/next-rsc/EXAMPLE.md
@@ -1,0 +1,12 @@
+# Markdown Feature
+
+A tiny doc that hits most **basic** features of Markdown.
+
+# H1
+
+## H2
+
+_Italic_ · _Italic_  
+**Bold** · **Bold**  
+**_Bold + Italic_**  
+~~Strikethrough~~

--- a/apps/next-rsc/README.md
+++ b/apps/next-rsc/README.md
@@ -1,0 +1,15 @@
+This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+
+## Getting Started
+
+First, run the development server:
+
+```bash
+npm run dev
+# or
+yarn dev
+# or
+pnpm dev
+# or
+bun dev
+```

--- a/apps/next-rsc/next.config.mjs
+++ b/apps/next-rsc/next.config.mjs
@@ -1,0 +1,10 @@
+import createWithMakeswift from '@makeswift/runtime/next/plugin'
+
+const withMakeswift = createWithMakeswift()
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+}
+
+export default withMakeswift(nextConfig)

--- a/apps/next-rsc/package.json
+++ b/apps/next-rsc/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "next-rsc",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "clean": "rm -rf .next",
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@makeswift/runtime": "workspace:^",
+    "next": "15.5.0",
+    "react": "19.1.0",
+    "react-dom": "19.1.0",
+    "react-markdown": "^10.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "autoprefixer": "^10.0.1",
+    "eslint": "^9.13.0",
+    "eslint-config-next": "15.0.2",
+    "postcss": "^8",
+    "tailwindcss": "^3.3.0",
+    "typescript": "^5"
+  }
+}

--- a/apps/next-rsc/package.json
+++ b/apps/next-rsc/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@makeswift/runtime": "workspace:^",
-    "next": "15.5.0",
+    "next": "15.5.15",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-markdown": "^10.1.0"

--- a/apps/next-rsc/postcss.config.js
+++ b/apps/next-rsc/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/next-rsc/src/app/[[...path]]/page.tsx
+++ b/apps/next-rsc/src/app/[[...path]]/page.tsx
@@ -1,0 +1,18 @@
+import { client } from '@/makeswift/client'
+import { getSiteVersion } from '@makeswift/runtime/next/server'
+import { notFound } from 'next/navigation'
+import { ExperimentalMakeswiftPage } from '@makeswift/runtime/next/rsc/server'
+
+type ParsedUrlQuery = Promise<{ path?: string[] }>
+
+export default async function Page(props: { params: ParsedUrlQuery }) {
+  const params = await props.params
+  const path = '/' + (params?.path ?? []).join('/')
+  const snapshot = await client.getPageSnapshot(path, {
+    siteVersion: getSiteVersion(),
+  })
+
+  if (snapshot == null) return notFound()
+
+  return <ExperimentalMakeswiftPage snapshot={snapshot} />
+}

--- a/apps/next-rsc/src/app/api/makeswift/[...makeswift]/route.ts
+++ b/apps/next-rsc/src/app/api/makeswift/[...makeswift]/route.ts
@@ -1,0 +1,16 @@
+import { MAKESWIFT_SITE_API_KEY } from '@/makeswift/env'
+import { MakeswiftApiHandler } from '@makeswift/runtime/next/server'
+
+import { runtime } from '@/makeswift/runtime'
+
+// required to make custom components' data available for introspection
+import '@/makeswift/components.client'
+import '@/makeswift/components.server'
+
+const handler = MakeswiftApiHandler(MAKESWIFT_SITE_API_KEY, {
+  runtime,
+  apiOrigin: process.env.NEXT_PUBLIC_MAKESWIFT_API_ORIGIN,
+  appOrigin: process.env.NEXT_PUBLIC_MAKESWIFT_APP_ORIGIN,
+})
+
+export { handler as GET, handler as POST, handler as OPTIONS }

--- a/apps/next-rsc/src/app/global.css
+++ b/apps/next-rsc/src/app/global.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/apps/next-rsc/src/app/layout.tsx
+++ b/apps/next-rsc/src/app/layout.tsx
@@ -1,0 +1,35 @@
+import { MakeswiftClientProvider } from '@/makeswift/provider'
+
+import '@/app/global.css'
+import '@/makeswift/components.server'
+import '@/makeswift/components.client'
+import { getSiteVersion } from '@makeswift/runtime/next/server'
+import { runtime } from '@/makeswift/runtime'
+import { ExperimentalServerProvider } from '@makeswift/runtime/next/rsc/server'
+
+type Params = Promise<{ path?: string[] }>
+
+export default async function RootLayout({
+  children,
+  params,
+}: Readonly<{
+  children: React.ReactNode
+  params: Params
+}>) {
+  const siteVersion = await getSiteVersion()
+
+  return (
+    <html>
+      <body>
+        <ExperimentalServerProvider runtime={runtime}>
+          <MakeswiftClientProvider
+            serializedServerState={runtime.serializeServerState()}
+            siteVersion={siteVersion}
+          >
+            {children}
+          </MakeswiftClientProvider>
+        </ExperimentalServerProvider>
+      </body>
+    </html>
+  )
+}

--- a/apps/next-rsc/src/app/layout.tsx
+++ b/apps/next-rsc/src/app/layout.tsx
@@ -6,6 +6,7 @@ import '@/makeswift/components.client'
 import { getSiteVersion } from '@makeswift/runtime/next/server'
 import { runtime } from '@/makeswift/runtime'
 import { ExperimentalServerProvider } from '@makeswift/runtime/next/rsc/server'
+import { client } from '@/makeswift/client'
 
 type Params = Promise<{ path?: string[] }>
 
@@ -21,7 +22,11 @@ export default async function RootLayout({
   return (
     <html>
       <body>
-        <ExperimentalServerProvider siteVersion={siteVersion} runtime={runtime}>
+        <ExperimentalServerProvider
+          client={client}
+          siteVersion={siteVersion}
+          runtime={runtime}
+        >
           <MakeswiftClientProvider
             serializedServerState={runtime.serializeServerState()}
             siteVersion={siteVersion}

--- a/apps/next-rsc/src/app/layout.tsx
+++ b/apps/next-rsc/src/app/layout.tsx
@@ -21,7 +21,7 @@ export default async function RootLayout({
   return (
     <html>
       <body>
-        <ExperimentalServerProvider runtime={runtime}>
+        <ExperimentalServerProvider siteVersion={siteVersion} runtime={runtime}>
           <MakeswiftClientProvider
             serializedServerState={runtime.serializeServerState()}
             siteVersion={siteVersion}

--- a/apps/next-rsc/src/makeswift/client.ts
+++ b/apps/next-rsc/src/makeswift/client.ts
@@ -5,5 +5,4 @@ import { MAKESWIFT_SITE_API_KEY } from '@/makeswift/env'
 
 export const client = new Makeswift(MAKESWIFT_SITE_API_KEY, {
   runtime,
-  apiOrigin: process.env.NEXT_PUBLIC_MAKESWIFT_API_ORIGIN,
 })

--- a/apps/next-rsc/src/makeswift/client.ts
+++ b/apps/next-rsc/src/makeswift/client.ts
@@ -1,0 +1,9 @@
+import { Makeswift } from '@makeswift/runtime/next'
+
+import { runtime } from '@/makeswift/runtime'
+import { MAKESWIFT_SITE_API_KEY } from '@/makeswift/env'
+
+export const client = new Makeswift(MAKESWIFT_SITE_API_KEY, {
+  runtime,
+  apiOrigin: process.env.NEXT_PUBLIC_MAKESWIFT_API_ORIGIN,
+})

--- a/apps/next-rsc/src/makeswift/components.client.ts
+++ b/apps/next-rsc/src/makeswift/components.client.ts
@@ -1,0 +1,1 @@
+import '@/makeswift/components/clock/clock.makeswift'

--- a/apps/next-rsc/src/makeswift/components.server.ts
+++ b/apps/next-rsc/src/makeswift/components.server.ts
@@ -1,0 +1,1 @@
+import '@/makeswift/components/rsc-markdown/rsc-markdown.makeswift.server'

--- a/apps/next-rsc/src/makeswift/components/clock/clock.makeswift.ts
+++ b/apps/next-rsc/src/makeswift/components/clock/clock.makeswift.ts
@@ -1,0 +1,21 @@
+import { Clock } from './clock'
+
+import { Combobox, Style } from '@makeswift/runtime/controls'
+import { runtime } from '@/makeswift/runtime'
+
+runtime.registerComponent(Clock, {
+  type: 'clock',
+  label: 'Custom / Clock',
+  props: {
+    className: Style(),
+    format: Combobox({
+      label: 'Format',
+      getOptions: () => {
+        return [
+          { id: 'time', value: 'time', label: 'Time' },
+          { id: 'datetime', value: 'datetime', label: 'Datetime' },
+        ] as const
+      },
+    }),
+  },
+})

--- a/apps/next-rsc/src/makeswift/components/clock/clock.tsx
+++ b/apps/next-rsc/src/makeswift/components/clock/clock.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+type Format = 'time' | 'datetime'
+
+type Props = {
+  className?: string
+  format?: Format
+}
+
+export function Clock({ className, format = 'datetime' }: Props) {
+  const [time, setTime] = useState(new Date())
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setTime(new Date())
+    }, 1000)
+    return () => clearInterval(interval)
+  }, [])
+
+  return (
+    <div className={className} suppressHydrationWarning>
+      {formatTime(time, format)}
+    </div>
+  )
+}
+
+function formatTime(time: Date, format: Format) {
+  switch (format) {
+    case 'time':
+      return time.toLocaleTimeString()
+    case 'datetime':
+      return time.toLocaleString()
+  }
+}

--- a/apps/next-rsc/src/makeswift/components/rsc-markdown/rsc-markdown.makeswift.server.ts
+++ b/apps/next-rsc/src/makeswift/components/rsc-markdown/rsc-markdown.makeswift.server.ts
@@ -1,0 +1,25 @@
+import { RscMarkdown } from './rsc-markdown'
+
+import { Style, Combobox } from '@makeswift/runtime/controls'
+import { readdir } from 'fs/promises'
+import { runtime } from '@/makeswift/runtime'
+
+runtime.registerComponent(RscMarkdown, {
+  type: 'rsc-markdown',
+  label: 'Custom / RSC Markdown',
+  props: {
+    className: Style(),
+    filename: Combobox({
+      label: 'Markdown File',
+      getOptions: async (query: string) => {
+        'use server'
+        const files = await readdir(process.cwd(), { withFileTypes: true })
+        return files
+          .filter((f) => f.isFile() && f.name.endsWith('.md'))
+          .filter((f) => f.name.toLowerCase().includes(query.toLowerCase()))
+          .map((f) => ({ id: f.name, label: f.name, value: f.name }))
+      },
+    }),
+  },
+  server: true,
+})

--- a/apps/next-rsc/src/makeswift/components/rsc-markdown/rsc-markdown.makeswift.server.ts
+++ b/apps/next-rsc/src/makeswift/components/rsc-markdown/rsc-markdown.makeswift.server.ts
@@ -1,6 +1,6 @@
 import { RscMarkdown } from './rsc-markdown'
 
-import { Style, Combobox } from '@makeswift/runtime/controls'
+import { Style, Combobox, Color, Link } from '@makeswift/runtime/controls'
 import { readdir } from 'fs/promises'
 import { runtime } from '@/makeswift/runtime'
 
@@ -9,6 +9,8 @@ runtime.registerComponent(RscMarkdown, {
   label: 'Custom / RSC Markdown',
   props: {
     className: Style(),
+    color: Color(),
+    link: Link(),
     filename: Combobox({
       label: 'Markdown File',
       getOptions: async (query: string) => {

--- a/apps/next-rsc/src/makeswift/components/rsc-markdown/rsc-markdown.tsx
+++ b/apps/next-rsc/src/makeswift/components/rsc-markdown/rsc-markdown.tsx
@@ -6,16 +6,24 @@ import { MarkdownAsync } from 'react-markdown'
 type Props = {
   className?: string
   filename?: string
+  color?: string
+  link: object
 }
 
 export async function RscMarkdown({
   className,
+  color,
   filename = 'README.md',
+  link,
 }: Props) {
   const markdown = (await readFile(filename)).toString()
 
   return (
-    <div className={className}>
+    <div
+      className={className}
+      style={{ backgroundColor: color ?? 'transparent' }}
+    >
+      Resolve link: {JSON.stringify(link)}
       <MarkdownAsync>{markdown}</MarkdownAsync>
     </div>
   )

--- a/apps/next-rsc/src/makeswift/components/rsc-markdown/rsc-markdown.tsx
+++ b/apps/next-rsc/src/makeswift/components/rsc-markdown/rsc-markdown.tsx
@@ -1,0 +1,22 @@
+import 'server-only'
+
+import { readFile } from 'fs/promises'
+import { MarkdownAsync } from 'react-markdown'
+
+type Props = {
+  className?: string
+  filename?: string
+}
+
+export async function RscMarkdown({
+  className,
+  filename = 'README.md',
+}: Props) {
+  const markdown = (await readFile(filename)).toString()
+
+  return (
+    <div className={className}>
+      <MarkdownAsync>{markdown}</MarkdownAsync>
+    </div>
+  )
+}

--- a/apps/next-rsc/src/makeswift/env.ts
+++ b/apps/next-rsc/src/makeswift/env.ts
@@ -1,0 +1,8 @@
+import { strict } from 'node:assert'
+
+strict(
+  process.env.MAKESWIFT_SITE_API_KEY,
+  '"MAKESWIFT_SITE_API_KEY" environment variable must be set.',
+)
+
+export const MAKESWIFT_SITE_API_KEY = process.env.MAKESWIFT_SITE_API_KEY

--- a/apps/next-rsc/src/makeswift/provider.tsx
+++ b/apps/next-rsc/src/makeswift/provider.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { ComponentPropsWithoutRef } from 'react'
+
+import { runtime } from '@/makeswift/runtime'
+
+import { ExperimentalReactRuntimeProvider } from '@makeswift/runtime/next/rsc'
+import { RootStyleRegistry } from '@makeswift/runtime/next'
+
+import '@/makeswift/components.client'
+
+export function MakeswiftClientProvider({
+  children,
+  ...props
+}: Omit<
+  ComponentPropsWithoutRef<typeof ExperimentalReactRuntimeProvider>,
+  'runtime'
+>) {
+  return (
+    <ExperimentalReactRuntimeProvider
+      {...props}
+      runtime={runtime}
+      apiOrigin={process.env.NEXT_PUBLIC_MAKESWIFT_API_ORIGIN}
+      appOrigin={process.env.NEXT_PUBLIC_MAKESWIFT_APP_ORIGIN}
+    >
+      <RootStyleRegistry>{children}</RootStyleRegistry>
+    </ExperimentalReactRuntimeProvider>
+  )
+}

--- a/apps/next-rsc/src/makeswift/runtime.ts
+++ b/apps/next-rsc/src/makeswift/runtime.ts
@@ -1,0 +1,10 @@
+import { ExperimentalReactRuntime } from '@makeswift/runtime/next/rsc'
+
+export const runtime = new ExperimentalReactRuntime({
+  breakpoints: {
+    mobile: { width: 575, viewport: 390, label: 'Mobile' },
+    tablet: { width: 768, viewport: 765, label: 'Tablet' },
+    laptop: { width: 1024, viewport: 1000, label: 'Laptop' },
+    external: { width: 1280, label: 'External' },
+  },
+})

--- a/apps/next-rsc/src/makeswift/runtime.ts
+++ b/apps/next-rsc/src/makeswift/runtime.ts
@@ -1,10 +1,14 @@
+import { fetch } from '@makeswift/runtime/next'
 import { ExperimentalReactRuntime } from '@makeswift/runtime/next/rsc'
 
 export const runtime = new ExperimentalReactRuntime({
+  apiOrigin: process.env.NEXT_PUBLIC_MAKESWIFT_API_ORIGIN,
+  appOrigin: process.env.NEXT_PUBLIC_MAKESWIFT_APP_ORIGIN,
   breakpoints: {
     mobile: { width: 575, viewport: 390, label: 'Mobile' },
     tablet: { width: 768, viewport: 765, label: 'Tablet' },
     laptop: { width: 1024, viewport: 1000, label: 'Laptop' },
     external: { width: 1280, label: 'External' },
   },
+  fetch: fetch,
 })

--- a/apps/next-rsc/tailwind.config.ts
+++ b/apps/next-rsc/tailwind.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  content: [
+    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
+  ],
+  plugins: [],
+}
+export default config

--- a/apps/next-rsc/tsconfig.json
+++ b/apps/next-rsc/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "target": "ES2017"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/react-router/src/components/framework-provider/index.tsx
+++ b/packages/react-router/src/components/framework-provider/index.tsx
@@ -5,6 +5,7 @@ import {
   DefaultHead,
   DefaultHeadSnippet,
   DefaultImage,
+  DefaultElementData,
 } from '@makeswift/runtime/unstable-framework-support'
 
 import { Link } from './link'
@@ -15,6 +16,7 @@ export function FrameworkProvider({ children }: PropsWithChildren) {
     HeadSnippet: DefaultHeadSnippet,
     Image: DefaultImage,
     Link,
+    ElementData: DefaultElementData,
   })
 
   return <FrameworkContext.Provider value={context}>{children}</FrameworkContext.Provider>

--- a/packages/runtime/next/rsc/package.json
+++ b/packages/runtime/next/rsc/package.json
@@ -1,0 +1,5 @@
+{
+  "main": "../../dist/cjs/next/rsc/index.js",
+  "module": "../../dist/esm/next/rsc/index.js",
+  "types": "../../dist/types/next/rsc/index.d.ts"
+}

--- a/packages/runtime/next/rsc/server/package.json
+++ b/packages/runtime/next/rsc/server/package.json
@@ -1,0 +1,5 @@
+{
+  "main": "../../../dist/cjs/next/rsc/server/index.js",
+  "module": "../../../dist/esm/next/rsc/server/index.js",
+  "types": "../../../dist/types/next/rsc/server/index.d.ts"
+}

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -87,6 +87,16 @@
       "require": "./dist/cjs/next/plugin.js",
       "import": "./dist/cjs/next/plugin.js"
     },
+    "./next/rsc": {
+      "require": "./dist/cjs/next/rsc/index.js",
+      "import": "./dist/esm/next/rsc/index.js",
+      "types": "./dist/types/next/rsc/index.d.ts"
+    },
+    "./next/rsc/server": {
+      "require": "./dist/cjs/next/rsc/server/index.js",
+      "import": "./dist/esm/next/rsc/server/index.js",
+      "types": "./dist/types/next/rsc/server/index.d.ts"
+    },
     "./next/server": {
       "types": "./dist/types/next/server.d.ts",
       "module": "./dist/esm/next/server.js",

--- a/packages/runtime/src/controls/serialization/base/index.ts
+++ b/packages/runtime/src/controls/serialization/base/index.ts
@@ -32,7 +32,11 @@ import {
 
 import { BaseControlSerializationVisitor } from './visitor'
 
-export { type SerializedRecord, type DeserializedRecord } from '@makeswift/controls'
+export {
+  type SerializedRecord,
+  type DeserializedRecord,
+  ControlDefinition,
+} from '@makeswift/controls'
 
 export function serializeControls(
   controls: Record<string, ControlDefinition>,

--- a/packages/runtime/src/controls/serialization/index.ts
+++ b/packages/runtime/src/controls/serialization/index.ts
@@ -1,5 +1,7 @@
 import { type SerializedRecord, type DeserializeControlOptions } from './base'
 
+export { type SerializedRecord, serializeControls } from './base'
+
 export function isSerializedRecord(r: unknown): r is SerializedRecord {
   return r != null && typeof r === 'object' && 'type' in r && typeof r.type === 'string'
 }

--- a/packages/runtime/src/controls/serialization/rsc/index.ts
+++ b/packages/runtime/src/controls/serialization/rsc/index.ts
@@ -1,0 +1,24 @@
+import {
+  type SerializedRecord,
+  type DeserializeControlOptions,
+  ControlDefinition,
+  serializeControls,
+  deserializeControl,
+} from '../base'
+import { RSCSerializationVisitor } from './visitor'
+
+export { type SerializedRecord, type DeserializedRecord } from '../base'
+
+export function serializeRSCControls(
+  controls: Record<string, ControlDefinition>,
+): Record<string, SerializedRecord> {
+  return serializeControls(controls, new RSCSerializationVisitor())
+}
+
+export function deserializeRSCControl(
+  serializedControl: SerializedRecord,
+  options?: Partial<DeserializeControlOptions>,
+): ControlDefinition {
+  const plugins = options?.plugins ?? []
+  return deserializeControl(serializedControl, { plugins })
+}

--- a/packages/runtime/src/controls/serialization/rsc/visitor.ts
+++ b/packages/runtime/src/controls/serialization/rsc/visitor.ts
@@ -1,6 +1,6 @@
 import { AnyFunction, SerializationPlugin } from '@makeswift/controls'
 
-import { BaseControlSerializationVisitor } from './base-control-serialization-visitor'
+import { BaseControlSerializationVisitor } from '../base/visitor'
 
 // https://github.com/facebook/react/blob/f739642745577a8e4dcb9753836ac3589b9c590a/packages/react-server-dom-webpack/src/ReactFlightWebpackReferences.js#L26-L35
 const SERVER_REFERENCE_TAG = Symbol.for('react.server.reference')
@@ -13,7 +13,7 @@ function isServerReference(reference: unknown): boolean {
   )
 }
 
-export class ServerSerializationVisitor extends BaseControlSerializationVisitor {
+export class RSCSerializationVisitor extends BaseControlSerializationVisitor {
   constructor() {
     const serializeFunctionPlugin: SerializationPlugin<AnyFunction> = {
       match: isServerReference,

--- a/packages/runtime/src/controls/visitors/base-control-serialization-visitor.ts
+++ b/packages/runtime/src/controls/visitors/base-control-serialization-visitor.ts
@@ -1,0 +1,46 @@
+import {
+  ControlDefinition,
+  SerializedRecord,
+  serializeObject,
+  SerializationPlugin,
+  ControlSerializationVisitor,
+} from '@makeswift/controls'
+
+import { RichTextV2Definition } from '../rich-text-v2'
+
+export class BaseControlSerializationVisitor extends ControlSerializationVisitor {
+  constructor(plugins: SerializationPlugin<any>[] = []) {
+    const serializeDefinitionPlugin: SerializationPlugin<ControlDefinition> = {
+      match: (val: unknown) => val instanceof ControlDefinition,
+      serialize: (val: ControlDefinition) => val.accept(this),
+    }
+
+    super([serializeDefinitionPlugin, ...plugins])
+  }
+
+  visitRichTextV2(def: RichTextV2Definition): SerializedRecord {
+    const { plugins, ...config } = def.config
+
+    // serialize only the plugin control definition, if any
+    const pluginDefs = plugins.map(({ control }) =>
+      control
+        ? {
+            control: {
+              definition: control.definition,
+              // FIXME: remove getValue/onChange stubs once we released a version of the builder
+              // built against the runtime where these can be optional
+              getValue: () => undefined,
+              onChange: () => {},
+            },
+          }
+        : {},
+    )
+
+    const serialized = serializeObject(
+      { config: { ...config, plugins: pluginDefs } },
+      this.serializationPlugins,
+    ) as SerializedRecord
+
+    return { ...serialized, type: RichTextV2Definition.type }
+  }
+}

--- a/packages/runtime/src/controls/visitors/server-serialization-visitor.ts
+++ b/packages/runtime/src/controls/visitors/server-serialization-visitor.ts
@@ -1,0 +1,25 @@
+import { AnyFunction, SerializationPlugin } from '@makeswift/controls'
+
+import { BaseControlSerializationVisitor } from './base-control-serialization-visitor'
+
+// https://github.com/facebook/react/blob/f739642745577a8e4dcb9753836ac3589b9c590a/packages/react-server-dom-webpack/src/ReactFlightWebpackReferences.js#L26-L35
+const SERVER_REFERENCE_TAG = Symbol.for('react.server.reference')
+
+function isServerReference(reference: unknown): boolean {
+  return (
+    typeof reference === 'function' &&
+    '$$typeof' in reference &&
+    reference.$$typeof === SERVER_REFERENCE_TAG
+  )
+}
+
+export class ServerSerializationVisitor extends BaseControlSerializationVisitor {
+  constructor() {
+    const serializeFunctionPlugin: SerializationPlugin<AnyFunction> = {
+      match: isServerReference,
+      serialize: (val: AnyFunction) => val,
+    }
+
+    super([serializeFunctionPlugin])
+  }
+}

--- a/packages/runtime/src/next/components/framework-provider/index.tsx
+++ b/packages/runtime/src/next/components/framework-provider/index.tsx
@@ -1,14 +1,13 @@
 'use client'
 
 import { type PropsWithChildren, useMemo } from 'react'
-import NextImage from 'next/image'
 
 import { useIsPagesRouter } from '../../hooks/use-is-pages-router'
 import { FrameworkContext } from '../../../runtimes/react/components/framework-context'
 
 import { context as appRouterContext } from './app-router'
 import { context as pagesRouterContext } from './pages-router'
-import { Link } from './link'
+import { context as nextContext } from './next'
 
 export function FrameworkProvider({
   children,
@@ -18,8 +17,7 @@ export function FrameworkProvider({
   const context = useMemo<FrameworkContext>(
     () => ({
       ...(isPagesRouter ? pagesRouterContext : appRouterContext),
-      Image: NextImage,
-      Link,
+      ...nextContext,
     }),
     [isPagesRouter],
   )

--- a/packages/runtime/src/next/components/framework-provider/next/index.ts
+++ b/packages/runtime/src/next/components/framework-provider/next/index.ts
@@ -1,0 +1,13 @@
+import NextImage from 'next/image'
+import { Link } from './link'
+
+import {
+  DefaultElementData,
+  type FrameworkContext,
+} from '../../../../runtimes/react/components/framework-context'
+
+export const context: Pick<FrameworkContext, 'Image' | 'Link' | 'ElementData'> = {
+  Image: NextImage,
+  Link,
+  ElementData: DefaultElementData,
+}

--- a/packages/runtime/src/next/components/framework-provider/next/link.tsx
+++ b/packages/runtime/src/next/components/framework-provider/next/link.tsx
@@ -3,9 +3,9 @@
 import { type ComponentPropsWithoutRef, forwardRef } from 'react'
 import NextLink from 'next/link'
 
-import { type FrameworkContext } from '../../../runtimes/react/components/framework-context'
+import { type FrameworkContext } from '../../../../runtimes/react/components/framework-context'
 
-import { useIsPagesRouter } from '../../hooks/use-is-pages-router'
+import { useIsPagesRouter } from '../../../hooks/use-is-pages-router'
 
 // workaround for https://github.com/vercel/next.js/issues/66650
 const isValidHref = (href: string) => {

--- a/packages/runtime/src/next/rsc/client/element-data.tsx
+++ b/packages/runtime/src/next/rsc/client/element-data.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { Ref, forwardRef, memo, type ReactNode } from 'react'
+import { ElementData as ReactPageElementData } from '../../../state/react-page'
+import { FallbackComponent } from '../../../components/shared/FallbackComponent'
+import { useRSCNode } from './rsc-nodes-provider'
+import { ElementData } from '../../../runtimes/react/components/ElementData'
+import { useComponentMeta } from '../../../runtimes/react/hooks/use-component-meta'
+
+type ElementDataProps = {
+  elementData: ReactPageElementData
+}
+
+export const RSCElementData = memo(
+  forwardRef(function RSCElementData(
+    { elementData }: ElementDataProps,
+    ref: Ref<unknown>,
+  ): ReactNode {
+    const componentMeta = useComponentMeta(elementData.type)
+    const rscNode = useRSCNode(elementData.key)
+
+    if (componentMeta == null) {
+      console.warn(`Component meta not found for ${elementData.type}`)
+      return <FallbackComponent ref={ref as Ref<HTMLDivElement>} text="Component not found" />
+    }
+
+    if (!componentMeta.server) {
+      return <ElementData elementData={elementData} ref={ref} />
+    }
+
+    if (rscNode == null) {
+      console.warn(`RSC node not found for ${elementData.key}`)
+      return <FallbackComponent ref={ref as Ref<HTMLDivElement>} text="RSC node not found" />
+    }
+
+    return rscNode
+  }),
+)

--- a/packages/runtime/src/next/rsc/client/element-data.tsx
+++ b/packages/runtime/src/next/rsc/client/element-data.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Ref, forwardRef, memo, type ReactNode } from 'react'
-import { ElementData as ReactPageElementData } from '../../../state/react-page'
+import { ElementData as ReactPageElementData } from '../../../state/read-only-state'
 import { FallbackComponent } from '../../../components/shared/FallbackComponent'
 import { useRSCNode } from './rsc-nodes-provider'
 import { ElementData } from '../../../runtimes/react/components/ElementData'

--- a/packages/runtime/src/next/rsc/client/framework-provider.tsx
+++ b/packages/runtime/src/next/rsc/client/framework-provider.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { type PropsWithChildren, useMemo } from 'react'
+
+import { FrameworkContext } from '../../../runtimes/react/components/framework-context'
+
+import { context as appRouterContext } from '../../components/framework-provider/app-router'
+import { context as nextContext } from '../../components/framework-provider/next'
+import { createRSCRefreshMiddleware } from './refresh-middleware'
+import { useRouter } from 'next/navigation'
+import { RSCElementData } from './element-data'
+
+export function NextRSCFrameworkProvider({ children }: PropsWithChildren) {
+  const router = useRouter()
+
+  const context = useMemo<FrameworkContext>(
+    () => ({
+      ...appRouterContext,
+      ...nextContext,
+      ElementData: RSCElementData,
+      previewStoreMiddlewares: [createRSCRefreshMiddleware(router)],
+    }),
+    [router],
+  )
+
+  return <FrameworkContext.Provider value={context}>{children}</FrameworkContext.Provider>
+}

--- a/packages/runtime/src/next/rsc/client/refresh-middleware.ts
+++ b/packages/runtime/src/next/rsc/client/refresh-middleware.ts
@@ -1,0 +1,61 @@
+import { type Middleware } from '@reduxjs/toolkit'
+import { type useRouter } from 'next/navigation'
+
+import { type State, type Dispatch, Element } from '../../../state/react-page'
+import * as ComponentsMeta from '../../../state/modules/components-meta'
+import { ActionTypes, type Action, type DocumentPayload } from '../../../state/actions'
+import { actionMiddleware } from '../../../state/toolkit'
+import { traverseElementTree } from '../../../state/modules/element-trees'
+import { type DescriptorsByComponentType } from '../../../state/modules/prop-controllers'
+
+export function createRSCRefreshMiddleware(
+  router?: ReturnType<typeof useRouter>,
+): Middleware<Dispatch, State, Dispatch> {
+  return actionMiddleware<State, Action>(({ getState }) => next => {
+    return action => {
+      switch (action.type) {
+        // TODO: this can be much more efficient if we send a new operation from the builder when a new RSC element is added
+        case ActionTypes.CHANGE_ELEMENT_TREE: {
+          const { oldDocument, newDocument, descriptors } = action.payload
+          const componentsMeta = ComponentsMeta.getComponentsMeta(getState().componentsMeta)
+          const newlyAddedElements = getNewlyAddedElements(oldDocument, newDocument, descriptors)
+
+          for (const element of newlyAddedElements) {
+            const meta = componentsMeta.get(element.type)
+
+            if (meta?.server) {
+              console.log(`[RSC] element "${element.type}" added, refreshing page`)
+              router?.refresh()
+              break
+            }
+          }
+
+          break
+        }
+      }
+
+      return next(action)
+    }
+  })
+}
+
+function getNewlyAddedElements(
+  oldDoc: DocumentPayload,
+  newDoc: DocumentPayload,
+  descriptors: DescriptorsByComponentType,
+): Element[] {
+  const oldElementKeys = new Set<string>()
+  const newElements: Element[] = []
+
+  for (const element of traverseElementTree(oldDoc.rootElement, descriptors)) {
+    oldElementKeys.add(element.key)
+  }
+
+  for (const element of traverseElementTree(newDoc.rootElement, descriptors)) {
+    if (!oldElementKeys.has(element.key)) {
+      newElements.push(element)
+    }
+  }
+
+  return newElements
+}

--- a/packages/runtime/src/next/rsc/client/refresh-middleware.ts
+++ b/packages/runtime/src/next/rsc/client/refresh-middleware.ts
@@ -1,7 +1,7 @@
 import { type Middleware } from '@reduxjs/toolkit'
 import { type useRouter } from 'next/navigation'
 
-import { type State, type Dispatch, Element } from '../../../state/react-page'
+import { type State, type Dispatch, Element } from '../../../state/read-only-state'
 import * as ComponentsMeta from '../../../state/modules/components-meta'
 import { ActionTypes, type Action, type DocumentPayload } from '../../../state/actions'
 import { actionMiddleware } from '../../../state/toolkit'

--- a/packages/runtime/src/next/rsc/client/rsc-builder-updater.tsx
+++ b/packages/runtime/src/next/rsc/client/rsc-builder-updater.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { ReactNode, useEffect, useMemo, useRef } from 'react'
+import { useRouter } from 'next/navigation'
+import { deepEqual, ElementData, isElementReference, StyleDefinition } from '@makeswift/controls'
+import { useControlDefs } from '../../../runtimes/react/controls'
+import { useBreakpoints, useDocumentKey, useSelector } from '../../../runtimes/react'
+import { useResourceResolver } from '../../../runtimes/react/hooks/use-resource-resolver'
+import { getElement } from '../../../state/react-page'
+import { StylesheetEngine } from '../css/css-runtime'
+import { useClientCSS } from '../css/client-css'
+
+type RSCBuilderUpdaterProps = {
+  initialElementData: ElementData
+  children: ReactNode
+}
+
+export function RSCBuilderUpdater({ initialElementData, children }: RSCBuilderUpdaterProps) {
+  const { updateStyle } = useClientCSS()
+  const documentKey = useDocumentKey()
+  const breakpoints = useBreakpoints()
+  const router = useRouter()
+  const resourceResolver = useResourceResolver()
+  const elementKey = initialElementData.key
+  const prevPropsRef = useRef(initialElementData.props)
+  const [, definitions] = useControlDefs(initialElementData.type)
+
+  const element = useSelector(state => {
+    if (documentKey == null) return null
+    const element = getElement(state, documentKey, elementKey)
+    if (element == null || isElementReference(element)) return null
+    return element
+  })
+
+  const clientStylesheet = useMemo(
+    () =>
+      new StylesheetEngine(
+        breakpoints,
+        elementKey,
+        undefined,
+        (_className, css, elementKey, propName) => {
+          if (elementKey && propName) updateStyle(elementKey, propName, css)
+        },
+      ),
+    [breakpoints, elementKey, updateStyle],
+  )
+
+  useEffect(() => {
+    if (!element) return
+
+    const prevProps = prevPropsRef.current
+
+    if (prevProps === element.props) return
+
+    Object.entries(definitions).forEach(([propName, def]) => {
+      const currentValue = element.props[propName]
+      const prevValue = prevProps[propName]
+
+      if (def.controlType === StyleDefinition.type) {
+        if (currentValue != null && !deepEqual(currentValue, prevValue)) {
+          const resolvable = def.resolveValue(
+            currentValue,
+            resourceResolver,
+            clientStylesheet.child(propName),
+          )
+          resolvable.readStable()
+        }
+      } else {
+        if (!deepEqual(currentValue, prevValue)) {
+          console.log('[RSC] Non-style prop changed, refreshing page')
+          router.refresh()
+        }
+      }
+    })
+
+    prevPropsRef.current = element.props
+  }, [element, definitions, resourceResolver, clientStylesheet, router])
+
+  return children
+}

--- a/packages/runtime/src/next/rsc/client/rsc-builder-updater.tsx
+++ b/packages/runtime/src/next/rsc/client/rsc-builder-updater.tsx
@@ -6,7 +6,7 @@ import { deepEqual, ElementData, isElementReference, StyleDefinition } from '@ma
 import { useControlDefs } from '../../../runtimes/react/controls'
 import { useBreakpoints, useDocumentKey, useSelector } from '../../../runtimes/react'
 import { useResourceResolver } from '../../../runtimes/react/hooks/use-resource-resolver'
-import { getElement } from '../../../state/react-page'
+import { getElement } from '../../../state/read-only-state'
 import { StylesheetEngine } from '../css/css-runtime'
 import { useClientCSS } from '../css/client-css'
 

--- a/packages/runtime/src/next/rsc/client/rsc-nodes-provider.tsx
+++ b/packages/runtime/src/next/rsc/client/rsc-nodes-provider.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { createContext, ReactNode, useContext } from 'react'
+
+export type RSCNodes = Map<string, ReactNode>
+
+const RSCNodesContext = createContext<RSCNodes>(new Map())
+
+export const RSCNodesProvider = ({ children, value }: { children: ReactNode; value: RSCNodes }) => {
+  return <RSCNodesContext.Provider value={value}>{children}</RSCNodesContext.Provider>
+}
+
+export const useRSCNode = (elementKey: string): ReactNode | undefined => {
+  return useContext(RSCNodesContext).get(elementKey)
+}

--- a/packages/runtime/src/next/rsc/client/runtime-provider.tsx
+++ b/packages/runtime/src/next/rsc/client/runtime-provider.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { ComponentProps } from 'react'
+
+import { NextRSCRuntime, SerializedServerState } from '../shared/react-runtime'
+import { RuntimeProvider } from '../../../runtimes/react/components/RuntimeProvider'
+import { NextRSCFrameworkProvider } from './framework-provider'
+
+export function NextRSCRuntimeProvider({
+  runtime,
+  serializedServerState,
+  ...props
+}: Omit<ComponentProps<typeof RuntimeProvider>, 'runtime'> & {
+  runtime: NextRSCRuntime
+  serializedServerState: SerializedServerState
+}) {
+  runtime.loadServerState(serializedServerState)
+
+  return (
+    <NextRSCFrameworkProvider>
+      <RuntimeProvider runtime={runtime} {...props} />
+    </NextRSCFrameworkProvider>
+  )
+}

--- a/packages/runtime/src/next/rsc/css/client-css.tsx
+++ b/packages/runtime/src/next/rsc/css/client-css.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { createContext, ReactNode, useContext, useEffect, useRef, useCallback } from 'react'
+
+type ClientCSSContextValue = {
+  updateStyle: (elementKey: string, propName: string, cssString: string) => void
+}
+
+const ClientCSSContext = createContext<ClientCSSContextValue>({
+  updateStyle: () => {},
+})
+
+export function ClientCSSProvider({ children }: { children: ReactNode }) {
+  const styleElementRef = useRef<HTMLStyleElement | null>(null)
+  const serverStylesRef = useRef<string>('')
+  const dynamicStylesRef = useRef<Map<string, string>>(new Map())
+
+  // Initialize style element and capture server styles
+  useEffect(() => {
+    const styleElement = document.querySelector<HTMLStyleElement>(
+      'style[data-makeswift-rsc="true"]',
+    )
+
+    if (!styleElement) {
+      throw new Error(
+        'Makeswift RSC style element not found. Ensure CSSInjector is rendered on the server.',
+      )
+    }
+
+    serverStylesRef.current = styleElement.textContent
+    styleElementRef.current = styleElement
+
+    return () => {
+      styleElementRef.current = null
+    }
+  }, [])
+
+  const updateStyleElement = useCallback(() => {
+    if (!styleElementRef.current) return
+
+    const dynamicCss = Array.from(dynamicStylesRef.current.values()).join('\n')
+    const separator = serverStylesRef.current && dynamicCss ? '\n' : ''
+    const combinedStyles = serverStylesRef.current + separator + dynamicCss
+
+    styleElementRef.current.textContent = combinedStyles
+  }, [])
+
+  const updateStyle = useCallback(
+    (elementKey: string, propName: string, cssString: string) => {
+      const styleKey = `${elementKey}:${propName}`
+      dynamicStylesRef.current.set(styleKey, cssString)
+      updateStyleElement()
+    },
+    [updateStyleElement],
+  )
+
+  return <ClientCSSContext.Provider value={{ updateStyle }}>{children}</ClientCSSContext.Provider>
+}
+
+export function useClientCSS(): ClientCSSContextValue {
+  const context = useContext(ClientCSSContext)
+  if (!context) throw new Error('useClientCSS must be used within ClientCSSProvider')
+  return context
+}

--- a/packages/runtime/src/next/rsc/css/css-runtime.ts
+++ b/packages/runtime/src/next/rsc/css/css-runtime.ts
@@ -1,0 +1,102 @@
+import type { CSSObject } from '@emotion/serialize'
+import { type Breakpoints, type Stylesheet, type ResolvedStyle } from '@makeswift/controls'
+import { resolvedStyleToCss } from '../../../runtimes/react/resolve-style'
+
+function cssObjectToString(cssObject: CSSObject, className: string): string {
+  const cssRules: string[] = []
+  const mediaRules: string[] = []
+  const baseStyles: Record<string, any> = {}
+
+  Object.entries(cssObject).forEach(([property, value]) => {
+    if (property.startsWith('@media')) {
+      const mediaQueryStyles = value as CSSObject
+      const mediaCSS = Object.entries(mediaQueryStyles)
+        .map(([prop, val]) => formatCSSProperty(prop, val))
+        .filter(Boolean)
+        .join(' ')
+
+      if (mediaCSS) {
+        mediaRules.push(`${property} { .${className} { ${mediaCSS} } }`)
+      }
+    } else {
+      baseStyles[property] = value
+    }
+  })
+
+  const baseCSS = Object.entries(baseStyles)
+    .map(([prop, val]) => formatCSSProperty(prop, val))
+    .filter(Boolean)
+    .join(' ')
+
+  if (baseCSS) {
+    cssRules.push(`.${className} { ${baseCSS} }`)
+  }
+
+  cssRules.push(...mediaRules)
+  return cssRules.join('\n')
+}
+
+function formatCSSProperty(property: string, value: any): string {
+  if (value == null || value === '') return ''
+
+  if (Array.isArray(value)) {
+    return value.length > 0 ? `${kebabCase(property)}: ${value.join(' ')};` : ''
+  }
+
+  return `${kebabCase(property)}: ${value};`
+}
+
+function kebabCase(str: string): string {
+  return str.replace(/[A-Z]/g, letter => `-${letter.toLowerCase()}`)
+}
+
+function generateClassName(elementKey?: string, propName?: string, counter?: number): string {
+  const parts = ['makeswift-rsc']
+  if (elementKey) parts.push(elementKey)
+  if (propName) parts.push(propName)
+  if (counter !== undefined) parts.push(counter.toString())
+  return parts.join('-')
+}
+
+type OnStyleGenerated = (
+  className: string,
+  css: string,
+  elementKey?: string,
+  propName?: string,
+) => void
+
+// Unified stylesheet engine that handles both server and client modes
+export class StylesheetEngine implements Stylesheet {
+  private styleCounter = 0
+
+  constructor(
+    private breakpointsData: Breakpoints,
+    private elementKey?: string,
+    private basePropName?: string,
+    private onStyleGenerated?: OnStyleGenerated,
+  ) {}
+
+  breakpoints(): Breakpoints {
+    return this.breakpointsData
+  }
+
+  defineStyle(style: ResolvedStyle): string {
+    const className = generateClassName(this.elementKey, this.basePropName, ++this.styleCounter)
+
+    const cssObject = resolvedStyleToCss(this.breakpointsData, style)
+    const cssString = cssObjectToString(cssObject, className)
+
+    this.onStyleGenerated?.(className, cssString, this.elementKey, this.basePropName)
+
+    return className
+  }
+
+  child(propName: string): Stylesheet {
+    return new StylesheetEngine(
+      this.breakpointsData,
+      this.elementKey,
+      propName,
+      this.onStyleGenerated,
+    )
+  }
+}

--- a/packages/runtime/src/next/rsc/css/server-css.tsx
+++ b/packages/runtime/src/next/rsc/css/server-css.tsx
@@ -1,0 +1,44 @@
+import 'server-only'
+import { cache } from 'react'
+import { type Breakpoints, type Stylesheet } from '@makeswift/controls'
+import { StylesheetEngine } from './css-runtime'
+
+export class ServerCSSCollector {
+  private styles = new Map<string, string>()
+
+  collect(className: string, css: string) {
+    if (this.styles.has(className)) return
+    this.styles.set(className, css)
+  }
+
+  getAllStyles(): string {
+    return Array.from(this.styles.values()).join('\n')
+  }
+
+  clear() {
+    this.styles.clear()
+  }
+}
+
+export const getCSSCollector = cache((): ServerCSSCollector => {
+  return new ServerCSSCollector()
+})
+
+export function createCollectingServerStylesheet(
+  breakpoints: Breakpoints,
+  elementKey?: string,
+): Stylesheet {
+  const collector = getCSSCollector()
+
+  return new StylesheetEngine(breakpoints, elementKey, undefined, (className, css) => {
+    collector.collect(className, css)
+  })
+}
+
+export function CSSInjector() {
+  const collector = getCSSCollector()
+  const css = collector.getAllStyles()
+
+  // Always render the style element, even when empty, to ensure consistency between server and client
+  return <style data-makeswift-rsc="true">{css}</style>
+}

--- a/packages/runtime/src/next/rsc/index.ts
+++ b/packages/runtime/src/next/rsc/index.ts
@@ -1,0 +1,2 @@
+export { NextRSCRuntime as ExperimentalReactRuntime } from './shared/react-runtime'
+export { NextRSCRuntimeProvider as ExperimentalReactRuntimeProvider } from './client/runtime-provider'

--- a/packages/runtime/src/next/rsc/server/index.ts
+++ b/packages/runtime/src/next/rsc/server/index.ts
@@ -1,0 +1,4 @@
+import 'server-only'
+
+export { NextRSCMakeswiftPage as ExperimentalMakeswiftPage } from './makeswift-page'
+export { NextRSCServerProvider as ExperimentalServerProvider } from './server-provider'

--- a/packages/runtime/src/next/rsc/server/makeswift-page.tsx
+++ b/packages/runtime/src/next/rsc/server/makeswift-page.tsx
@@ -4,11 +4,13 @@ import { prerenderRSCNodes } from './prerender-rsc-nodes'
 import { RSCNodesProvider } from '../client/rsc-nodes-provider'
 import { CSSInjector } from '../css/server-css'
 import { ClientCSSProvider } from '../css/client-css'
+import { pageToRootDocument } from '../../../client'
 
 type Props = ComponentPropsWithoutRef<typeof Page>
 
 export function NextRSCMakeswiftPage(props: Props) {
-  const rscNodes = prerenderRSCNodes(props.snapshot.document.data)
+  const rootDocument = pageToRootDocument(props.snapshot.document)
+  const rscNodes = prerenderRSCNodes(rootDocument)
 
   return (
     <RSCNodesProvider value={rscNodes}>

--- a/packages/runtime/src/next/rsc/server/makeswift-page.tsx
+++ b/packages/runtime/src/next/rsc/server/makeswift-page.tsx
@@ -1,0 +1,21 @@
+import { ComponentPropsWithoutRef } from 'react'
+import { Page } from '../..'
+import { prerenderRSCNodes } from './prerender-rsc-nodes'
+import { RSCNodesProvider } from '../client/rsc-nodes-provider'
+import { CSSInjector } from '../css/server-css'
+import { ClientCSSProvider } from '../css/client-css'
+
+type Props = ComponentPropsWithoutRef<typeof Page>
+
+export function NextRSCMakeswiftPage(props: Props) {
+  const rscNodes = prerenderRSCNodes(props.snapshot.document.data)
+
+  return (
+    <RSCNodesProvider value={rscNodes}>
+      <ClientCSSProvider>
+        <CSSInjector />
+        <Page {...props} />
+      </ClientCSSProvider>
+    </RSCNodesProvider>
+  )
+}

--- a/packages/runtime/src/next/rsc/server/prerender-rsc-nodes.tsx
+++ b/packages/runtime/src/next/rsc/server/prerender-rsc-nodes.tsx
@@ -1,0 +1,33 @@
+import { getRuntime } from './runtime'
+import { getComponentsMeta } from '../../../state/modules/components-meta'
+import { Element, getPropControllerDescriptors } from '../../../state/react-page'
+import { ServerElement } from './server-element'
+import { traverseElementTree } from '../../../state/modules/element-trees'
+import { RSCNodes } from '../client/rsc-nodes-provider'
+
+export function prerenderRSCNodes(elementTree: Element): RSCNodes {
+  const runtime = getRuntime()
+  const state = runtime.store.getState()
+  const descriptors = getPropControllerDescriptors(state)
+  const rscNodes: RSCNodes = new Map()
+
+  for (const element of traverseElementTree(elementTree, descriptors)) {
+    const meta = getComponentsMeta(state.componentsMeta).get(element.type)
+
+    if (meta == null) {
+      console.warn(`[prerenderRSCNodes] Component meta not found for ${element.type}`)
+      continue
+    }
+
+    if (rscNodes.has(element.key)) {
+      console.warn(`[prerenderRSCNodes] RSC node already exists for ${element.key}`)
+      continue
+    }
+
+    if (meta.server) {
+      rscNodes.set(element.key, <ServerElement key={element.key} element={element} />)
+    }
+  }
+
+  return rscNodes
+}

--- a/packages/runtime/src/next/rsc/server/prerender-rsc-nodes.tsx
+++ b/packages/runtime/src/next/rsc/server/prerender-rsc-nodes.tsx
@@ -1,17 +1,22 @@
-import { getRuntime } from './runtime'
+import { getRuntime, setDocument } from './runtime'
 import { getComponentsMeta } from '../../../state/modules/components-meta'
-import { Element, getPropControllerDescriptors } from '../../../state/react-page'
+import { Document, getPropControllerDescriptors } from '../../../state/react-page'
 import { ServerElement } from './server-element'
 import { traverseElementTree } from '../../../state/modules/element-trees'
 import { RSCNodes } from '../client/rsc-nodes-provider'
+import { registerDocument } from '../../../state/shared-api'
 
-export function prerenderRSCNodes(elementTree: Element): RSCNodes {
+export function prerenderRSCNodes(document: Document): RSCNodes {
+  setDocument(document)
+
   const runtime = getRuntime()
+  runtime.store.dispatch(registerDocument(document))
   const state = runtime.store.getState()
+
   const descriptors = getPropControllerDescriptors(state)
   const rscNodes: RSCNodes = new Map()
 
-  for (const element of traverseElementTree(elementTree, descriptors)) {
+  for (const element of traverseElementTree(document.rootElement, descriptors)) {
     const meta = getComponentsMeta(state.componentsMeta).get(element.type)
 
     if (meta == null) {

--- a/packages/runtime/src/next/rsc/server/prerender-rsc-nodes.tsx
+++ b/packages/runtime/src/next/rsc/server/prerender-rsc-nodes.tsx
@@ -1,6 +1,6 @@
 import { getRuntime, setDocument } from './runtime'
 import { getComponentsMeta } from '../../../state/modules/components-meta'
-import { Document, getPropControllerDescriptors } from '../../../state/react-page'
+import { Document, getPropControllerDescriptors } from '../../../state/read-only-state'
 import { ServerElement } from './server-element'
 import { traverseElementTree } from '../../../state/modules/element-trees'
 import { RSCNodes } from '../client/rsc-nodes-provider'
@@ -10,8 +10,8 @@ export function prerenderRSCNodes(document: Document): RSCNodes {
   setDocument(document)
 
   const runtime = getRuntime()
-  runtime.store.dispatch(registerDocument(document))
-  const state = runtime.store.getState()
+  runtime.protoStore.dispatch(registerDocument(document))
+  const state = runtime.protoStore.getState()
 
   const descriptors = getPropControllerDescriptors(state)
   const rscNodes: RSCNodes = new Map()

--- a/packages/runtime/src/next/rsc/server/resolve-props.ts
+++ b/packages/runtime/src/next/rsc/server/resolve-props.ts
@@ -1,0 +1,42 @@
+import { ElementData, StyleDefinition } from '@makeswift/controls'
+import { getRuntime } from './runtime'
+import { getBreakpoints } from '../../../state/react-page'
+import { createCollectingServerStylesheet } from '../css/server-css'
+import { isLegacyDescriptor } from '../../../prop-controllers/descriptors'
+import { DescriptorsByProp } from '../../../state/modules/prop-controllers'
+import { mockResourceResolver } from './resource-resolver'
+
+export function resolveProps(
+  props: ElementData['props'],
+  propDescriptors: DescriptorsByProp,
+  elementKey: string,
+): Record<string, unknown> {
+  const runtime = getRuntime()
+  const state = runtime.store.getState()
+  const breakpoints = getBreakpoints(state)
+  const stylesheet = createCollectingServerStylesheet(breakpoints, elementKey)
+  const resolvedProps: Record<string, unknown> = {}
+
+  Object.entries(propDescriptors).forEach(([propName, descriptor]) => {
+    if (isLegacyDescriptor(descriptor)) {
+      console.warn(`[resolveProps] Cannot use legacy descriptor in RSC. Prop: ${propName}`)
+      return
+    }
+
+    const propData = props[propName]
+    const isStyleControl = descriptor.controlType === StyleDefinition.type
+
+    // Always process style controls, even when they have no data
+    if (propData !== undefined || isStyleControl) {
+      const resolvedValue = descriptor.resolveValue(
+        propData,
+        mockResourceResolver,
+        stylesheet.child(propName),
+      )
+      const result = resolvedValue.readStable()
+      resolvedProps[propName] = result
+    }
+  })
+
+  return resolvedProps
+}

--- a/packages/runtime/src/next/rsc/server/resolve-props.ts
+++ b/packages/runtime/src/next/rsc/server/resolve-props.ts
@@ -5,7 +5,7 @@ import {
   getRuntime,
   getSiteVersionFromCache,
 } from './runtime'
-import { getBreakpoints } from '../../../state/react-page'
+import { getBreakpoints } from '../../../state/read-only-state'
 import { createCollectingServerStylesheet } from '../css/server-css'
 import { isLegacyDescriptor } from '../../../prop-controllers/descriptors'
 import { DescriptorsByProp } from '../../../state/modules/prop-controllers'
@@ -20,7 +20,7 @@ export async function resolveProps(
   const document = getDocumentFromCache()
   const client = getMakeswiftClient()
 
-  const state = runtime.store.getState()
+  const state = runtime.protoStore.getState()
   const breakpoints = getBreakpoints(state)
   const stylesheet = createCollectingServerStylesheet(breakpoints, element.key)
 

--- a/packages/runtime/src/next/rsc/server/resource-resolver.ts
+++ b/packages/runtime/src/next/rsc/server/resource-resolver.ts
@@ -1,1 +1,73 @@
-export const mockResourceResolver = {} as any
+import { FetchableValue, ResourceResolver } from '@makeswift/controls'
+import { type SiteVersion } from '../../../api/site-version'
+import { ReactRuntimeCore } from '../../../runtimes/react/react-runtime-core'
+import { Document, getElementId } from '../../../state/react-page'
+import { MakeswiftClient } from '../../../client'
+
+function createFetchable<T>(
+  name: string,
+  fetcher: () => Promise<T | null>,
+): FetchableValue<T | null> {
+  let lastValue: T | null = null
+
+  return {
+    name,
+    subscribe: () => () => {},
+    readStable: () => lastValue,
+    fetch: async () => {
+      const res = await fetcher()
+      lastValue = res
+      return res
+    },
+  }
+}
+
+export function serverResourceResolver(
+  runtime: ReactRuntimeCore,
+  client: MakeswiftClient,
+  siteVersion: SiteVersion | null,
+  { key: documentKey, locale }: Document,
+): ResourceResolver {
+  const serverResourceResolver: ResourceResolver = {
+    resolveSwatch(swatchId: string | undefined) {
+      return createFetchable(`swatch:${swatchId}`, async () => {
+        if (!swatchId) return null
+        return client.getSwatch(swatchId, siteVersion)
+      })
+    },
+
+    resolveFile(fileId: string | undefined) {
+      return createFetchable(`file:${fileId}`, async () => {
+        if (!fileId) return null
+        return client.getFile(fileId)
+      })
+    },
+
+    resolveTypography(typographyId: string | undefined) {
+      return createFetchable(`typography:${typographyId}`, async () => {
+        if (!typographyId) return null
+        return client.getTypography(typographyId, siteVersion)
+      })
+    },
+
+    resolvePagePathnameSlice(pageId: string | undefined) {
+      return createFetchable(`pagePathnameSlice:${pageId}`, async () => {
+        if (!pageId) return null
+        return client.getPagePathnameSlice(pageId, siteVersion, {
+          locale: locale ?? undefined,
+        })
+      })
+    },
+
+    resolveElementId(elementKey: string) {
+      return {
+        name: `elementId:${documentKey}:${elementKey}`,
+        subscribe: () => () => {},
+        readStable: () => getElementId(runtime.store.getState(), documentKey, elementKey),
+        fetch: async () => null,
+      }
+    },
+  }
+
+  return serverResourceResolver
+}

--- a/packages/runtime/src/next/rsc/server/resource-resolver.ts
+++ b/packages/runtime/src/next/rsc/server/resource-resolver.ts
@@ -1,0 +1,1 @@
+export const mockResourceResolver = {} as any

--- a/packages/runtime/src/next/rsc/server/resource-resolver.ts
+++ b/packages/runtime/src/next/rsc/server/resource-resolver.ts
@@ -1,7 +1,7 @@
 import { FetchableValue, ResourceResolver } from '@makeswift/controls'
 import { type SiteVersion } from '../../../api/site-version'
 import { ReactRuntimeCore } from '../../../runtimes/react/react-runtime-core'
-import { Document, getElementId } from '../../../state/react-page'
+import { Document, getElementId } from '../../../state/read-only-state'
 import { MakeswiftClient } from '../../../client'
 
 function createFetchable<T>(
@@ -63,7 +63,7 @@ export function serverResourceResolver(
       return {
         name: `elementId:${documentKey}:${elementKey}`,
         subscribe: () => () => {},
-        readStable: () => getElementId(runtime.store.getState(), documentKey, elementKey),
+        readStable: () => getElementId(runtime.protoStore.getState(), documentKey, elementKey),
         fetch: async () => null,
       }
     },

--- a/packages/runtime/src/next/rsc/server/runtime.ts
+++ b/packages/runtime/src/next/rsc/server/runtime.ts
@@ -2,8 +2,12 @@ import 'server-only'
 
 import { cache } from 'react'
 import { ReactRuntime } from '../../../runtimes/react/react-runtime'
+import { SiteVersion } from '../../../unstable-framework-support'
 
 const getRuntimeCache = cache((): { runtime: ReactRuntime | null } => ({ runtime: null }))
+const getSiteVersionCache = cache((): { siteVersion: SiteVersion | null } => ({
+  siteVersion: null,
+}))
 
 export function setRuntime(runtime: ReactRuntime): void {
   const cache = getRuntimeCache()
@@ -17,4 +21,14 @@ export const getRuntime = (): ReactRuntime => {
     throw new Error('Makeswift context not found. Ensure your page uses `runWithMakeswiftContext`.')
   }
   return cache.runtime
+}
+
+export function setSiteVersion(siteVersion: SiteVersion | null): void {
+  const cache = getSiteVersionCache()
+  cache.siteVersion = siteVersion
+}
+
+export function getSiteVersionFromCache(): SiteVersion | null {
+  const cache = getSiteVersionCache()
+  return cache.siteVersion
 }

--- a/packages/runtime/src/next/rsc/server/runtime.ts
+++ b/packages/runtime/src/next/rsc/server/runtime.ts
@@ -2,12 +2,18 @@ import 'server-only'
 
 import { cache } from 'react'
 import { ReactRuntime } from '../../../runtimes/react/react-runtime'
-import { SiteVersion } from '../../../unstable-framework-support'
+import { MakeswiftClient, SiteVersion } from '../../../unstable-framework-support'
+import { Document } from '../../../state/react-page'
 
 const getRuntimeCache = cache((): { runtime: ReactRuntime | null } => ({ runtime: null }))
+
 const getSiteVersionCache = cache((): { siteVersion: SiteVersion | null } => ({
   siteVersion: null,
 }))
+
+const getDocumentCache = cache((): { document: Document | null } => ({ document: null }))
+
+const getMakeswiftClientCache = cache((): { client: MakeswiftClient | null } => ({ client: null }))
 
 export function setRuntime(runtime: ReactRuntime): void {
   const cache = getRuntimeCache()
@@ -21,6 +27,33 @@ export const getRuntime = (): ReactRuntime => {
     throw new Error('Makeswift context not found. Ensure your page uses `runWithMakeswiftContext`.')
   }
   return cache.runtime
+}
+
+export function getMakeswiftClient(): MakeswiftClient {
+  const cache = getMakeswiftClientCache()
+
+  if (!cache.client) {
+    throw new Error('Makeswift client not found in cache.')
+  }
+  return cache.client
+}
+
+export function getDocumentFromCache(): Document {
+  const cache = getDocumentCache()
+  if (!cache.document) {
+    throw new Error('Document not found in cache.')
+  }
+  return cache.document
+}
+
+export function setMakeswiftClient(client: MakeswiftClient): void {
+  const cache = getMakeswiftClientCache()
+  cache.client = client
+}
+
+export function setDocument(document: Document): void {
+  const cache = getDocumentCache()
+  cache.document = document
 }
 
 export function setSiteVersion(siteVersion: SiteVersion | null): void {

--- a/packages/runtime/src/next/rsc/server/runtime.ts
+++ b/packages/runtime/src/next/rsc/server/runtime.ts
@@ -1,0 +1,20 @@
+import 'server-only'
+
+import { cache } from 'react'
+import { ReactRuntime } from '../../../runtimes/react/react-runtime'
+
+const getRuntimeCache = cache((): { runtime: ReactRuntime | null } => ({ runtime: null }))
+
+export function setRuntime(runtime: ReactRuntime): void {
+  const cache = getRuntimeCache()
+  cache.runtime = runtime
+}
+
+export const getRuntime = (): ReactRuntime => {
+  const cache = getRuntimeCache()
+
+  if (!cache.runtime) {
+    throw new Error('Makeswift context not found. Ensure your page uses `runWithMakeswiftContext`.')
+  }
+  return cache.runtime
+}

--- a/packages/runtime/src/next/rsc/server/runtime.ts
+++ b/packages/runtime/src/next/rsc/server/runtime.ts
@@ -3,7 +3,7 @@ import 'server-only'
 import { cache } from 'react'
 import { ReactRuntime } from '../../../runtimes/react/react-runtime'
 import { MakeswiftClient, SiteVersion } from '../../../unstable-framework-support'
-import { Document } from '../../../state/react-page'
+import { Document } from '../../../state/read-only-state'
 
 const getRuntimeCache = cache((): { runtime: ReactRuntime | null } => ({ runtime: null }))
 

--- a/packages/runtime/src/next/rsc/server/server-element-data.tsx
+++ b/packages/runtime/src/next/rsc/server/server-element-data.tsx
@@ -1,6 +1,6 @@
 import {
   getReactComponent,
-  ElementData as ReactPageElementData,
+  ElementData,
   getComponentPropControllerDescriptors,
 } from '../../../state/react-page'
 import { FallbackComponent } from '../../../components/shared/FallbackComponent'
@@ -8,11 +8,11 @@ import { getRuntime } from './runtime'
 import { resolveProps } from './resolve-props'
 import { ReactNode } from 'react'
 
-type ElementDataProps = {
-  elementData: ReactPageElementData
+type Props = {
+  elementData: ElementData
 }
 
-export async function ServerElementData({ elementData }: ElementDataProps): Promise<ReactNode> {
+export async function ServerElementData({ elementData }: Props): Promise<ReactNode> {
   const state = getRuntime().store.getState()
   const Component = getReactComponent(state, elementData.type)
 
@@ -22,7 +22,7 @@ export async function ServerElementData({ elementData }: ElementDataProps): Prom
     return <FallbackComponent text={`Descriptors not found for ${elementData.type}`} />
   }
 
-  const props = resolveProps(elementData.props, descriptors, elementData.key)
+  const props = await resolveProps(elementData, descriptors)
 
   if (Component == null) {
     return <FallbackComponent text="Component not found" />

--- a/packages/runtime/src/next/rsc/server/server-element-data.tsx
+++ b/packages/runtime/src/next/rsc/server/server-element-data.tsx
@@ -1,0 +1,32 @@
+import {
+  getReactComponent,
+  ElementData as ReactPageElementData,
+  getComponentPropControllerDescriptors,
+} from '../../../state/react-page'
+import { FallbackComponent } from '../../../components/shared/FallbackComponent'
+import { getRuntime } from './runtime'
+import { resolveProps } from './resolve-props'
+import { ReactNode } from 'react'
+
+type ElementDataProps = {
+  elementData: ReactPageElementData
+}
+
+export async function ServerElementData({ elementData }: ElementDataProps): Promise<ReactNode> {
+  const state = getRuntime().store.getState()
+  const Component = getReactComponent(state, elementData.type)
+
+  let descriptors = getComponentPropControllerDescriptors(state, elementData.type)
+
+  if (descriptors == null) {
+    return <FallbackComponent text={`Descriptors not found for ${elementData.type}`} />
+  }
+
+  const props = resolveProps(elementData.props, descriptors, elementData.key)
+
+  if (Component == null) {
+    return <FallbackComponent text="Component not found" />
+  }
+
+  return <Component {...props} key={elementData.key} />
+}

--- a/packages/runtime/src/next/rsc/server/server-element-data.tsx
+++ b/packages/runtime/src/next/rsc/server/server-element-data.tsx
@@ -2,7 +2,7 @@ import {
   getReactComponent,
   ElementData,
   getComponentPropControllerDescriptors,
-} from '../../../state/react-page'
+} from '../../../state/read-only-state'
 import { FallbackComponent } from '../../../components/shared/FallbackComponent'
 import { getRuntime } from './runtime'
 import { resolveProps } from './resolve-props'
@@ -13,7 +13,7 @@ type Props = {
 }
 
 export async function ServerElementData({ elementData }: Props): Promise<ReactNode> {
-  const state = getRuntime().store.getState()
+  const state = getRuntime().protoStore.getState()
   const Component = getReactComponent(state, elementData.type)
 
   let descriptors = getComponentPropControllerDescriptors(state, elementData.type)

--- a/packages/runtime/src/next/rsc/server/server-element.tsx
+++ b/packages/runtime/src/next/rsc/server/server-element.tsx
@@ -1,0 +1,43 @@
+import { ReactNode } from 'react'
+import { isElementReference, type Element as ElementDataOrRef } from '../../../state/react-page'
+import { ServerElementData } from './server-element-data'
+import { getRuntime } from './runtime'
+import { Element } from '../../../runtimes/react'
+import { FallbackComponent } from '../../../components/shared/FallbackComponent'
+import { RSCBuilderUpdater } from '../client/rsc-builder-updater'
+
+type Props = {
+  element: ElementDataOrRef
+}
+
+export function ServerElement({ element }: Props): ReactNode {
+  const state = getRuntime().store.getState()
+  const elementMeta = state.componentsMeta.get(element.type)
+
+  if (elementMeta == null) {
+    return <FallbackComponent text="Component not found" />
+  }
+
+  const isRSC = elementMeta.server ?? false
+
+  if (!isRSC) {
+    return <Element key={element.key} element={element} />
+  }
+
+  if (isElementReference(element)) {
+    return <FallbackComponent text="Element reference is not supported on server yet" />
+  }
+
+  // TODO: Get this value from the context/props
+  const isPreview = true
+
+  if (isPreview) {
+    return (
+      <RSCBuilderUpdater initialElementData={element}>
+        <ServerElementData key={element.key} elementData={element} />
+      </RSCBuilderUpdater>
+    )
+  }
+
+  return <ServerElementData key={element.key} elementData={element} />
+}

--- a/packages/runtime/src/next/rsc/server/server-element.tsx
+++ b/packages/runtime/src/next/rsc/server/server-element.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react'
 import { isElementReference, type Element as ElementDataOrRef } from '../../../state/react-page'
 import { ServerElementData } from './server-element-data'
-import { getRuntime } from './runtime'
+import { getRuntime, getSiteVersionFromCache } from './runtime'
 import { Element } from '../../../runtimes/react'
 import { FallbackComponent } from '../../../components/shared/FallbackComponent'
 import { RSCBuilderUpdater } from '../client/rsc-builder-updater'
@@ -28,8 +28,8 @@ export function ServerElement({ element }: Props): ReactNode {
     return <FallbackComponent text="Element reference is not supported on server yet" />
   }
 
-  // TODO: Get this value from the context/props
-  const isPreview = true
+  const siteVersion = getSiteVersionFromCache()
+  const isPreview = siteVersion != null
 
   if (isPreview) {
     return (

--- a/packages/runtime/src/next/rsc/server/server-element.tsx
+++ b/packages/runtime/src/next/rsc/server/server-element.tsx
@@ -1,5 +1,8 @@
 import { ReactNode } from 'react'
-import { isElementReference, type Element as ElementDataOrRef } from '../../../state/react-page'
+import {
+  isElementReference,
+  type Element as ElementDataOrRef,
+} from '../../../state/read-only-state'
 import { ServerElementData } from './server-element-data'
 import { getRuntime, getSiteVersionFromCache } from './runtime'
 import { Element } from '../../../runtimes/react'
@@ -11,7 +14,7 @@ type Props = {
 }
 
 export function ServerElement({ element }: Props): ReactNode {
-  const state = getRuntime().store.getState()
+  const state = getRuntime().protoStore.getState()
   const elementMeta = state.componentsMeta.get(element.type)
 
   if (elementMeta == null) {

--- a/packages/runtime/src/next/rsc/server/server-provider.tsx
+++ b/packages/runtime/src/next/rsc/server/server-provider.tsx
@@ -1,13 +1,16 @@
+import { SiteVersion } from '../../../unstable-framework-support'
 import { NextRSCRuntime } from '../shared/react-runtime'
-import { setRuntime } from './runtime'
+import { setRuntime, setSiteVersion } from './runtime'
 
 type Props = {
   runtime: NextRSCRuntime
+  siteVersion: SiteVersion | null
   children: React.ReactNode
 }
 
-export function NextRSCServerProvider({ runtime, children }: Props) {
+export function NextRSCServerProvider({ runtime, siteVersion, children }: Props) {
   setRuntime(runtime)
+  setSiteVersion(siteVersion)
 
   return children
 }

--- a/packages/runtime/src/next/rsc/server/server-provider.tsx
+++ b/packages/runtime/src/next/rsc/server/server-provider.tsx
@@ -1,16 +1,21 @@
-import { SiteVersion } from '../../../unstable-framework-support'
+import { MakeswiftClient, SiteVersion } from '../../../unstable-framework-support'
 import { NextRSCRuntime } from '../shared/react-runtime'
-import { setRuntime, setSiteVersion } from './runtime'
+import { setMakeswiftClient, setRuntime, setSiteVersion } from './runtime'
 
+// TODO: Having client be part of the props for the provider is non-ideal.
+// However, attempting to pass it via the RSC Page component failed, with errors
+// related to not being able to pass a class
 type Props = {
   runtime: NextRSCRuntime
+  client: MakeswiftClient
   siteVersion: SiteVersion | null
   children: React.ReactNode
 }
 
-export function NextRSCServerProvider({ runtime, siteVersion, children }: Props) {
+export function NextRSCServerProvider({ runtime, siteVersion, children, client }: Props) {
   setRuntime(runtime)
   setSiteVersion(siteVersion)
+  setMakeswiftClient(client)
 
   return children
 }

--- a/packages/runtime/src/next/rsc/server/server-provider.tsx
+++ b/packages/runtime/src/next/rsc/server/server-provider.tsx
@@ -1,0 +1,13 @@
+import { NextRSCRuntime } from '../shared/react-runtime'
+import { setRuntime } from './runtime'
+
+type Props = {
+  runtime: NextRSCRuntime
+  children: React.ReactNode
+}
+
+export function NextRSCServerProvider({ runtime, children }: Props) {
+  setRuntime(runtime)
+
+  return children
+}

--- a/packages/runtime/src/next/rsc/shared/react-runtime.ts
+++ b/packages/runtime/src/next/rsc/shared/react-runtime.ts
@@ -1,0 +1,112 @@
+import { type ControlDefinition as UnifiedControlDefinition } from '@makeswift/controls'
+
+import { ReactRuntimeCore, validateComponentType } from '../../../runtimes/react/react-runtime-core'
+import {
+  type LegacyDescriptor,
+  type DescriptorValueType,
+} from '../../../prop-controllers/descriptors'
+import {
+  registerComponentEffect,
+  registerReactComponentEffect,
+} from '../../../state/actions/internal'
+import { ComponentIcon } from '../../../state/modules/components-meta'
+import type { ComponentType, Data, State } from '../../../state/react-page'
+import { deserializeControls, SerializedControl, serializeServerControls } from '../../../builder'
+import { PropControllerDescriptor } from '../../../state/modules/prop-controllers'
+import { registerBuiltinComponents } from '../../../components/builtin/register'
+
+export type SerializedServerState = {
+  componentsMeta: State['componentsMeta']
+  propControllers: Map<string, Record<string, SerializedControl<Data>>>
+}
+
+export class NextRSCRuntime extends ReactRuntimeCore {
+  constructor() {
+    super()
+    // todo: we may want to remove this
+    registerBuiltinComponents(this)
+  }
+
+  registerComponent<
+    ControlDef extends UnifiedControlDefinition,
+    P extends Record<string, LegacyDescriptor | ControlDef>,
+    C extends ComponentType<{ [K in keyof P]: DescriptorValueType<P[K]> }>,
+  >(
+    component: C,
+    {
+      type,
+      label,
+      icon = ComponentIcon.Cube,
+      hidden = false,
+      props,
+      description,
+      server = false,
+    }: {
+      type: string
+      label: string
+      icon?: ComponentIcon
+      hidden?: boolean
+      props?: P
+      description?: string
+      server?: boolean
+    },
+  ): () => void {
+    validateComponentType(type, component as unknown as ComponentType)
+
+    const unregisterComponent = this.store.dispatch(
+      registerComponentEffect(type, { label, icon, hidden, description, server }, props ?? {}),
+    )
+
+    const unregisterReactComponent = this.store.dispatch(
+      registerReactComponentEffect(type, component as unknown as ComponentType),
+    )
+
+    return () => {
+      unregisterComponent()
+      unregisterReactComponent()
+    }
+  }
+
+  serializeServerState(): SerializedServerState {
+    const componentsMeta = this.store.getState().componentsMeta
+    const propControllers = new Map(
+      Array.from(this.store.getState().propControllers.entries())
+        // Only serialize server components. Client components will be imported again on the client bundle.
+        .filter(([componentType]) => componentsMeta.get(componentType)?.server === true)
+        .map(([componentType, descriptors]) => {
+          const serializedControls = serializeServerControls(descriptors)
+          return [componentType, serializedControls] as const
+        }),
+    )
+
+    return {
+      componentsMeta: this.store.getState().componentsMeta,
+      propControllers: propControllers,
+    }
+  }
+
+  loadServerState(serializedState: SerializedServerState): void {
+    const deserializedPropControllers = Array.from(serializedState.propControllers.entries()).map(
+      ([componentType, serializedControls]) => {
+        const deserializedControls = deserializeControls(serializedControls) as Record<
+          string,
+          PropControllerDescriptor
+        >
+        return [componentType, deserializedControls] as const
+      },
+    )
+
+    for (const [componentType, propControllerDescriptors] of deserializedPropControllers) {
+      const componentMeta = serializedState.componentsMeta.get(componentType)
+
+      if (componentMeta == null) {
+        console.warn(`Component meta not found for ${componentType}`)
+        continue
+      }
+
+      this.store.dispatch(
+        registerComponentEffect(componentType, componentMeta, propControllerDescriptors),
+      )
+    }
+  }
+}

--- a/packages/runtime/src/next/rsc/shared/react-runtime.ts
+++ b/packages/runtime/src/next/rsc/shared/react-runtime.ts
@@ -8,12 +8,13 @@ import {
 import {
   registerComponentEffect,
   registerReactComponentEffect,
-} from '../../../state/actions/internal'
+} from '../../../state/actions/internal/read-only-actions'
 import { ComponentIcon } from '../../../state/modules/components-meta'
-import type { ComponentType, Data, State } from '../../../state/react-page'
+import type { ComponentType, Data, State } from '../../../state/read-only-state'
 import { deserializeControls, SerializedControl, serializeServerControls } from '../../../builder'
 import { PropControllerDescriptor } from '../../../state/modules/prop-controllers'
 import { registerBuiltinComponents } from '../../../components/builtin/register'
+import { supportsActivity } from '../../../runtimes/react/components/activity-with-fallback'
 
 export type SerializedServerState = {
   componentsMeta: State['componentsMeta']
@@ -21,9 +22,8 @@ export type SerializedServerState = {
 }
 
 export class NextRSCRuntime extends ReactRuntimeCore {
-  constructor() {
-    super()
-    // todo: we may want to remove this
+  constructor(...args: ConstructorParameters<typeof ReactRuntimeCore>) {
+    super(...args)
     registerBuiltinComponents(this)
   }
 
@@ -40,6 +40,7 @@ export class NextRSCRuntime extends ReactRuntimeCore {
       hidden = false,
       props,
       description,
+      builtinSuspense,
       server = false,
     }: {
       type: string
@@ -48,16 +49,28 @@ export class NextRSCRuntime extends ReactRuntimeCore {
       hidden?: boolean
       props?: P
       description?: string
+      /**
+       * In React <= 19.1, controls the default `<Suspense>` boundary.
+       * Ignored in React >= 19.2; components are always wrapped in `<Activity>`.
+       * Defaults to `true`.
+       */
+      builtinSuspense?: boolean
       server?: boolean
     },
   ): () => void {
     validateComponentType(type, component as unknown as ComponentType)
 
-    const unregisterComponent = this.store.dispatch(
+    const unregisterComponent = this.protoStore.dispatch(
       registerComponentEffect(type, { label, icon, hidden, description, server }, props ?? {}),
     )
 
-    const unregisterReactComponent = this.store.dispatch(
+    if (supportsActivity() && builtinSuspense !== undefined) {
+      console.warn(
+        'builtinSuspense is ignored in React >= 19.2; components are always wrapped in <Activity>.',
+      )
+    }
+
+    const unregisterReactComponent = this.protoStore.dispatch(
       registerReactComponentEffect(type, component as unknown as ComponentType),
     )
 
@@ -68,9 +81,9 @@ export class NextRSCRuntime extends ReactRuntimeCore {
   }
 
   serializeServerState(): SerializedServerState {
-    const componentsMeta = this.store.getState().componentsMeta
+    const componentsMeta = this.protoStore.getState().componentsMeta
     const propControllers = new Map(
-      Array.from(this.store.getState().propControllers.entries())
+      Array.from(this.protoStore.getState().propControllers.entries())
         // Only serialize server components. Client components will be imported again on the client bundle.
         .filter(([componentType]) => componentsMeta.get(componentType)?.server === true)
         .map(([componentType, descriptors]) => {
@@ -80,7 +93,7 @@ export class NextRSCRuntime extends ReactRuntimeCore {
     )
 
     return {
-      componentsMeta: this.store.getState().componentsMeta,
+      componentsMeta: this.protoStore.getState().componentsMeta,
       propControllers: propControllers,
     }
   }
@@ -104,7 +117,7 @@ export class NextRSCRuntime extends ReactRuntimeCore {
         continue
       }
 
-      this.store.dispatch(
+      this.protoStore.dispatch(
         registerComponentEffect(componentType, componentMeta, propControllerDescriptors),
       )
     }

--- a/packages/runtime/src/next/rsc/shared/react-runtime.ts
+++ b/packages/runtime/src/next/rsc/shared/react-runtime.ts
@@ -1,4 +1,7 @@
-import { type ControlDefinition as UnifiedControlDefinition } from '@makeswift/controls'
+import {
+  ControlDefinition,
+  type ControlDefinition as UnifiedControlDefinition,
+} from '@makeswift/controls'
 
 import { ReactRuntimeCore, validateComponentType } from '../../../runtimes/react/react-runtime-core'
 import {
@@ -10,15 +13,20 @@ import {
   registerReactComponentEffect,
 } from '../../../state/actions/internal/read-only-actions'
 import { ComponentIcon } from '../../../state/modules/components-meta'
-import type { ComponentType, Data, State } from '../../../state/read-only-state'
-import { deserializeControls, SerializedControl, serializeServerControls } from '../../../builder'
-import { PropControllerDescriptor } from '../../../state/modules/prop-controllers'
+import type { ComponentType, State } from '../../../state/read-only-state'
+import {
+  type SerializedRecord,
+  serializeRSCControls,
+  deserializeRSCControl,
+} from '../../../controls/serialization/rsc'
+import { deserializeControlRecords } from '../../../controls/serialization'
+import { type Descriptor, isLegacyDescriptor } from '../../../prop-controllers/descriptors'
 import { registerBuiltinComponents } from '../../../components/builtin/register'
 import { supportsActivity } from '../../../runtimes/react/components/activity-with-fallback'
 
 export type SerializedServerState = {
   componentsMeta: State['componentsMeta']
-  propControllers: Map<string, Record<string, SerializedControl<Data>>>
+  propControllers: Map<string, Record<string, SerializedRecord>>
 }
 
 export class NextRSCRuntime extends ReactRuntimeCore {
@@ -87,7 +95,8 @@ export class NextRSCRuntime extends ReactRuntimeCore {
         // Only serialize server components. Client components will be imported again on the client bundle.
         .filter(([componentType]) => componentsMeta.get(componentType)?.server === true)
         .map(([componentType, descriptors]) => {
-          const serializedControls = serializeServerControls(descriptors)
+          assertNoLegacyDescriptors(descriptors, componentType)
+          const serializedControls = serializeRSCControls(descriptors)
           return [componentType, serializedControls] as const
         }),
     )
@@ -101,10 +110,10 @@ export class NextRSCRuntime extends ReactRuntimeCore {
   loadServerState(serializedState: SerializedServerState): void {
     const deserializedPropControllers = Array.from(serializedState.propControllers.entries()).map(
       ([componentType, serializedControls]) => {
-        const deserializedControls = deserializeControls(serializedControls) as Record<
-          string,
-          PropControllerDescriptor
-        >
+        const deserializedControls = deserializeControlRecords(
+          serializedControls,
+          (serializedControl, options) => deserializeRSCControl(serializedControl, options),
+        )
         return [componentType, deserializedControls] as const
       },
     )
@@ -121,5 +130,20 @@ export class NextRSCRuntime extends ReactRuntimeCore {
         registerComponentEffect(componentType, componentMeta, propControllerDescriptors),
       )
     }
+  }
+}
+
+function assertNoLegacyDescriptors(
+  descriptors: Record<string, Descriptor>,
+  componentType: string,
+): asserts descriptors is Record<string, ControlDefinition> {
+  const propControllers = Object.entries(descriptors).filter(([_, desc]) =>
+    isLegacyDescriptor(desc),
+  )
+
+  if (propControllers.length > 0) {
+    throw Error(
+      `Legacy prop controllers are disallowed in server component registrations (${componentType} / ${[...propControllers.keys()].join(', ')})`,
+    )
   }
 }

--- a/packages/runtime/src/runtimes/react/components/Element.tsx
+++ b/packages/runtime/src/runtimes/react/components/Element.tsx
@@ -7,7 +7,7 @@ import {
 } from '../../../state/read-only-state'
 import { ElementRegistration } from './ElementRegistration'
 import { ElementReference } from './ElementReference'
-import { ElementData } from './ElementData'
+import { useFrameworkContext } from './hooks/use-framework-context'
 import { ElementImperativeHandle } from '../element-imperative-handle'
 import { FindDomNode } from '../find-dom-node'
 import { FallbackComponent } from '../../../components/shared/FallbackComponent'
@@ -24,6 +24,7 @@ export const Element = memo(
   ): ReactNode | null {
     const useFindDomNodeRef = useRef(true)
     const imperativeHandleRef = useRef(new ElementImperativeHandle())
+    const { ElementData } = useFrameworkContext()
 
     const findDomNodeCallbackRef = useCallback((current: (() => Element | Text | null) | null) => {
       if (useFindDomNodeRef.current === true) {

--- a/packages/runtime/src/runtimes/react/components/RuntimeProvider.tsx
+++ b/packages/runtime/src/runtimes/react/components/RuntimeProvider.tsx
@@ -10,6 +10,7 @@ import { StoreContext } from '../hooks/use-store'
 import { type ReactRuntimeCore } from '../react-runtime-core'
 
 import { PreviewSwitcher } from './preview-switcher/preview-switcher'
+import { useFrameworkContext } from './hooks/use-framework-context'
 
 export function RuntimeProvider({
   children,
@@ -24,11 +25,16 @@ export function RuntimeProvider({
 }) {
   const siteVersion = siteVersionProp ?? null
   const isPreview = siteVersion != null
+  const { previewStoreMiddlewares } = useFrameworkContext()
+  const middlewares = useMemo(
+    () => (siteVersion != null ? (previewStoreMiddlewares ?? []) : []),
+    [previewStoreMiddlewares, siteVersion],
+  )
 
   // see `getOrCreateStore` for the description of the stores' lifecycle
   const store = useMemo(
-    () => runtime.getOrCreateStore({ siteVersion, locale }),
-    [runtime, siteVersion, locale],
+    () => runtime.getOrCreateStore({ siteVersion, locale }, { middlewares }),
+    [runtime, siteVersion, locale, middlewares],
   )
 
   useEffect(() => {

--- a/packages/runtime/src/runtimes/react/components/framework-context.tsx
+++ b/packages/runtime/src/runtimes/react/components/framework-context.tsx
@@ -9,12 +9,15 @@ import {
   type RefAttributes,
   forwardRef,
 } from 'react'
+import { type Middleware } from '@reduxjs/toolkit'
 
 import { type LinkData } from '@makeswift/prop-controllers'
 
 import { type Snippet } from '../../../client'
+import { ElementData } from './ElementData'
 
 import { BaseHeadSnippet } from './page/HeadSnippet'
+import { type Dispatch, type State } from '../../../state/read-write-state'
 
 type HeadComponent = (props: { children: ReactNode }) => ReactNode
 type HeadSnippet = (props: { snippet: Snippet }) => ReactNode
@@ -36,11 +39,15 @@ type LinkProps = Omit<ComponentPropsWithoutRef<'a'>, 'onClick'> & {
 
 type LinkComponent = ForwardRefExoticComponent<RefAttributes<HTMLAnchorElement> & LinkProps>
 
+type ElementDataComponent = typeof ElementData
+
 export type FrameworkContext = {
   Head: HeadComponent
   HeadSnippet: HeadSnippet
   Image: ImageComponent
   Link: LinkComponent
+  ElementData: ElementDataComponent
+  previewStoreMiddlewares?: Middleware<Dispatch, State, Dispatch>[]
 }
 
 // React 19 automatically hoists metadata tags to the <head>
@@ -69,9 +76,12 @@ export const DefaultLink: LinkComponent = forwardRef<HTMLAnchorElement, LinkProp
   ({ linkType, ...props }, ref) => <a {...props} ref={ref} />,
 )
 
+export const DefaultElementData = ElementData
+
 export const FrameworkContext = createContext<FrameworkContext>({
   Head: DefaultHead,
   HeadSnippet: DefaultHeadSnippet,
   Image: DefaultImage,
   Link: DefaultLink,
+  ElementData: DefaultElementData,
 })

--- a/packages/runtime/src/runtimes/react/controls.tsx
+++ b/packages/runtime/src/runtimes/react/controls.tsx
@@ -17,7 +17,7 @@ type PropsValueProps = {
   children(props: Record<string, unknown>): ReactNode
 }
 
-function useControlDefs(
+export function useControlDefs(
   elementType: string,
 ): readonly [Record<string, LegacyDescriptor>, Record<string, ControlDefinition>] {
   const store = useStore()

--- a/packages/runtime/src/runtimes/react/hooks/use-component-meta.ts
+++ b/packages/runtime/src/runtimes/react/hooks/use-component-meta.ts
@@ -1,0 +1,6 @@
+import { ComponentMeta, getComponentsMeta } from '../../../state/modules/components-meta'
+import { useSelector } from './use-selector'
+
+export function useComponentMeta(type: string): ComponentMeta | null {
+  return useSelector(state => getComponentsMeta(state.componentsMeta).get(type) ?? null)
+}

--- a/packages/runtime/src/runtimes/react/hooks/use-is-in-builder.ts
+++ b/packages/runtime/src/runtimes/react/hooks/use-is-in-builder.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import { useStore } from './use-store'
 import { getIsInBuilder } from '../../../state/read-only-state'
 import { useSyncExternalStore } from 'react'

--- a/packages/runtime/src/runtimes/react/hooks/use-stylesheet-factory.ts
+++ b/packages/runtime/src/runtimes/react/hooks/use-stylesheet-factory.ts
@@ -1,5 +1,5 @@
 import { useMemo, useEffect, useRef } from 'react'
-import { type CSSObject, serializeStyles } from '@emotion/serialize'
+import { serializeStyles } from '@emotion/serialize'
 import { type EmotionCache } from '@emotion/cache'
 import { type SerializedStyles } from '@emotion/utils'
 
@@ -8,21 +8,16 @@ import {
   type Breakpoints,
   type Stylesheet,
   type ResolvedStyle,
-  type ResolvedStyleV2,
-  type ResolvedTypographyStyle,
   isNotNil,
-  getBaseBreakpoint,
-  getBreakpointMediaQuery,
 } from '@makeswift/controls'
 
 import { useCache } from '../root-style-registry'
-import { styleV1Css } from '../controls/style'
-import { typographyCss } from '../controls/typography'
 
 import { useBreakpoints } from './use-breakpoints'
 import { useCssId } from './use-css-id'
 import { useStyles, serializedStyleClassName } from '../use-style'
 import { pollBoxModel } from '../poll-box-model'
+import { resolvedStyleToCss } from '../resolve-style'
 
 export type StylesheetFactory = {
   get(propName: string): Stylesheet
@@ -88,40 +83,6 @@ export function useStylesheetFactory(): StylesheetFactory {
       },
     }
   }, [breakpoints, cache, componentUid])
-}
-
-function isTypographyStyle(style: ResolvedStyle): style is ResolvedTypographyStyle {
-  return Array.isArray(style)
-}
-
-function isStyleV2(style: ResolvedStyle): style is ResolvedStyleV2 {
-  return typeof style === 'object' && 'getStyle' in style && typeof style.getStyle === 'function'
-}
-
-function styleV2Css(breakpoints: Breakpoints, style: ResolvedStyleV2<CSSObject>): CSSObject {
-  return {
-    ...style.getStyle(getBaseBreakpoint(breakpoints)),
-    ...breakpoints.reduce(
-      (styles, breakpoint) => ({
-        ...styles,
-        [getBreakpointMediaQuery(breakpoint)]: style.getStyle(breakpoint),
-      }),
-      {},
-    ),
-  }
-}
-
-function resolvedStyleToCss(breakpoints: Breakpoints, style: ResolvedStyle) {
-  if (isTypographyStyle(style)) {
-    return typographyCss(breakpoints, style)
-  }
-
-  if (isStyleV2(style)) {
-    return styleV2Css(breakpoints, style as ResolvedStyleV2<CSSObject>)
-  }
-
-  const { properties, styleData } = style
-  return styleV1Css(breakpoints, styleData, properties)
 }
 
 function serializeStyle(

--- a/packages/runtime/src/runtimes/react/react-runtime-core.ts
+++ b/packages/runtime/src/runtimes/react/react-runtime-core.ts
@@ -14,7 +14,7 @@ import type { ComponentType } from '../../state/read-only-state'
 
 import { RuntimeCore } from './runtime-core'
 
-function validateComponentType(type: string, component?: ComponentType): void {
+export function validateComponentType(type: string, component?: ComponentType): void {
   const componentName = component?.name ?? 'Component'
   if (typeof type !== 'string' || type === '') {
     throw new Error(

--- a/packages/runtime/src/runtimes/react/resolve-style.ts
+++ b/packages/runtime/src/runtimes/react/resolve-style.ts
@@ -1,0 +1,47 @@
+import { type CSSObject } from '@emotion/serialize'
+
+import {
+  type Breakpoints,
+  ResolvedStyle,
+  type ResolvedStyleV2,
+  type ResolvedTypographyStyle,
+  getBaseBreakpoint,
+  getBreakpointMediaQuery,
+} from '@makeswift/controls'
+
+import { styleV1Css } from './controls/style'
+import { typographyCss } from './controls/typography'
+
+function isTypographyStyle(style: ResolvedStyle): style is ResolvedTypographyStyle {
+  return Array.isArray(style)
+}
+
+function isStyleV2(style: ResolvedStyle): style is ResolvedStyleV2 {
+  return typeof style === 'object' && 'getStyle' in style && typeof style.getStyle === 'function'
+}
+
+function styleV2Css(breakpoints: Breakpoints, style: ResolvedStyleV2<CSSObject>): CSSObject {
+  return {
+    ...style.getStyle(getBaseBreakpoint(breakpoints)),
+    ...breakpoints.reduce(
+      (styles, breakpoint) => ({
+        ...styles,
+        [getBreakpointMediaQuery(breakpoint)]: style.getStyle(breakpoint),
+      }),
+      {},
+    ),
+  }
+}
+
+export function resolvedStyleToCss(breakpoints: Breakpoints, style: ResolvedStyle): CSSObject {
+  if (isTypographyStyle(style)) {
+    return typographyCss(breakpoints, style)
+  }
+
+  if (isStyleV2(style)) {
+    return styleV2Css(breakpoints, style as ResolvedStyleV2<CSSObject>)
+  }
+
+  const { properties, styleData } = style
+  return styleV1Css(breakpoints, styleData, properties)
+}

--- a/packages/runtime/src/runtimes/react/runtime-core.ts
+++ b/packages/runtime/src/runtimes/react/runtime-core.ts
@@ -1,4 +1,5 @@
 import { type SerializableReplacementContext } from '@makeswift/controls'
+import { type Middleware } from '@reduxjs/toolkit'
 
 import { MakeswiftHostApiClient } from '../../api/client'
 import * as MakeswiftApiClient from '../../state/makeswift-api-client'
@@ -73,7 +74,10 @@ export class RuntimeCore {
     })
   }
 
-  getOrCreateStore({ siteVersion, locale }: StoreKey): Store {
+  getOrCreateStore(
+    { siteVersion, locale }: StoreKey,
+    { middlewares }: { middlewares?: Middleware[] },
+  ): Store {
     const key = storeCacheKey({ siteVersion, locale })
 
     const createStore = () => {
@@ -93,6 +97,7 @@ export class RuntimeCore {
         appOrigin: this.appOrigin,
         hostApiClient,
         preloadedState: { ...this.protoStore.getState(), siteVersion, isReadOnly, locale },
+        middlewares,
       })
     }
 

--- a/packages/runtime/src/state/modules/components-meta.ts
+++ b/packages/runtime/src/state/modules/components-meta.ts
@@ -34,6 +34,7 @@ export type ComponentMeta = {
   hidden: boolean
   description?: string
   builtinSuspense?: boolean
+  server?: boolean
 }
 
 export type State = Map<string, ComponentMeta>

--- a/packages/runtime/src/state/store.ts
+++ b/packages/runtime/src/state/store.ts
@@ -173,11 +173,13 @@ export function configureReadWriteStore({
   appOrigin,
   hostApiClient,
   preloadedState,
+  middlewares,
 }: {
   name: string
   appOrigin: string
   hostApiClient: MakeswiftHostApiClient
   preloadedState: Partial<State>
+  middlewares?: Middleware[]
 }) {
   const readWriteMiddlewareRef: ReadWriteMiddlewareRef = {
     current: null,
@@ -241,6 +243,7 @@ export function configureReadWriteStore({
     middleware: () => [
       makeswiftApiClientSyncMiddleware(hostApiClient),
       conditionalReadWriteMiddleware(readWriteMiddlewareRef),
+      ...(middlewares ?? []),
     ],
 
     enhancers: () =>

--- a/packages/runtime/src/unstable-framework-support/index.ts
+++ b/packages/runtime/src/unstable-framework-support/index.ts
@@ -24,6 +24,7 @@ export {
   DefaultHead,
   DefaultHeadSnippet,
   DefaultImage,
+  DefaultElementData,
 } from '../runtimes/react/components/framework-context'
 
 export { MakeswiftComponent } from '../runtimes/react/components/MakeswiftComponent'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,52 @@ importers:
         specifier: ^1.13.3
         version: 1.13.3
 
+  apps/next-rsc:
+    dependencies:
+      '@makeswift/runtime':
+        specifier: workspace:^
+        version: link:../../packages/runtime
+      next:
+        specifier: 15.5.0
+        version: 15.5.0(@playwright/test@1.41.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.7)(react@19.1.0)
+    devDependencies:
+      '@types/node':
+        specifier: ^20
+        version: 20.14.11
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.7
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.7)
+      autoprefixer:
+        specifier: ^10.0.1
+        version: 10.4.17(postcss@8.5.3)
+      eslint:
+        specifier: ^9.13.0
+        version: 9.13.0(jiti@2.4.2)
+      eslint-config-next:
+        specifier: 15.0.2
+        version: 15.0.2(eslint@9.13.0(jiti@2.4.2))(typescript@5.9.2)
+      postcss:
+        specifier: ^8
+        version: 8.5.3
+      tailwindcss:
+        specifier: ^3.3.0
+        version: 3.4.1(ts-node@10.9.2(@swc/core@1.7.0(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.9.2))
+      typescript:
+        specifier: ^5
+        version: 5.9.2
+
   apps/nextjs-app-router:
     dependencies:
       '@formatjs/intl-localematcher':
@@ -2203,6 +2249,9 @@ packages:
   '@next/env@15.0.7':
     resolution: {integrity: sha512-g/v9G2Xmv9T6w/DcRdcdVkLuAHnGt5fcJ3C33PmPrrdtUrwrjXcT4jXasdedSbw+koXa4YeEA3nPgy6q2wmk2A==}
 
+  '@next/env@15.5.0':
+    resolution: {integrity: sha512-sDaprBAfzCQiOgo2pO+LhnV0Wt2wBgartjrr+dpcTORYVnnXD0gwhHhiiyIih9hQbq+JnbqH4odgcFWhqCGidw==}
+
   '@next/env@15.5.9':
     resolution: {integrity: sha512-4GlTZ+EJM7WaW2HEZcyU317tIQDjkQIyENDLxYJfSWlfqguN+dHkZgyQTV/7ykvobU7yEH5gKvreNrH4B6QgIg==}
 
@@ -2220,6 +2269,12 @@ packages:
 
   '@next/swc-darwin-arm64@15.0.5':
     resolution: {integrity: sha512-BrNm/9BZoV6QEFKFZdgZRyYwhdhxV8GhW+U4D5cdkT4Wefj7YflAUZNx2FWyBPp7utBPCgJXnVbVLhlDoIfKFg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-arm64@15.5.0':
+    resolution: {integrity: sha512-v7Jj9iqC6enxIRBIScD/o0lH7QKvSxq2LM8UTyqJi+S2w2QzhMYjven4vgu/RzgsdtdbpkyCxBTzHl/gN5rTRg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -2242,6 +2297,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@next/swc-darwin-x64@15.5.0':
+    resolution: {integrity: sha512-s2Nk6ec+pmYmAb/utawuURy7uvyYKDk+TRE5aqLRsdnj3AhwC9IKUBmhfnLmY/+P+DnwqpeXEFIKe9tlG0p6CA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
   '@next/swc-darwin-x64@15.5.7':
     resolution: {integrity: sha512-UP6CaDBcqaCBuiq/gfCEJw7sPEoX1aIjZHnBWN9v9qYHQdMKvCKcAVs4OX1vIjeE+tC5EIuwDTVIoXpUes29lg==}
     engines: {node: '>= 10'}
@@ -2256,6 +2317,12 @@ packages:
 
   '@next/swc-linux-arm64-gnu@15.0.5':
     resolution: {integrity: sha512-nk+6BAIkIHTeQg+U1uqGpZ8K1KSAbhq80EkSgpgPC6wBmRkEeBitn4yL9C0fUiEPeZ3zN4yrvI635GG/H2QmSQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@next/swc-linux-arm64-gnu@15.5.0':
+    resolution: {integrity: sha512-mGlPJMZReU4yP5fSHjOxiTYvZmwPSWn/eF/dcg21pwfmiUCKS1amFvf1F1RkLHPIMPfocxLViNWFvkvDB14Isg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -2278,6 +2345,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@next/swc-linux-arm64-musl@15.5.0':
+    resolution: {integrity: sha512-biWqIOE17OW/6S34t1X8K/3vb1+svp5ji5QQT/IKR+VfM3B7GvlCwmz5XtlEan2ukOUf9tj2vJJBffaGH4fGRw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
   '@next/swc-linux-arm64-musl@15.5.7':
     resolution: {integrity: sha512-nfymt+SE5cvtTrG9u1wdoxBr9bVB7mtKTcj0ltRn6gkP/2Nu1zM5ei8rwP9qKQP0Y//umK+TtkKgNtfboBxRrw==}
     engines: {node: '>= 10'}
@@ -2292,6 +2365,12 @@ packages:
 
   '@next/swc-linux-x64-gnu@15.0.5':
     resolution: {integrity: sha512-VWfvl8toyC/5Rn1GgKfiASYgssCsxz4GtwK2cFKmmnyGfoKubFc6DfCI5MzBoe2Q2gzd2CeZDoT1BhuutSiL7A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@next/swc-linux-x64-gnu@15.5.0':
+    resolution: {integrity: sha512-zPisT+obYypM/l6EZ0yRkK3LEuoZqHaSoYKj+5jiD9ESHwdr6QhnabnNxYkdy34uCigNlWIaCbjFmQ8FY5AlxA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -2314,6 +2393,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@next/swc-linux-x64-musl@15.5.0':
+    resolution: {integrity: sha512-+t3+7GoU9IYmk+N+FHKBNFdahaReoAktdOpXHFIPOU1ixxtdge26NgQEEkJkCw2dHT9UwwK5zw4mAsURw4E8jA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
   '@next/swc-linux-x64-musl@15.5.7':
     resolution: {integrity: sha512-4IUO539b8FmF0odY6/SqANJdgwn1xs1GkPO5doZugwZ3ETF6JUdckk7RGmsfSf7ws8Qb2YB5It33mvNL/0acqA==}
     engines: {node: '>= 10'}
@@ -2328,6 +2413,12 @@ packages:
 
   '@next/swc-win32-arm64-msvc@15.0.5':
     resolution: {integrity: sha512-OmKXP/mUzY+AiDFk9PR3RoM6YfgzNYhtSbfvTUDk3PxoCLKnwTZ8xsFoWX2ph/RFC25QucTeAFepouGGsdBPAg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-arm64-msvc@15.5.0':
+    resolution: {integrity: sha512-d8MrXKh0A+c9DLiy1BUFwtg3Hu90Lucj3k6iKTUdPOv42Ve2UiIG8HYi3UAb8kFVluXxEfdpCoPPCSODk5fDcw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -2352,6 +2443,12 @@ packages:
 
   '@next/swc-win32-x64-msvc@15.0.5':
     resolution: {integrity: sha512-O34P9asvZtdNQ+4sEczSLruYvM7XEQKY/FCwRAeQQnrWW3tol3VEuv2GtnFb1YHsP3lZtagd11UYJqrs0Y0r2A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@15.5.0':
+    resolution: {integrity: sha512-Fe1tGHxOWEyQjmygWkkXSwhFcTJuimrNu52JEuwItrKJVV4iRjbWp9I7zZjwqtiNnQmxoEvoisn8wueFLrNpvQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -2843,6 +2940,9 @@ packages:
   '@types/cross-spawn@6.0.2':
     resolution: {integrity: sha512-KuwNhp3eza+Rhu8IFI5HUXRP0LIhqH5cAjubUvGXXthh4YYBuP2ntwEX+Cz8GJoZUHlKo247wPWOfA9LYEq4cw==}
 
+  '@types/debug@4.1.12':
+    resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
   '@types/detect-port@1.3.2':
     resolution: {integrity: sha512-xxgAGA2SAU4111QefXPSp5eGbDm/hW6zhvYl9IeEPZEry9F4d66QAHm5qpUXjb6IsevZV/7emAEx5MhP6O192g==}
 
@@ -2852,6 +2952,9 @@ packages:
 
   '@types/escape-html@1.0.2':
     resolution: {integrity: sha512-gaBLT8pdcexFztLSPRtriHeXY/Kn4907uOCZ4Q3lncFBkheAWOuNt53ypsF8szgxbEJ513UeBzcf4utN0EzEwA==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
@@ -2873,6 +2976,9 @@ packages:
 
   '@types/graceful-fs@4.1.5':
     resolution: {integrity: sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==}
+
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
@@ -2925,6 +3031,9 @@ packages:
   '@types/lodash@4.14.191':
     resolution: {integrity: sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==}
 
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
 
@@ -2933,6 +3042,9 @@ packages:
 
   '@types/minimist@1.2.5':
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/mute-stream@0.0.4':
     resolution: {integrity: sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==}
@@ -3003,6 +3115,12 @@ packages:
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@types/use-sync-external-store@1.5.0':
     resolution: {integrity: sha512-5dyB8nLC/qogMrlCizZnYWQTA4lnb/v+It+sqNl5YnSRAPMlIqY/X0Xn+gZw8vOL+TgTTr28VEbn3uf8fUtAkw==}
@@ -3480,6 +3598,9 @@ packages:
   backo2@1.0.2:
     resolution: {integrity: sha512-zj6Z6M7Eq+PBZ7PQxl5NT665MvJdAkzp0f60nAJ+sLaSCBPMwVak5ZegFbgVCzFcCJTKFoMizvM5Ld7+JrRJHA==}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -3619,6 +3740,9 @@ packages:
   capital-case@1.0.4:
     resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chalk@1.1.3:
     resolution: {integrity: sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==}
     engines: {node: '>=0.10.0'}
@@ -3647,6 +3771,18 @@ packages:
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
     engines: {node: '>=10'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
@@ -3755,6 +3891,9 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -4022,6 +4161,9 @@ packages:
   decimal.js@10.4.3:
     resolution: {integrity: sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==}
 
+  decode-named-character-reference@1.2.0:
+    resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
+
   decompress-response@3.3.0:
     resolution: {integrity: sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==}
     engines: {node: '>=4'}
@@ -4192,6 +4334,9 @@ packages:
   detective-typescript@9.1.1:
     resolution: {integrity: sha512-Uc1yVutTF0RRm1YJ3g//i1Cn2vx1kwHj15cnzQP6ff5koNzQ0idc1zAC73ryaWEulA0ElRXFTq6wOqe8vUQ3MA==}
     engines: {node: ^12.20.0 || ^14.14.0 || >=16.0.0}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
@@ -4612,6 +4757,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -4650,6 +4798,9 @@ packages:
   express@5.1.0:
     resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
     engines: {node: '>= 18'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
@@ -5091,6 +5242,12 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   header-case@2.0.4:
     resolution: {integrity: sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==}
 
@@ -5129,6 +5286,9 @@ packages:
   html-tokenize@2.0.1:
     resolution: {integrity: sha512-QY6S+hZ0f5m1WT8WffYN+Hg+xm/w5I8XeUcAq/ZYP5wVC8xbKi4Whhru3FtrAebD5EhBW8rmFzkDI6eCAuFe2w==}
     hasBin: true
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   htmlparser2@9.0.0:
     resolution: {integrity: sha512-uxbSI98wmFT/G4P2zXx4OVx04qWUmyFPrD2/CNepa2Zo3GPNaCaaxElDgwUrwYWkK1nr9fft0Ya8dws8coDLLQ==}
@@ -5267,6 +5427,12 @@ packages:
     resolution: {integrity: sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==}
     engines: {node: '>=0.10.0'}
 
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
   is-array-buffer@3.0.2:
     resolution: {integrity: sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==}
 
@@ -5321,6 +5487,9 @@ packages:
     resolution: {integrity: sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==}
     engines: {node: '>= 0.4'}
 
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
   is-docker@2.2.1:
     resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
     engines: {node: '>=8'}
@@ -5356,6 +5525,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
   is-hotkey@0.1.8:
     resolution: {integrity: sha512-qs3NZ1INIS+H+yeo7cD9pDfwYV/jqRh1JG9S9zYrNudkoUQg7OL7ziXqRKu+InFjUIDoP2o6HIkLYMh1pcWgyQ==}
@@ -5404,6 +5576,10 @@ packages:
   is-plain-obj@1.1.0:
     resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
     engines: {node: '>=0.10.0'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-plain-object@5.0.0:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
@@ -6084,6 +6260,9 @@ packages:
     resolution: {integrity: sha512-vlP11XfFGyeNQlmEn9tJ66rEW1coA/79m5z6BCkudjbAGE83uhAcGYrBFwfs3AdLiLzGRusRPAbSPK9xZteCmg==}
     engines: {node: '>=4'}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -6150,6 +6329,30 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-from-markdown@2.0.2:
+    resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.0:
+    resolution: {integrity: sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
@@ -6191,6 +6394,69 @@ packages:
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.5:
     resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
@@ -6375,6 +6641,28 @@ packages:
       babel-plugin-react-compiler: '*'
       react: ^18.2.0 || 19.0.0-rc-66855b96-20241106 || ^19.0.0
       react-dom: ^18.2.0 || 19.0.0-rc-66855b96-20241106 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
+  next@15.5.0:
+    resolution: {integrity: sha512-N1lp9Hatw3a9XLt0307lGB4uTKsXDhyOKQo7uYMzX4i0nF/c27grcGXkLdb7VcT8QPYLBa8ouIyEoUQJ2OyeNQ==}
+    engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/CVE-2025-66478 for more details.
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
       sass: ^1.3.0
     peerDependenciesMeta:
       '@opentelemetry/api':
@@ -6644,6 +6932,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   parse-filepath@1.0.2:
     resolution: {integrity: sha512-FwdRXKCohSVeXqwtYonZTXtbGJKrn+HNyWDYVcp5yuJlesTwNH4rsmRZ+GrKAPJ5bLpRxESMeS+Rl0VCHRvB2Q==}
     engines: {node: '>=0.8'}
@@ -6717,9 +7008,6 @@ packages:
 
   picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
-
-  picocolors@1.0.1:
-    resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -6893,6 +7181,9 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -6947,6 +7238,11 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-dom@19.1.0:
+    resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
+    peerDependencies:
+      react: ^19.1.0
+
   react-dom@19.2.3:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
     peerDependencies:
@@ -6966,6 +7262,12 @@ packages:
 
   react-is@18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
+
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
 
   react-player@2.16.1:
     resolution: {integrity: sha512-mxP6CqjSWjidtyDoMOSHVPdhX0pY16aSvw5fVr44EMaT7X5Xz46uQ4b/YBm1v2x+3hHkB9PmjEEkmbHb9PXQ4w==}
@@ -6987,6 +7289,10 @@ packages:
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.1.0:
+    resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
     engines: {node: '>=0.10.0'}
 
   react@19.2.3:
@@ -7063,6 +7369,12 @@ packages:
 
   relay-runtime@12.0.0:
     resolution: {integrity: sha512-QU6JKr1tMsry22DXNy9Whsq5rmvwr3LSZiiWV/9+DFpuTWvp+WFhobWMc8TC4OjKFfNhEZy7mOiqUAn5atQtug==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
 
   remedial@1.0.8:
     resolution: {integrity: sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg==}
@@ -7231,6 +7543,9 @@ packages:
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
+  scheduler@0.26.0:
+    resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -7250,6 +7565,11 @@ packages:
 
   semver@7.5.1:
     resolution: {integrity: sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.7.1:
+    resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -7418,6 +7738,9 @@ packages:
     engines: {node: '>= 8'}
     deprecated: The work that was done in this beta branch won't be included in future versions
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   spawn-command@0.0.2:
     resolution: {integrity: sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==}
 
@@ -7540,6 +7863,9 @@ packages:
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   stringify-object@3.3.0:
     resolution: {integrity: sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==}
@@ -7787,9 +8113,15 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
   trim-newlines@3.0.1:
     resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
     engines: {node: '>=8'}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
   ts-api-utils@1.0.3:
     resolution: {integrity: sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==}
@@ -8082,8 +8414,26 @@ packages:
     resolution: {integrity: sha512-JfjKqIauur3Q6biAtHJ564e3bWa8VvT+7cSiOJHFbX4Erv6CLGDpg8z+Fmg/1OI/47RA+GI2QZaF48SSaLvyBA==}
     engines: {node: '>=18.17'}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
   uniq@1.0.1:
     resolution: {integrity: sha512-Gw+zz50YNKPDKXs+9d+aKAjVwpjNwqzvNpLigIruT4HA9lMZNdMqs9x07kKHB/L9WRzqp4+DlTU5s4wG2esdoA==}
+
+  unist-util-is@6.0.0:
+    resolution: {integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.1:
+    resolution: {integrity: sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==}
+
+  unist-util-visit@5.0.0:
+    resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -8165,6 +8515,12 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   w3c-xmlserializer@4.0.0:
     resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}
@@ -8427,6 +8783,9 @@ packages:
   zod@3.21.4:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
 
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
 snapshots:
 
   '@aashutoshrathi/word-wrap@1.2.6': {}
@@ -8493,7 +8852,7 @@ snapshots:
   '@babel/code-frame@7.24.7':
     dependencies:
       '@babel/highlight': 7.24.7
-      picocolors: 1.0.1
+      picocolors: 1.1.1
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -9428,7 +9787,7 @@ snapshots:
       lodash.get: 4.4.2
       make-error: 1.3.6
       ts-node: 9.1.1(typescript@5.9.2)
-      tslib: 2.6.2
+      tslib: 2.8.1
     transitivePeerDependencies:
       - typescript
 
@@ -9863,7 +10222,7 @@ snapshots:
   '@graphql-tools/optimize@1.3.1(graphql@16.3.0)':
     dependencies:
       graphql: 16.3.0
-      tslib: 2.6.2
+      tslib: 2.8.1
 
   '@graphql-tools/prisma-loader@7.1.3(@types/node@20.14.11)(graphql@16.3.0)':
     dependencies:
@@ -9900,7 +10259,7 @@ snapshots:
       '@ardatan/relay-compiler': 12.0.0(graphql@16.3.0)
       '@graphql-tools/utils': 9.1.3(graphql@16.3.0)
       graphql: 16.3.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -9948,7 +10307,7 @@ snapshots:
   '@graphql-tools/utils@9.1.3(graphql@16.3.0)':
     dependencies:
       graphql: 16.3.0
-      tslib: 2.6.2
+      tslib: 2.8.1
 
   '@graphql-tools/wrap@8.4.6(graphql@16.3.0)':
     dependencies:
@@ -10645,6 +11004,8 @@ snapshots:
 
   '@next/env@15.0.7': {}
 
+  '@next/env@15.5.0': {}
+
   '@next/env@15.5.9': {}
 
   '@next/eslint-plugin-next@14.1.0':
@@ -10661,6 +11022,9 @@ snapshots:
   '@next/swc-darwin-arm64@15.0.5':
     optional: true
 
+  '@next/swc-darwin-arm64@15.5.0':
+    optional: true
+
   '@next/swc-darwin-arm64@15.5.7':
     optional: true
 
@@ -10668,6 +11032,9 @@ snapshots:
     optional: true
 
   '@next/swc-darwin-x64@15.0.5':
+    optional: true
+
+  '@next/swc-darwin-x64@15.5.0':
     optional: true
 
   '@next/swc-darwin-x64@15.5.7':
@@ -10679,6 +11046,9 @@ snapshots:
   '@next/swc-linux-arm64-gnu@15.0.5':
     optional: true
 
+  '@next/swc-linux-arm64-gnu@15.5.0':
+    optional: true
+
   '@next/swc-linux-arm64-gnu@15.5.7':
     optional: true
 
@@ -10686,6 +11056,9 @@ snapshots:
     optional: true
 
   '@next/swc-linux-arm64-musl@15.0.5':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@15.5.0':
     optional: true
 
   '@next/swc-linux-arm64-musl@15.5.7':
@@ -10697,6 +11070,9 @@ snapshots:
   '@next/swc-linux-x64-gnu@15.0.5':
     optional: true
 
+  '@next/swc-linux-x64-gnu@15.5.0':
+    optional: true
+
   '@next/swc-linux-x64-gnu@15.5.7':
     optional: true
 
@@ -10706,6 +11082,9 @@ snapshots:
   '@next/swc-linux-x64-musl@15.0.5':
     optional: true
 
+  '@next/swc-linux-x64-musl@15.5.0':
+    optional: true
+
   '@next/swc-linux-x64-musl@15.5.7':
     optional: true
 
@@ -10713,6 +11092,9 @@ snapshots:
     optional: true
 
   '@next/swc-win32-arm64-msvc@15.0.5':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@15.5.0':
     optional: true
 
   '@next/swc-win32-arm64-msvc@15.5.7':
@@ -10725,6 +11107,9 @@ snapshots:
     optional: true
 
   '@next/swc-win32-x64-msvc@15.0.5':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@15.5.0':
     optional: true
 
   '@next/swc-win32-x64-msvc@15.5.7':
@@ -11123,6 +11508,10 @@ snapshots:
     dependencies:
       '@types/node': 20.14.11
 
+  '@types/debug@4.1.12':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/detect-port@1.3.2': {}
 
   '@types/dotenv@8.2.3':
@@ -11130,6 +11519,10 @@ snapshots:
       dotenv: 17.2.3
 
   '@types/escape-html@1.0.2': {}
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.6
 
   '@types/estree@1.0.5': {}
 
@@ -11160,6 +11553,10 @@ snapshots:
   '@types/graceful-fs@4.1.5':
     dependencies:
       '@types/node': 20.14.11
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
 
   '@types/http-errors@2.0.5': {}
 
@@ -11219,11 +11616,17 @@ snapshots:
 
   '@types/lodash@4.14.191': {}
 
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/mime@1.3.5': {}
 
   '@types/minimatch@5.1.2': {}
 
   '@types/minimist@1.2.5': {}
+
+  '@types/ms@2.1.0': {}
 
   '@types/mute-stream@0.0.4':
     dependencies:
@@ -11294,6 +11697,10 @@ snapshots:
 
   '@types/tough-cookie@4.0.5': {}
 
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
+
   '@types/use-sync-external-store@1.5.0': {}
 
   '@types/uuid@9.0.1': {}
@@ -11334,6 +11741,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@8.12.0(@typescript-eslint/parser@6.20.0(eslint@9.13.0(jiti@2.4.2))(typescript@5.9.2))(eslint@9.13.0(jiti@2.4.2))(typescript@5.9.2)':
+    dependencies:
+      '@eslint-community/regexpp': 4.10.0
+      '@typescript-eslint/parser': 6.20.0(eslint@9.13.0(jiti@2.4.2))(typescript@5.9.2)
+      '@typescript-eslint/scope-manager': 8.12.0
+      '@typescript-eslint/type-utils': 8.12.0(eslint@9.13.0(jiti@2.4.2))(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.12.0(eslint@9.13.0(jiti@2.4.2))(typescript@5.9.2)
+      '@typescript-eslint/visitor-keys': 8.12.0
+      eslint: 9.13.0(jiti@2.4.2)
+      graphemer: 1.4.0
+      ignore: 5.3.2
+      natural-compare: 1.4.0
+      ts-api-utils: 1.3.0(typescript@5.9.2)
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6)':
     dependencies:
       '@typescript-eslint/scope-manager': 6.20.0
@@ -11360,6 +11785,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@6.20.0(eslint@9.13.0(jiti@2.4.2))(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 6.20.0
+      '@typescript-eslint/types': 6.20.0
+      '@typescript-eslint/typescript-estree': 6.20.0(typescript@5.9.2)
+      '@typescript-eslint/visitor-keys': 6.20.0
+      debug: 4.3.4
+      eslint: 9.13.0(jiti@2.4.2)
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@6.20.0':
     dependencies:
       '@typescript-eslint/types': 6.20.0
@@ -11378,6 +11816,18 @@ snapshots:
       ts-api-utils: 1.3.0(typescript@5.1.6)
     optionalDependencies:
       typescript: 5.1.6
+    transitivePeerDependencies:
+      - eslint
+      - supports-color
+
+  '@typescript-eslint/type-utils@8.12.0(eslint@9.13.0(jiti@2.4.2))(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/typescript-estree': 8.12.0(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.12.0(eslint@9.13.0(jiti@2.4.2))(typescript@5.9.2)
+      debug: 4.4.1
+      ts-api-utils: 1.3.0(typescript@5.9.2)
+    optionalDependencies:
+      typescript: 5.9.2
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -11426,10 +11876,25 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
-      semver: 7.7.2
+      semver: 7.7.1
       ts-api-utils: 1.0.3(typescript@5.1.6)
     optionalDependencies:
       typescript: 5.1.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@6.20.0(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/types': 6.20.0
+      '@typescript-eslint/visitor-keys': 6.20.0
+      debug: 4.4.1
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.3
+      semver: 7.7.1
+      ts-api-utils: 1.0.3(typescript@5.9.2)
+    optionalDependencies:
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
@@ -11448,12 +11913,38 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.12.0(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/types': 8.12.0
+      '@typescript-eslint/visitor-keys': 8.12.0
+      debug: 4.4.1
+      fast-glob: 3.3.2
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.2
+      ts-api-utils: 1.3.0(typescript@5.9.2)
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@8.12.0(eslint@9.13.0(jiti@2.4.2))(typescript@5.1.6)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@9.13.0(jiti@2.4.2))
       '@typescript-eslint/scope-manager': 8.12.0
       '@typescript-eslint/types': 8.12.0
       '@typescript-eslint/typescript-estree': 8.12.0(typescript@5.1.6)
+      eslint: 9.13.0(jiti@2.4.2)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@typescript-eslint/utils@8.12.0(eslint@9.13.0(jiti@2.4.2))(typescript@5.9.2)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.13.0(jiti@2.4.2))
+      '@typescript-eslint/scope-manager': 8.12.0
+      '@typescript-eslint/types': 8.12.0
+      '@typescript-eslint/typescript-estree': 8.12.0(typescript@5.9.2)
       eslint: 9.13.0(jiti@2.4.2)
     transitivePeerDependencies:
       - supports-color
@@ -11741,6 +12232,16 @@ snapshots:
       postcss: 8.4.33
       postcss-value-parser: 4.2.0
 
+  autoprefixer@10.4.17(postcss@8.5.3):
+    dependencies:
+      browserslist: 4.22.2
+      caniuse-lite: 1.0.30001580
+      fraction.js: 4.3.7
+      normalize-range: 0.1.2
+      picocolors: 1.0.0
+      postcss: 8.5.3
+      postcss-value-parser: 4.2.0
+
   available-typed-arrays@1.0.5: {}
 
   available-typed-arrays@1.0.7:
@@ -11920,6 +12421,8 @@ snapshots:
 
   backo2@1.0.2: {}
 
+  bail@2.0.2: {}
+
   balanced-match@1.0.2: {}
 
   base64-js@1.5.1: {}
@@ -12085,6 +12588,8 @@ snapshots:
       tslib: 2.8.1
       upper-case-first: 2.0.2
 
+  ccount@2.0.1: {}
+
   chalk@1.1.3:
     dependencies:
       ansi-styles: 2.2.1
@@ -12151,6 +12656,14 @@ snapshots:
       tslib: 2.8.1
 
   char-regex@1.0.2: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   chardet@0.7.0: {}
 
@@ -12264,6 +12777,8 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  comma-separated-tokens@2.0.3: {}
 
   commander@2.20.3: {}
 
@@ -12556,6 +13071,10 @@ snapshots:
 
   decimal.js@10.4.3: {}
 
+  decode-named-character-reference@1.2.0:
+    dependencies:
+      character-entities: 2.0.2
+
   decompress-response@3.3.0:
     dependencies:
       mimic-response: 1.0.1
@@ -12736,6 +13255,10 @@ snapshots:
       typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   didyoumean@1.2.2: {}
 
@@ -13110,6 +13633,25 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
+  eslint-config-next@15.0.2(eslint@9.13.0(jiti@2.4.2))(typescript@5.9.2):
+    dependencies:
+      '@next/eslint-plugin-next': 15.0.2
+      '@rushstack/eslint-patch': 1.10.4
+      '@typescript-eslint/eslint-plugin': 8.12.0(@typescript-eslint/parser@6.20.0(eslint@9.13.0(jiti@2.4.2))(typescript@5.9.2))(eslint@9.13.0(jiti@2.4.2))(typescript@5.9.2)
+      '@typescript-eslint/parser': 6.20.0(eslint@9.13.0(jiti@2.4.2))(typescript@5.9.2)
+      eslint: 9.13.0(jiti@2.4.2)
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.20.0(eslint@9.13.0(jiti@2.4.2))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.13.0(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.20.0(eslint@9.13.0(jiti@2.4.2))(typescript@5.9.2))(eslint-import-resolver-typescript@3.6.1)(eslint@9.13.0(jiti@2.4.2))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.13.0(jiti@2.4.2))
+      eslint-plugin-react: 7.37.2(eslint@9.13.0(jiti@2.4.2))
+      eslint-plugin-react-hooks: 5.0.0(eslint@9.13.0(jiti@2.4.2))
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - eslint-import-resolver-webpack
+      - supports-color
+
   eslint-import-resolver-node@0.3.9:
     dependencies:
       debug: 3.2.7
@@ -13152,6 +13694,23 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.20.0(eslint@9.13.0(jiti@2.4.2))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.13.0(jiti@2.4.2)):
+    dependencies:
+      debug: 4.3.5
+      enhanced-resolve: 5.14.1
+      eslint: 9.13.0(jiti@2.4.2)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.20.0(eslint@9.13.0(jiti@2.4.2))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.13.0(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.20.0(eslint@9.13.0(jiti@2.4.2))(typescript@5.9.2))(eslint-import-resolver-typescript@3.6.1)(eslint@9.13.0(jiti@2.4.2))
+      fast-glob: 3.3.2
+      get-tsconfig: 4.7.2
+      is-core-module: 2.15.1
+      is-glob: 4.0.3
+    transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - eslint-import-resolver-node
+      - eslint-import-resolver-webpack
+      - supports-color
+
   eslint-module-utils@2.12.0(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
     dependencies:
       debug: 3.2.7
@@ -13171,6 +13730,17 @@ snapshots:
       eslint: 9.13.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.20.0(eslint@9.13.0(jiti@2.4.2))(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.13.0(jiti@2.4.2))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.20.0(eslint@9.13.0(jiti@2.4.2))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.13.0(jiti@2.4.2)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 6.20.0(eslint@9.13.0(jiti@2.4.2))(typescript@5.9.2)
+      eslint: 9.13.0(jiti@2.4.2)
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.20.0(eslint@9.13.0(jiti@2.4.2))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.13.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -13236,6 +13806,35 @@ snapshots:
       tsconfig-paths: 3.15.0
     optionalDependencies:
       '@typescript-eslint/parser': 6.20.0(eslint@9.13.0(jiti@2.4.2))(typescript@5.1.6)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.20.0(eslint@9.13.0(jiti@2.4.2))(typescript@5.9.2))(eslint-import-resolver-typescript@3.6.1)(eslint@9.13.0(jiti@2.4.2)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.8
+      array.prototype.findlastindex: 1.2.5
+      array.prototype.flat: 1.3.2
+      array.prototype.flatmap: 1.3.2
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.13.0(jiti@2.4.2)
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.20.0(eslint@9.13.0(jiti@2.4.2))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.13.0(jiti@2.4.2))
+      hasown: 2.0.2
+      is-core-module: 2.15.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.0
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.8
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 6.20.0(eslint@9.13.0(jiti@2.4.2))(typescript@5.9.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -13455,6 +14054,8 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-util-is-identifier-name@3.0.0: {}
+
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
@@ -13526,6 +14127,8 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  extend@3.0.2: {}
 
   extendable-error@0.1.7: {}
 
@@ -13976,7 +14579,7 @@ snapshots:
   graphql-tag@2.12.6(graphql@16.3.0):
     dependencies:
       graphql: 16.3.0
-      tslib: 2.6.2
+      tslib: 2.8.1
 
   graphql-ws@5.6.3(graphql@16.3.0):
     dependencies:
@@ -14034,6 +14637,30 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.6
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.10
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   header-case@2.0.4:
     dependencies:
       capital-case: 1.0.4
@@ -14079,6 +14706,8 @@ snapshots:
       minimist: 1.2.8
       readable-stream: 1.0.34
       through2: 0.4.2
+
+  html-url-attributes@3.0.1: {}
 
   htmlparser2@9.0.0:
     dependencies:
@@ -14235,6 +14864,13 @@ snapshots:
       is-relative: 1.0.0
       is-windows: 1.0.2
 
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
   is-array-buffer@3.0.2:
     dependencies:
       call-bind: 1.0.7
@@ -14293,6 +14929,8 @@ snapshots:
     dependencies:
       has-tostringtag: 1.0.2
 
+  is-decimal@2.0.1: {}
+
   is-docker@2.2.1: {}
 
   is-extglob@2.1.1: {}
@@ -14318,6 +14956,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-hexadecimal@2.0.1: {}
 
   is-hotkey@0.1.8: {}
 
@@ -14350,6 +14990,8 @@ snapshots:
   is-path-inside@3.0.3: {}
 
   is-plain-obj@1.1.0: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-plain-object@5.0.0: {}
 
@@ -15554,6 +16196,8 @@ snapshots:
       cli-cursor: 2.1.0
       wrap-ansi: 3.0.1
 
+  longest-streak@3.1.0: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -15633,6 +16277,95 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  mdast-util-from-markdown@2.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.2.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.0
+
+  mdast-util-to-hast@13.2.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.2.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.0.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.0.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
   media-typer@0.3.0: {}
 
   media-typer@1.1.0: {}
@@ -15666,6 +16399,139 @@ snapshots:
       '@types/node': 20.14.11
 
   methods@1.1.2: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.2.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.2.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.12
+      debug: 4.4.1
+      decode-named-character-reference: 1.2.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   micromatch@4.0.5:
     dependencies:
@@ -15858,6 +16724,30 @@ snapshots:
       '@next/swc-win32-x64-msvc': 15.0.5
       '@playwright/test': 1.41.1
       sharp: 0.33.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  next@15.5.0(@playwright/test@1.41.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@next/env': 15.5.0
+      '@swc/helpers': 0.5.15
+      caniuse-lite: 1.0.30001642
+      postcss: 8.4.31
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      styled-jsx: 5.1.6(react@19.1.0)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 15.5.0
+      '@next/swc-darwin-x64': 15.5.0
+      '@next/swc-linux-arm64-gnu': 15.5.0
+      '@next/swc-linux-arm64-musl': 15.5.0
+      '@next/swc-linux-x64-gnu': 15.5.0
+      '@next/swc-linux-x64-musl': 15.5.0
+      '@next/swc-win32-arm64-msvc': 15.5.0
+      '@next/swc-win32-x64-msvc': 15.5.0
+      '@playwright/test': 1.41.1
+      sharp: 0.34.3
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -16143,6 +17033,16 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.2.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   parse-filepath@1.0.2:
     dependencies:
       is-absolute: 1.0.0
@@ -16208,8 +17108,6 @@ snapshots:
 
   picocolors@1.0.0: {}
 
-  picocolors@1.0.1: {}
-
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -16242,25 +17140,17 @@ snapshots:
 
   possible-typed-array-names@1.0.0: {}
 
-  postcss-import@15.1.0(postcss@8.4.33):
+  postcss-import@15.1.0(postcss@8.5.3):
     dependencies:
-      postcss: 8.4.33
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.8
 
-  postcss-js@4.0.1(postcss@8.4.33):
+  postcss-js@4.0.1(postcss@8.5.3):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.4.33
-
-  postcss-load-config@4.0.2(postcss@8.4.33)(ts-node@10.9.2(@swc/core@1.7.0(@swc/helpers@0.5.15))(@types/node@20.11.11)(typescript@5.1.6)):
-    dependencies:
-      lilconfig: 3.0.0
-      yaml: 2.3.4
-    optionalDependencies:
-      postcss: 8.4.33
-      ts-node: 10.9.2(@swc/core@1.7.0(@swc/helpers@0.5.15))(@types/node@20.11.11)(typescript@5.1.6)
+      postcss: 8.5.3
 
   postcss-load-config@4.0.2(postcss@8.5.3)(ts-node@10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.9.2)):
     dependencies:
@@ -16269,6 +17159,14 @@ snapshots:
     optionalDependencies:
       postcss: 8.5.3
       ts-node: 10.9.2(@swc/core@1.4.15(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.9.2)
+
+  postcss-load-config@4.0.2(postcss@8.5.3)(ts-node@10.9.2(@swc/core@1.7.0(@swc/helpers@0.5.15))(@types/node@20.11.11)(typescript@5.1.6)):
+    dependencies:
+      lilconfig: 3.0.0
+      yaml: 2.3.4
+    optionalDependencies:
+      postcss: 8.5.3
+      ts-node: 10.9.2(@swc/core@1.7.0(@swc/helpers@0.5.15))(@types/node@20.11.11)(typescript@5.1.6)
 
   postcss-load-config@4.0.2(postcss@8.5.3)(ts-node@10.9.2(@swc/core@1.7.0(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.1.6)):
     dependencies:
@@ -16286,9 +17184,9 @@ snapshots:
       postcss: 8.5.3
       ts-node: 10.9.2(@swc/core@1.7.0(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.9.2)
 
-  postcss-nested@6.0.1(postcss@8.4.33):
+  postcss-nested@6.0.1(postcss@8.5.3):
     dependencies:
-      postcss: 8.4.33
+      postcss: 8.5.3
       postcss-selector-parser: 6.0.15
 
   postcss-selector-parser@6.0.15:
@@ -16421,6 +17319,8 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  property-information@7.1.0: {}
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -16473,6 +17373,11 @@ snapshots:
       react: 19.2.3
       scheduler: 0.23.2
 
+  react-dom@19.1.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      scheduler: 0.26.0
+
   react-dom@19.2.3(react@19.2.3):
     dependencies:
       react: 19.2.3
@@ -16487,6 +17392,24 @@ snapshots:
   react-is@17.0.2: {}
 
   react-is@18.2.0: {}
+
+  react-markdown@10.1.0(@types/react@19.2.7)(react@19.1.0):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.7
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.0
+      react: 19.1.0
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.0.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   react-player@2.16.1(react@19.2.3):
     dependencies:
@@ -16510,6 +17433,8 @@ snapshots:
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
+
+  react@19.1.0: {}
 
   react@19.2.3: {}
 
@@ -16620,6 +17545,23 @@ snapshots:
       invariant: 2.2.4
     transitivePeerDependencies:
       - encoding
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.2
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.0
+      unified: 11.0.5
+      vfile: 6.0.3
 
   remedial@1.0.8: {}
 
@@ -16812,6 +17754,8 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  scheduler@0.26.0: {}
+
   scheduler@0.27.0: {}
 
   scroll-into-view-if-needed@2.2.29:
@@ -16827,6 +17771,8 @@ snapshots:
   semver@7.5.1:
     dependencies:
       lru-cache: 6.0.0
+
+  semver@7.7.1: {}
 
   semver@7.7.2: {}
 
@@ -17083,6 +18029,8 @@ snapshots:
     dependencies:
       whatwg-url: 7.1.0
 
+  space-separated-tokens@2.0.2: {}
+
   spawn-command@0.0.2: {}
 
   spawn-command@0.0.2-1: {}
@@ -17253,6 +18201,11 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   stringify-object@3.3.0:
     dependencies:
       get-own-enumerable-property-symbols: 3.0.2
@@ -17313,6 +18266,11 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.24.9
       babel-plugin-macros: 3.1.0
+
+  styled-jsx@5.1.6(react@19.1.0):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.1.0
 
   stylis@4.2.0: {}
 
@@ -17401,11 +18359,38 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.0.0
-      postcss: 8.4.33
-      postcss-import: 15.1.0(postcss@8.4.33)
-      postcss-js: 4.0.1(postcss@8.4.33)
-      postcss-load-config: 4.0.2(postcss@8.4.33)(ts-node@10.9.2(@swc/core@1.7.0(@swc/helpers@0.5.15))(@types/node@20.11.11)(typescript@5.1.6))
-      postcss-nested: 6.0.1(postcss@8.4.33)
+      postcss: 8.5.3
+      postcss-import: 15.1.0(postcss@8.5.3)
+      postcss-js: 4.0.1(postcss@8.5.3)
+      postcss-load-config: 4.0.2(postcss@8.5.3)(ts-node@10.9.2(@swc/core@1.7.0(@swc/helpers@0.5.15))(@types/node@20.11.11)(typescript@5.1.6))
+      postcss-nested: 6.0.1(postcss@8.5.3)
+      postcss-selector-parser: 6.0.15
+      resolve: 1.22.8
+      sucrase: 3.35.0
+    transitivePeerDependencies:
+      - ts-node
+
+  tailwindcss@3.4.1(ts-node@10.9.2(@swc/core@1.7.0(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.9.2)):
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      arg: 5.0.2
+      chokidar: 3.5.3
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.3.2
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      jiti: 1.21.0
+      lilconfig: 2.1.0
+      micromatch: 4.0.5
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.0.0
+      postcss: 8.5.3
+      postcss-import: 15.1.0(postcss@8.5.3)
+      postcss-js: 4.0.1(postcss@8.5.3)
+      postcss-load-config: 4.0.2(postcss@8.5.3)(ts-node@10.9.2(@swc/core@1.7.0(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.9.2))
+      postcss-nested: 6.0.1(postcss@8.5.3)
       postcss-selector-parser: 6.0.15
       resolve: 1.22.8
       sucrase: 3.35.0
@@ -17503,15 +18488,27 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
+  trim-lines@3.0.1: {}
+
   trim-newlines@3.0.1: {}
+
+  trough@2.2.0: {}
 
   ts-api-utils@1.0.3(typescript@5.1.6):
     dependencies:
       typescript: 5.1.6
 
+  ts-api-utils@1.0.3(typescript@5.9.2):
+    dependencies:
+      typescript: 5.9.2
+
   ts-api-utils@1.3.0(typescript@5.1.6):
     dependencies:
       typescript: 5.1.6
+
+  ts-api-utils@1.3.0(typescript@5.9.2):
+    dependencies:
+      typescript: 5.9.2
 
   ts-graphviz@1.7.0: {}
 
@@ -17894,7 +18891,40 @@ snapshots:
 
   undici@6.19.2: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
   uniq@1.0.1: {}
+
+  unist-util-is@6.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.0
+
+  unist-util-visit@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.0
+      unist-util-visit-parents: 6.0.1
 
   universalify@0.1.2: {}
 
@@ -17912,7 +18942,7 @@ snapshots:
     dependencies:
       browserslist: 4.22.2
       escalade: 3.1.1
-      picocolors: 1.0.1
+      picocolors: 1.1.1
 
   update-browserslist-db@1.1.0(browserslist@4.23.2):
     dependencies:
@@ -17968,6 +18998,16 @@ snapshots:
   value-or-promise@1.0.11: {}
 
   vary@1.1.2: {}
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   w3c-xmlserializer@4.0.0:
     dependencies:
@@ -18229,3 +19269,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zod@3.21.4: {}
+
+  zwitch@2.0.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/runtime
       next:
-        specifier: 15.5.0
-        version: 15.5.0(@playwright/test@1.41.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 15.5.15
+        version: 15.5.15(@playwright/test@1.41.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -2249,8 +2249,8 @@ packages:
   '@next/env@15.0.7':
     resolution: {integrity: sha512-g/v9G2Xmv9T6w/DcRdcdVkLuAHnGt5fcJ3C33PmPrrdtUrwrjXcT4jXasdedSbw+koXa4YeEA3nPgy6q2wmk2A==}
 
-  '@next/env@15.5.0':
-    resolution: {integrity: sha512-sDaprBAfzCQiOgo2pO+LhnV0Wt2wBgartjrr+dpcTORYVnnXD0gwhHhiiyIih9hQbq+JnbqH4odgcFWhqCGidw==}
+  '@next/env@15.5.15':
+    resolution: {integrity: sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==}
 
   '@next/env@15.5.9':
     resolution: {integrity: sha512-4GlTZ+EJM7WaW2HEZcyU317tIQDjkQIyENDLxYJfSWlfqguN+dHkZgyQTV/7ykvobU7yEH5gKvreNrH4B6QgIg==}
@@ -2273,8 +2273,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-arm64@15.5.0':
-    resolution: {integrity: sha512-v7Jj9iqC6enxIRBIScD/o0lH7QKvSxq2LM8UTyqJi+S2w2QzhMYjven4vgu/RzgsdtdbpkyCxBTzHl/gN5rTRg==}
+  '@next/swc-darwin-arm64@15.5.15':
+    resolution: {integrity: sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -2297,8 +2297,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.5.0':
-    resolution: {integrity: sha512-s2Nk6ec+pmYmAb/utawuURy7uvyYKDk+TRE5aqLRsdnj3AhwC9IKUBmhfnLmY/+P+DnwqpeXEFIKe9tlG0p6CA==}
+  '@next/swc-darwin-x64@15.5.15':
+    resolution: {integrity: sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -2321,8 +2321,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-gnu@15.5.0':
-    resolution: {integrity: sha512-mGlPJMZReU4yP5fSHjOxiTYvZmwPSWn/eF/dcg21pwfmiUCKS1amFvf1F1RkLHPIMPfocxLViNWFvkvDB14Isg==}
+  '@next/swc-linux-arm64-gnu@15.5.15':
+    resolution: {integrity: sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -2345,8 +2345,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@15.5.0':
-    resolution: {integrity: sha512-biWqIOE17OW/6S34t1X8K/3vb1+svp5ji5QQT/IKR+VfM3B7GvlCwmz5XtlEan2ukOUf9tj2vJJBffaGH4fGRw==}
+  '@next/swc-linux-arm64-musl@15.5.15':
+    resolution: {integrity: sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -2369,8 +2369,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@15.5.0':
-    resolution: {integrity: sha512-zPisT+obYypM/l6EZ0yRkK3LEuoZqHaSoYKj+5jiD9ESHwdr6QhnabnNxYkdy34uCigNlWIaCbjFmQ8FY5AlxA==}
+  '@next/swc-linux-x64-gnu@15.5.15':
+    resolution: {integrity: sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -2393,8 +2393,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@15.5.0':
-    resolution: {integrity: sha512-+t3+7GoU9IYmk+N+FHKBNFdahaReoAktdOpXHFIPOU1ixxtdge26NgQEEkJkCw2dHT9UwwK5zw4mAsURw4E8jA==}
+  '@next/swc-linux-x64-musl@15.5.15':
+    resolution: {integrity: sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -2417,8 +2417,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-arm64-msvc@15.5.0':
-    resolution: {integrity: sha512-d8MrXKh0A+c9DLiy1BUFwtg3Hu90Lucj3k6iKTUdPOv42Ve2UiIG8HYi3UAb8kFVluXxEfdpCoPPCSODk5fDcw==}
+  '@next/swc-win32-arm64-msvc@15.5.15':
+    resolution: {integrity: sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -2447,8 +2447,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.5.0':
-    resolution: {integrity: sha512-Fe1tGHxOWEyQjmygWkkXSwhFcTJuimrNu52JEuwItrKJVV4iRjbWp9I7zZjwqtiNnQmxoEvoisn8wueFLrNpvQ==}
+  '@next/swc-win32-x64-msvc@15.5.15':
+    resolution: {integrity: sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -6652,10 +6652,9 @@ packages:
       sass:
         optional: true
 
-  next@15.5.0:
-    resolution: {integrity: sha512-N1lp9Hatw3a9XLt0307lGB4uTKsXDhyOKQo7uYMzX4i0nF/c27grcGXkLdb7VcT8QPYLBa8ouIyEoUQJ2OyeNQ==}
+  next@15.5.15:
+    resolution: {integrity: sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
-    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/CVE-2025-66478 for more details.
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
@@ -11004,7 +11003,7 @@ snapshots:
 
   '@next/env@15.0.7': {}
 
-  '@next/env@15.5.0': {}
+  '@next/env@15.5.15': {}
 
   '@next/env@15.5.9': {}
 
@@ -11022,7 +11021,7 @@ snapshots:
   '@next/swc-darwin-arm64@15.0.5':
     optional: true
 
-  '@next/swc-darwin-arm64@15.5.0':
+  '@next/swc-darwin-arm64@15.5.15':
     optional: true
 
   '@next/swc-darwin-arm64@15.5.7':
@@ -11034,7 +11033,7 @@ snapshots:
   '@next/swc-darwin-x64@15.0.5':
     optional: true
 
-  '@next/swc-darwin-x64@15.5.0':
+  '@next/swc-darwin-x64@15.5.15':
     optional: true
 
   '@next/swc-darwin-x64@15.5.7':
@@ -11046,7 +11045,7 @@ snapshots:
   '@next/swc-linux-arm64-gnu@15.0.5':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.5.0':
+  '@next/swc-linux-arm64-gnu@15.5.15':
     optional: true
 
   '@next/swc-linux-arm64-gnu@15.5.7':
@@ -11058,7 +11057,7 @@ snapshots:
   '@next/swc-linux-arm64-musl@15.0.5':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.5.0':
+  '@next/swc-linux-arm64-musl@15.5.15':
     optional: true
 
   '@next/swc-linux-arm64-musl@15.5.7':
@@ -11070,7 +11069,7 @@ snapshots:
   '@next/swc-linux-x64-gnu@15.0.5':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.5.0':
+  '@next/swc-linux-x64-gnu@15.5.15':
     optional: true
 
   '@next/swc-linux-x64-gnu@15.5.7':
@@ -11082,7 +11081,7 @@ snapshots:
   '@next/swc-linux-x64-musl@15.0.5':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.5.0':
+  '@next/swc-linux-x64-musl@15.5.15':
     optional: true
 
   '@next/swc-linux-x64-musl@15.5.7':
@@ -11094,7 +11093,7 @@ snapshots:
   '@next/swc-win32-arm64-msvc@15.0.5':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.5.0':
+  '@next/swc-win32-arm64-msvc@15.5.15':
     optional: true
 
   '@next/swc-win32-arm64-msvc@15.5.7':
@@ -11109,7 +11108,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.0.5':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.5.0':
+  '@next/swc-win32-x64-msvc@15.5.15':
     optional: true
 
   '@next/swc-win32-x64-msvc@15.5.7':
@@ -16728,9 +16727,9 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@15.5.0(@playwright/test@1.41.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next@15.5.15(@playwright/test@1.41.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
-      '@next/env': 15.5.0
+      '@next/env': 15.5.15
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001642
       postcss: 8.4.31
@@ -16738,14 +16737,14 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
       styled-jsx: 5.1.6(react@19.1.0)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.5.0
-      '@next/swc-darwin-x64': 15.5.0
-      '@next/swc-linux-arm64-gnu': 15.5.0
-      '@next/swc-linux-arm64-musl': 15.5.0
-      '@next/swc-linux-x64-gnu': 15.5.0
-      '@next/swc-linux-x64-musl': 15.5.0
-      '@next/swc-win32-arm64-msvc': 15.5.0
-      '@next/swc-win32-x64-msvc': 15.5.0
+      '@next/swc-darwin-arm64': 15.5.15
+      '@next/swc-darwin-x64': 15.5.15
+      '@next/swc-linux-arm64-gnu': 15.5.15
+      '@next/swc-linux-arm64-musl': 15.5.15
+      '@next/swc-linux-x64-gnu': 15.5.15
+      '@next/swc-linux-x64-musl': 15.5.15
+      '@next/swc-win32-arm64-msvc': 15.5.15
+      '@next/swc-win32-x64-msvc': 15.5.15
       '@playwright/test': 1.41.1
       sharp: 0.34.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Demo


https://github.com/user-attachments/assets/ec1096eb-2bf6-40a7-909c-e53b1bb531e4




## Important Notes
- I try to minimize changes to the runtime core by isolating RSC-related code in its own entry points. This way, we can iterate on RSC quickly while ensuring the non-RSC path remains stable.
- Changes that affect runtime core are isolated on the first few commits.
- Currently the RSC support is tied to Next.js, this is why I put the entrypoint in `@makeswift/runtime/next/rsc`. Once we add RSC support to more framework, we should decouple the RSC core and framework-specific RSC implementation.
- The Next RSC package `packages/runtime/src/next/rsc` is still under heavy development and it's not production-ready yet. We want to merge this early so multiple people can collaborate on this and to unlock other initiative like Makeswift on Stencil.
- We’re planning another spike to explore what it would take to refactor the runtime from the ground up to be RSC-first. That said, this will be a longer journey. In the meantime, it’s nice to have incremental RSC support without having to refactor everything first.
- RSC-support can change everything, like how user register component, how user set up the `MakeswiftProvider`, and other things. This PR keeps most of the status quo, and focus on enabling users to register and edit RSCs.
- There are still quite a few bugs when using RSC. Again, the goal isn’t to deliver a completely bug-free experience, but to establish a foundation we can iterate on.

## RSC User Flow
- User imports experimental `ReactRuntime`, `MakeswiftPage`, `RuntimeProvider`, and `ServerProvider`, from `@makeswift/runtime/next/rsc`.
- User registers an RSC by adding `server: true` to `runtime.registerComponent`.
- If the registration includes a function, like `getOptions`, they need to add `use server` so we can serialize the functions from RSC to the client bundle.
- User creates two separate registrations files, `components.client` and `components.server`. User imports the clients and the server registration on the server provider, and import only the client registration on the client provider.
- Please refer to `next-rsc` to see an example on how to integrate RSCs.

## RSC Mechanism
- The runtime serializes server component registrations and pass that to the client. This is needed so we can show the correct overlays and controls when user is selecting an RSC.
- The runtime pre-renders all the RSCs before rendering any client components, then it'll pass the RSCs as a context to client components. If the client component has an RSC child, then it can return the RSC since the runtime already prerendered the RSC on the server. This relies on an important assumption that we can resolve RSC props ahead of time, before rendering any client components.
- The runtime has an RSC middleware that tracks all element tree changes, and calls `router.refresh()` when a user inserts an RSC.
- For `Style` control, on the server rendering, the runtime collects all the CSS, and inject them to the HTML. When it's on the builder, it'll listen to prop changes, and modify the `<style>` tag directly to avoid needing a server refresh when user is changing a style.
- For other controls, when user changes a property, the runtime will call `router.refresh()`.
