### PR TITLE
refactor: merge translatable data visitor

### DIFF
--- a/.changeset/wet-emus-perform.md
+++ b/.changeset/wet-emus-perform.md
@@ -1,0 +1,6 @@
+---
+"@makeswift/controls": patch
+"@makeswift/runtime": patch
+---
+
+Remove translatable data merging from controls in favor of visitor pattern

--- a/packages/controls/src/controls/checkbox/checkbox.ts
+++ b/packages/controls/src/controls/checkbox/checkbox.ts
@@ -17,6 +17,7 @@ import {
   type SchemaType,
 } from '../definition'
 import { DefaultControlInstance, type SendMessage } from '../instance'
+import { ControlDefinitionVisitor } from '../visitor'
 
 type Config = z.infer<typeof Definition.schema.relaxed.config>
 
@@ -178,6 +179,10 @@ class Definition<C extends Config> extends ControlDefinition<
       type: Definition.type,
       version: this.version,
     })
+  }
+
+  accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {
+    return visitor.visitCheckbox(this, ...args)
   }
 }
 

--- a/packages/controls/src/controls/color/color.ts
+++ b/packages/controls/src/controls/color/color.ts
@@ -25,6 +25,7 @@ import {
   type SchemaType,
 } from '../definition'
 import { DefaultControlInstance, type SendMessage } from '../instance'
+import { ControlDefinitionVisitor } from '../visitor'
 
 import { swatchToColorString } from './conversion'
 
@@ -270,6 +271,10 @@ class Definition<C extends Config> extends ControlDefinition<
       type: Definition.type,
       version: this.version,
     })
+  }
+
+  accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {
+    return visitor.visitColor(this, ...args)
   }
 }
 

--- a/packages/controls/src/controls/combobox/combobox.ts
+++ b/packages/controls/src/controls/combobox/combobox.ts
@@ -16,6 +16,7 @@ import {
   type SchemaType,
 } from '../definition'
 import { DefaultControlInstance, type SendMessage } from '../instance'
+import { ControlDefinitionVisitor } from '../visitor'
 
 type Option<T extends Data> = { id: string; value: T; label: string }
 type GetOptionsType<T extends Data> = (
@@ -140,6 +141,10 @@ class Definition<C extends Config> extends ControlDefinition<
     return serialize(this.config, {
       type: Definition.type,
     })
+  }
+
+  accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {
+    return visitor.visitCombobox(this, ...args)
   }
 }
 

--- a/packages/controls/src/controls/definition.ts
+++ b/packages/controls/src/controls/definition.ts
@@ -4,11 +4,7 @@ import { type ValueSubscription } from '../lib/value-subscription'
 import { type ParseResult } from '../lib/zod'
 
 import { type Data } from '../common/types'
-import {
-  type CopyContext,
-  type MergeContext,
-  type MergeTranslatableDataContext,
-} from '../context'
+import { type CopyContext, type MergeContext } from '../context'
 import { type IntrospectionTarget } from '../introspection'
 import { type ResourceResolver } from '../resources/resolver'
 import {
@@ -19,6 +15,7 @@ import {
 import { type Stylesheet } from '../stylesheet'
 
 import { ControlInstance, type SendMessage } from './instance'
+import { ControlDefinitionVisitor } from './visitor'
 
 export type SchemaType<T> = z.ZodType<T>
 export type SchemaTypeAny = SchemaType<any> | z.ZodBranded<SchemaType<any>, any>
@@ -83,14 +80,6 @@ export abstract class ControlDefinition<
     return null
   }
 
-  mergeTranslatedData(
-    data: DataType | undefined,
-    _translatedData: Data,
-    _context: MergeTranslatableDataContext,
-  ): Data {
-    return data as Data
-  }
-
   abstract resolveValue(
     data: DataType | undefined,
     resolver: ResourceResolver,
@@ -101,6 +90,11 @@ export abstract class ControlDefinition<
   abstract createInstance(sendMessage: SendMessage<any>): InstanceType
 
   abstract serialize(): [SerializedRecord, Transferable[]]
+
+  abstract accept<R>(
+    visitor: ControlDefinitionVisitor<R>,
+    ...args: unknown[]
+  ): R
 
   introspect<R>(
     data: DataType | undefined,

--- a/packages/controls/src/controls/font/font.ts
+++ b/packages/controls/src/controls/font/font.ts
@@ -16,6 +16,7 @@ import {
   type SchemaType,
 } from '../definition'
 import { DefaultControlInstance, type SendMessage } from '../instance'
+import { ControlDefinitionVisitor } from '../visitor'
 
 type Config = z.infer<
   | typeof Definition.schema.withVariants.relaxed.config
@@ -267,6 +268,10 @@ class Definition<C extends Config> extends ControlDefinition<
       type: Definition.type,
       version: this.version,
     })
+  }
+
+  accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {
+    return visitor.visitFont(this, ...args)
   }
 }
 

--- a/packages/controls/src/controls/group/group.test.ts
+++ b/packages/controls/src/controls/group/group.test.ts
@@ -1,3 +1,5 @@
+import { TestMergeTranslationsVisitor } from '../../testing/test-merge-translation-visitor'
+
 import { ControlDataTypeKey } from '../../common'
 import { createReplacementContext } from '../../context'
 import { Targets } from '../../introspection'
@@ -342,17 +344,13 @@ describe('Group', () => {
     test('getTranslatableData', () =>
       expect(group.getTranslatableData(data)).toMatchSnapshot())
 
-    test('mergeTranslatedData', () =>
-      expect(
-        group.mergeTranslatedData(
-          data,
-          {},
-          {
-            translatedData: {},
-            mergeTranslatedData: (node) => node,
-          },
-        ),
-      ).toMatchSnapshot())
+    test('mergeTranslatedData', () => {
+      const visitor = new TestMergeTranslationsVisitor({
+        translatedData: {},
+        mergeTranslatedData: (node) => node,
+      })
+      expect(group.accept(visitor, data, {})).toMatchSnapshot()
+    })
 
     test('introspect', () =>
       expect(group.introspect(data, Targets.ChildrenElement)).toStrictEqual([]))
@@ -403,17 +401,14 @@ describe('Group', () => {
     test('getTranslatableData', () =>
       expect(group.getTranslatableData(data)).toMatchSnapshot())
 
-    test('mergeTranslatedData', () =>
-      expect(
-        group.mergeTranslatedData(
-          data,
-          {},
-          {
-            translatedData: {},
-            mergeTranslatedData: (node) => node,
-          },
-        ),
-      ).toMatchSnapshot())
+    test('mergeTranslatedData', () => {
+      const visitor = new TestMergeTranslationsVisitor({
+        translatedData: {},
+        mergeTranslatedData: (node) => node,
+      })
+
+      expect(group.accept(visitor, data, {})).toMatchSnapshot()
+    })
 
     test('introspect', () =>
       expect(group.introspect(data, Targets.ChildrenElement)).toStrictEqual([]))

--- a/packages/controls/src/controls/icon-radio-group/icon-radio-group.ts
+++ b/packages/controls/src/controls/icon-radio-group/icon-radio-group.ts
@@ -16,6 +16,7 @@ import {
   type SchemaType,
 } from '../definition'
 import { DefaultControlInstance, type SendMessage } from '../instance'
+import { ControlDefinitionVisitor } from '../visitor'
 
 type IconType = (typeof Definition.Icon)[keyof typeof Definition.Icon]
 
@@ -194,6 +195,10 @@ class Definition<C extends Config> extends ControlDefinition<
       type: Definition.type,
     })
   }
+
+  accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {
+    return visitor.visitIconRadioGroup(this, ...args)
+  }
 }
 
 export class IconRadioGroupDefinition<
@@ -228,4 +233,7 @@ export function unstable_IconRadioGroup<
 
 unstable_IconRadioGroup.Icon = Definition.Icon
 
-export { type IconType as IconRadioGroupIcon }
+export {
+  type IconType as IconRadioGroupIcon,
+  type Config as IconRadioGroupConfig,
+}

--- a/packages/controls/src/controls/image/image.ts
+++ b/packages/controls/src/controls/image/image.ts
@@ -24,6 +24,7 @@ import {
   type SchemaType,
 } from '../definition'
 import { DefaultControlInstance, type SendMessage } from '../instance'
+import { ControlDefinitionVisitor } from '../visitor'
 
 type Config = z.infer<typeof Definition.schema.config>
 type DefaultConfig = Config & {
@@ -374,6 +375,10 @@ class Definition<C extends Config = DefaultConfig> extends ControlDefinition<
     })
   }
 
+  accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {
+    return visitor.visitImage(this, ...args)
+  }
+
   introspect<R>(
     data: DataType<C> | undefined,
     target: IntrospectionTarget<R>,
@@ -387,6 +392,8 @@ class Definition<C extends Config = DefaultConfig> extends ControlDefinition<
       .otherwise(() => []) as R[]
   }
 }
+
+export { type Config as ImageConfig }
 
 export class ImageDefinition<
   C extends Config = DefaultConfig,

--- a/packages/controls/src/controls/index.ts
+++ b/packages/controls/src/controls/index.ts
@@ -20,3 +20,5 @@ export * from './typography'
 export * from './associated-types'
 export * from './definition'
 export * from './instance'
+
+export * from './visitor'

--- a/packages/controls/src/controls/list/list.ts
+++ b/packages/controls/src/controls/list/list.ts
@@ -6,10 +6,7 @@ import { StableValue } from '../../lib/stable-value'
 import { safeParse, type ParseResult } from '../../lib/zod'
 
 import { type Data } from '../../common'
-import {
-  type CopyContext,
-  type MergeTranslatableDataContext,
-} from '../../context'
+import { type CopyContext } from '../../context'
 import { type IntrospectionTarget } from '../../introspection'
 import { type ResourceResolver } from '../../resources/resolver'
 import {
@@ -32,6 +29,7 @@ import {
   type SchemaTypeAny,
 } from '../definition'
 import { type SendMessage } from '../instance'
+import { ControlDefinitionVisitor } from '../visitor'
 
 import { ListControl } from './list-control'
 
@@ -180,24 +178,6 @@ class Definition<C extends Config> extends ControlDefinition<
     )
   }
 
-  mergeTranslatedData(
-    data: DataType<C> | undefined,
-    translatedData: Record<string, DataType<C>>,
-    context: MergeTranslatableDataContext,
-  ): Data {
-    if (data == null || translatedData == null) return data
-    return data.map((item) => {
-      return {
-        ...item,
-        value: this.itemDef.mergeTranslatedData(
-          item.value,
-          translatedData[item.id],
-          context,
-        ),
-      }
-    })
-  }
-
   resolveValue(
     data: DataType<C> | undefined,
     resolver: ResourceResolver,
@@ -252,6 +232,10 @@ class Definition<C extends Config> extends ControlDefinition<
     return (
       data?.flatMap((item) => this.itemDef.introspect(item.value, target)) ?? []
     )
+  }
+
+  accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {
+    return visitor.visitList(this, ...args)
   }
 }
 

--- a/packages/controls/src/controls/number/number.ts
+++ b/packages/controls/src/controls/number/number.ts
@@ -17,6 +17,7 @@ import {
   type SchemaType,
 } from '../definition'
 import { DefaultControlInstance, type SendMessage } from '../instance'
+import { ControlDefinitionVisitor } from '../visitor'
 
 type Config = z.infer<typeof Definition.schema.relaxed.config>
 
@@ -185,6 +186,10 @@ class Definition<C extends Config> extends ControlDefinition<
       type: Definition.type,
       version: this.version,
     })
+  }
+
+  accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {
+    return visitor.visitNumber(this, ...args)
   }
 }
 

--- a/packages/controls/src/controls/rich-text/v1/rich-text.ts
+++ b/packages/controls/src/controls/rich-text/v1/rich-text.ts
@@ -1,12 +1,14 @@
 import { Selection } from 'slate'
 import { z } from 'zod'
 
+import { safeParse, type ParseResult } from '../../../lib/zod'
+
 import { type CopyContext } from '../../../context'
 import { type IntrospectionTarget } from '../../../introspection'
-import { safeParse, type ParseResult } from '../../../lib/zod'
 import { type SerializedRecord } from '../../../serialization'
 import { ControlDefinition, serialize, type SchemaType } from '../../definition'
 import { ControlInstance } from '../../instance'
+import { ControlDefinitionVisitor } from '../../visitor'
 
 import {
   DTOSchema,
@@ -94,6 +96,10 @@ abstract class Definition<
     return serialize(this.config, {
       type: Definition.type,
     })
+  }
+
+  accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {
+    return visitor.visitRichTextV1(this, ...args)
   }
 
   introspect<R>(

--- a/packages/controls/src/controls/rich-text/v2/rich-text.ts
+++ b/packages/controls/src/controls/rich-text/v2/rich-text.ts
@@ -1,11 +1,13 @@
 import { v4 as uuid } from 'uuid'
 import { z } from 'zod'
 
+import { safeParse, type ParseResult } from '../../../lib/zod'
+
 import { type CopyContext } from '../../../context'
 import { type IntrospectionTarget } from '../../../introspection'
-import { safeParse, type ParseResult } from '../../../lib/zod'
 import { ControlDefinition, type SchemaType } from '../../definition'
 import { ControlInstance } from '../../instance'
+import { ControlDefinitionVisitor } from '../../visitor'
 
 import { DTOSchema, isRichTextDTO, richTextDTOtoDAO } from '../dto'
 import * as Slate from '../slate'
@@ -126,6 +128,10 @@ abstract class Definition<
 
     const nodes = Definition.dataToNodes(data)
     return introspectNodes(nodes, target, this.pluginControls)
+  }
+
+  accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {
+    return visitor.visitRichTextV2(this, ...args)
   }
 
   static isV1Data(data: DataType | undefined): data is DataV1Type {

--- a/packages/controls/src/controls/select/select.ts
+++ b/packages/controls/src/controls/select/select.ts
@@ -16,6 +16,7 @@ import {
   type SchemaType,
 } from '../definition'
 import { DefaultControlInstance, type SendMessage } from '../instance'
+import { ControlDefinitionVisitor } from '../visitor'
 
 type Option<T extends string> = { readonly value: T; readonly label: string }
 type OptionList<T extends string> = readonly [Option<T>, ...Option<T>[]]
@@ -169,6 +170,10 @@ class Definition<C extends Config> extends ControlDefinition<
       type: Definition.type,
     })
   }
+
+  accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {
+    return visitor.visitSelect(this, ...args)
+  }
 }
 
 export class SelectDefinition<
@@ -200,3 +205,4 @@ export function Select<
 ): SelectDefinition<NormedConfig<T, D>> {
   return new SelectDefinition(config as NormedConfig<T, D>)
 }
+export { type Config as SelectConfig }

--- a/packages/controls/src/controls/shape/v1/shape.test.ts
+++ b/packages/controls/src/controls/shape/v1/shape.test.ts
@@ -1,3 +1,5 @@
+import { TestMergeTranslationsVisitor } from '../../../testing/test-merge-translation-visitor'
+
 import { createReplacementContext } from '../../../context'
 import { Targets } from '../../../introspection'
 import {
@@ -236,17 +238,14 @@ describe('Shape', () => {
     test('getTranslatableData', () =>
       expect(shape.getTranslatableData(data)).toMatchSnapshot())
 
-    test('mergeTranslatedData', () =>
-      expect(
-        shape.mergeTranslatedData(
-          data,
-          {},
-          {
-            translatedData: {},
-            mergeTranslatedData: (node) => node,
-          },
-        ),
-      ).toMatchSnapshot())
+    test('mergeTranslatedData', () => {
+      const visitor = new TestMergeTranslationsVisitor({
+        translatedData: {},
+        mergeTranslatedData: (node) => node,
+      })
+
+      expect(shape.accept(visitor, data, {})).toMatchSnapshot()
+    })
 
     test('introspect', () =>
       expect(shape.introspect(data, Targets.ChildrenElement)).toStrictEqual([]))

--- a/packages/controls/src/controls/shape/v1/shape.ts
+++ b/packages/controls/src/controls/shape/v1/shape.ts
@@ -5,10 +5,7 @@ import { StableValue } from '../../../lib/stable-value'
 import { safeParse, type ParseResult } from '../../../lib/zod'
 
 import { type Data } from '../../../common'
-import {
-  type CopyContext,
-  type MergeTranslatableDataContext,
-} from '../../../context'
+import { type CopyContext } from '../../../context'
 import { type IntrospectionTarget } from '../../../introspection'
 import { type ResourceResolver } from '../../../resources/resolver'
 import {
@@ -29,6 +26,7 @@ import {
   type SchemaType,
 } from '../../definition'
 import { type SendMessage } from '../../instance'
+import { ControlDefinitionVisitor } from '../../visitor'
 
 import { ShapeControl } from './shape-control'
 
@@ -161,17 +159,6 @@ class Definition<C extends Config> extends ControlDefinition<
     })
   }
 
-  mergeTranslatedData(
-    data: DataType<C> | undefined,
-    translatedData: Record<string, DataType<C>>,
-    context: MergeTranslatableDataContext,
-  ): Data {
-    if (data == null || translatedData == null) return data
-    return mapValues(this.keyDefs, (def, key) =>
-      def.mergeTranslatedData(data[key], translatedData[key], context),
-    )
-  }
-
   resolveValue(
     data: DataType<C> | undefined,
     resolver: ResourceResolver,
@@ -221,6 +208,10 @@ class Definition<C extends Config> extends ControlDefinition<
     return Object.entries(this.keyDefs).flatMap(
       ([key, def]) => def.introspect(data[key], target) ?? [],
     )
+  }
+
+  accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {
+    return visitor.visitShape(this, ...args)
   }
 }
 

--- a/packages/controls/src/controls/style/v1/style.ts
+++ b/packages/controls/src/controls/style/v1/style.ts
@@ -28,6 +28,7 @@ import {
   type SchemaType,
 } from '../../definition'
 import { type SendMessage } from '../../instance'
+import { ControlDefinitionVisitor } from '../../visitor'
 
 import * as StyleSchema from './schema'
 import { StyleControl } from './style-control'
@@ -226,6 +227,10 @@ class Definition<C extends Config> extends ControlDefinition<
     return serialize(this.config, {
       type: Definition.type,
     })
+  }
+
+  accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {
+    return visitor.visitStyleV1(this, ...args)
   }
 
   introspect<R>(data: DataType<C> | undefined, target: IntrospectionTarget<R>) {

--- a/packages/controls/src/controls/style/v2/style-v2.ts
+++ b/packages/controls/src/controls/style/v2/style-v2.ts
@@ -28,6 +28,7 @@ import {
   type SchemaTypeAny,
 } from '../../definition'
 import { type SendMessage } from '../../instance'
+import { ControlDefinitionVisitor } from '../../visitor'
 
 import { StyleV2Control } from './style-v2-control'
 
@@ -204,6 +205,10 @@ class Definition<
     return serialize(this.config, {
       type: Definition.type,
     })
+  }
+
+  accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {
+    return visitor.visitStyleV2(this, ...args)
   }
 
   introspect<R>(

--- a/packages/controls/src/controls/text-area/text-area.test.ts
+++ b/packages/controls/src/controls/text-area/text-area.test.ts
@@ -1,4 +1,5 @@
 import { testDefinition, testResolveValue } from '../../testing/test-definition'
+import { TestMergeTranslationsVisitor } from '../../testing/test-merge-translation-visitor'
 
 import { ControlDataTypeKey } from '../../common'
 import { MergeTranslatableDataContext, TranslationDto } from '../../context'
@@ -63,6 +64,8 @@ describe('TextArea', () => {
       mergeTranslatedData: (el) => el,
     }
 
+    const visitor = new TestMergeTranslationsVisitor(mergeContext)
+
     const def = TextArea({ label: 'TextArea' })
 
     test('returns translated data when translated data is non-nullish', () => {
@@ -72,12 +75,8 @@ describe('TextArea', () => {
         value: 'Finding Nemo',
       }
 
-      expect(
-        def.mergeTranslatedData(dataV1, translationData, mergeContext),
-      ).toBe(translationData)
-      expect(
-        def.mergeTranslatedData(dataV0, translationData, mergeContext),
-      ).toBe(translationData)
+      expect(def.accept(visitor, dataV1, translationData)).toBe(translationData)
+      expect(def.accept(visitor, dataV0, translationData)).toBe(translationData)
     })
 
     test('returns data when translated data is nullish', () => {
@@ -87,10 +86,8 @@ describe('TextArea', () => {
         value: 'Finding Nemo',
       }
 
-      expect(def.mergeTranslatedData(dataV1, undefined, mergeContext)).toBe(
-        dataV1,
-      )
-      expect(def.mergeTranslatedData(dataV0, null, mergeContext)).toBe(dataV0)
+      expect(def.accept(visitor, dataV1, undefined)).toBe(dataV1)
+      expect(def.accept(visitor, dataV0, null)).toBe(dataV0)
     })
   })
 })

--- a/packages/controls/src/controls/text-area/text-area.ts
+++ b/packages/controls/src/controls/text-area/text-area.ts
@@ -4,10 +4,7 @@ import { z } from 'zod'
 import { safeParse, type ParseResult } from '../../lib/zod'
 
 import { ControlDataTypeKey, type Data } from '../../common'
-import {
-  type CopyContext,
-  type MergeTranslatableDataContext,
-} from '../../context'
+import { type CopyContext } from '../../context'
 import {
   type DeserializedRecord,
   type SerializedRecord,
@@ -20,6 +17,7 @@ import {
   type SchemaType,
 } from '../definition'
 import { DefaultControlInstance, type SendMessage } from '../instance'
+import { ControlDefinitionVisitor } from '../visitor'
 
 type Config = z.infer<typeof Definition.schema.relaxed.config>
 
@@ -167,15 +165,6 @@ class Definition<C extends Config> extends ControlDefinition<
     return data
   }
 
-  mergeTranslatedData(
-    data: DataType<C> | undefined,
-    translatedData: Data,
-    _context: MergeTranslatableDataContext,
-  ): Data {
-    if (data == null || translatedData == null) return data
-    return translatedData
-  }
-
   resolveValue(
     data: DataType<C> | undefined,
   ): Resolvable<ResolvedValueType<C> | undefined> {
@@ -196,6 +185,10 @@ class Definition<C extends Config> extends ControlDefinition<
       type: Definition.type,
       version: this.version,
     })
+  }
+
+  accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {
+    return visitor.visitTextArea(this, ...args)
   }
 }
 

--- a/packages/controls/src/controls/text-input/text-input.test.ts
+++ b/packages/controls/src/controls/text-input/text-input.test.ts
@@ -1,4 +1,5 @@
 import { testDefinition, testResolveValue } from '../../testing/test-definition'
+import { TestMergeTranslationsVisitor } from '../../testing/test-merge-translation-visitor'
 
 import { ControlDataTypeKey } from '../../common'
 import { MergeTranslatableDataContext, TranslationDto } from '../../context'
@@ -64,21 +65,19 @@ describe('TextInput', () => {
       mergeTranslatedData: (el) => el,
     }
 
+    const visitor = new TestMergeTranslationsVisitor(mergeContext)
+
     const def = TextInput({ label: 'TextInput' })
 
     test('returns translated data when translated data is non-nullish', () => {
       const dataV0 = 'cookie monster'
-      expect(
-        def.mergeTranslatedData(dataV0, translationData, mergeContext),
-      ).toBe(translationData)
+      expect(def.accept(visitor, dataV0, translationData)).toBe(translationData)
 
       const dataV1 = {
         [ControlDataTypeKey]: 'text-input::v1' as const,
         value: 'elmo',
       }
-      expect(
-        def.mergeTranslatedData(dataV1, translationData, mergeContext),
-      ).toBe(translationData)
+      expect(def.accept(visitor, dataV1, translationData)).toBe(translationData)
     })
 
     test('returns data when translated data is nullish', () => {
@@ -89,13 +88,8 @@ describe('TextInput', () => {
         value: 'elmo',
       }
 
-      expect(def.mergeTranslatedData(dataV0, undefined, mergeContext)).toBe(
-        dataV0,
-      )
-
-      expect(def.mergeTranslatedData(dataV1, undefined, mergeContext)).toBe(
-        dataV1,
-      )
+      expect(def.accept(visitor, dataV0, undefined)).toBe(dataV0)
+      expect(def.accept(visitor, dataV1, undefined)).toBe(dataV1)
     })
   })
 })

--- a/packages/controls/src/controls/text-input/text-input.ts
+++ b/packages/controls/src/controls/text-input/text-input.ts
@@ -4,10 +4,7 @@ import { z } from 'zod'
 import { safeParse, type ParseResult } from '../../lib/zod'
 
 import { ControlDataTypeKey, type Data } from '../../common'
-import {
-  type CopyContext,
-  type MergeTranslatableDataContext,
-} from '../../context'
+import { type CopyContext } from '../../context'
 import {
   type DeserializedRecord,
   type SerializedRecord,
@@ -20,6 +17,7 @@ import {
   type SchemaType,
 } from '../definition'
 import { DefaultControlInstance, type SendMessage } from '../instance'
+import { ControlDefinitionVisitor } from '../visitor'
 
 type Config = z.infer<typeof Definition.schema.relaxed.config>
 
@@ -167,15 +165,6 @@ class Definition<C extends Config> extends ControlDefinition<
     return data
   }
 
-  mergeTranslatedData(
-    data: DataType<C> | undefined,
-    translatedData: Data,
-    _context: MergeTranslatableDataContext,
-  ): Data {
-    if (data == null || translatedData == null) return data
-    return translatedData
-  }
-
   resolveValue(
     data: DataType<C> | undefined,
   ): Resolvable<ResolvedValueType<C> | undefined> {
@@ -196,6 +185,10 @@ class Definition<C extends Config> extends ControlDefinition<
       type: Definition.type,
       version: this.version,
     })
+  }
+
+  accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {
+    return visitor.visitTextInput(this, ...args)
   }
 }
 

--- a/packages/controls/src/controls/typography/typography.ts
+++ b/packages/controls/src/controls/typography/typography.ts
@@ -25,6 +25,7 @@ import { type Stylesheet } from '../../stylesheet'
 import { Color } from '../color'
 import { ControlDefinition, serialize, type Resolvable } from '../definition'
 import { DefaultControlInstance, type SendMessage } from '../instance'
+import { ControlDefinitionVisitor } from '../visitor'
 
 import * as Schema from './schema'
 import { mergeStyles, type ResolvedStyle } from './style'
@@ -243,6 +244,10 @@ class Definition extends ControlDefinition<
     return serialize(this.config, {
       type: Definition.type,
     })
+  }
+
+  accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {
+    return visitor.visitTypography(this, ...args)
   }
 
   introspect<R>(data: DataType | undefined, target: IntrospectionTarget<R>) {

--- a/packages/controls/src/controls/visitor/definition-visitor.ts
+++ b/packages/controls/src/controls/visitor/definition-visitor.ts
@@ -1,0 +1,78 @@
+import { CheckboxDefinition } from '../checkbox'
+import { ColorDefinition } from '../color'
+import { ComboboxDefinition } from '../combobox'
+import { ControlDefinition } from '../definition'
+import { FontDefinition } from '../font'
+import { GroupDefinition } from '../group'
+import {
+  IconRadioGroupConfig,
+  IconRadioGroupDefinition,
+} from '../icon-radio-group'
+import { ImageConfig, ImageDefinition } from '../image'
+import { LinkDefinition } from '../link'
+import { ListDefinition } from '../list'
+import { NumberDefinition } from '../number'
+import { RichTextDefinition, RichTextV1Definition } from '../rich-text'
+import { SelectConfig, SelectDefinition } from '../select'
+import { ShapeDefinition } from '../shape'
+import { SlotDefinition } from '../slot'
+import { StyleDefinition, StyleV2Definition } from '../style'
+import { TextAreaDefinition } from '../text-area'
+import { TextInputDefinition } from '../text-input'
+import { unstable_TypographyDefinition } from '../typography'
+
+abstract class ControlDefinitionVisitor<R> {
+  abstract visitCheckbox(def: CheckboxDefinition, ...args: unknown[]): R
+  abstract visitColor(def: ColorDefinition, ...args: unknown[]): R
+  abstract visitCombobox(def: ComboboxDefinition, ...args: unknown[]): R
+  abstract visitFont(def: FontDefinition, ...args: unknown[]): R
+  abstract visitGroup(def: GroupDefinition, ...args: unknown[]): R
+  abstract visitIconRadioGroup<C extends IconRadioGroupConfig>(
+    def: IconRadioGroupDefinition<C>,
+    ...args: unknown[]
+  ): R
+
+  abstract visitImage<C extends ImageConfig>(
+    def: ImageDefinition<C>,
+    ...args: unknown[]
+  ): R
+
+  abstract visitLink(def: LinkDefinition<any>, ...args: unknown[]): R
+  abstract visitList(def: ListDefinition, ...args: unknown[]): R
+  abstract visitNumber(def: NumberDefinition, ...args: unknown[]): R
+  abstract visitRichTextV1(
+    def: RichTextV1Definition<unknown, any>,
+    ...args: unknown[]
+  ): R
+
+  abstract visitRichTextV2(
+    def: RichTextDefinition<unknown, any>,
+    ...args: unknown[]
+  ): R
+
+  abstract visitSelect<C extends SelectConfig>(
+    def: SelectDefinition<C>,
+    ...args: unknown[]
+  ): R
+
+  abstract visitShape(def: ShapeDefinition, ...args: unknown[]): R
+  abstract visitSlot<RuntimeNode>(
+    def: SlotDefinition<RuntimeNode>,
+    ...args: unknown[]
+  ): R
+
+  abstract visitStyleV1(def: StyleDefinition, ...args: unknown[]): R
+  abstract visitStyleV2(
+    def: StyleV2Definition<ControlDefinition, unknown>,
+    ...args: unknown[]
+  ): R
+
+  abstract visitTextArea(def: TextAreaDefinition, ...args: unknown[]): R
+  abstract visitTextInput(def: TextInputDefinition, ...args: unknown[]): R
+  abstract visitTypography(
+    def: unstable_TypographyDefinition,
+    ...args: unknown[]
+  ): R
+}
+
+export { ControlDefinitionVisitor }

--- a/packages/controls/src/controls/visitor/index.ts
+++ b/packages/controls/src/controls/visitor/index.ts
@@ -1,0 +1,2 @@
+export { ControlDefinitionVisitor } from './definition-visitor'
+export { MergeTranslationsVisitor } from './merge-translations-visitor'

--- a/packages/controls/src/controls/visitor/merge-translations-visitor.ts
+++ b/packages/controls/src/controls/visitor/merge-translations-visitor.ts
@@ -1,0 +1,223 @@
+import { mapValues } from '../../lib/functional'
+
+import { Data } from '../../common'
+import { MergeTranslatableDataContext } from '../../context'
+
+import { DataType } from '../associated-types'
+import { CheckboxDefinition } from '../checkbox'
+import { ColorDefinition } from '../color'
+import { ComboboxDefinition } from '../combobox'
+import { ControlDefinition } from '../definition'
+import { FontDefinition } from '../font'
+import { GroupDefinition } from '../group'
+import {
+  IconRadioGroupConfig,
+  IconRadioGroupDefinition,
+} from '../icon-radio-group'
+import { ImageConfig, ImageDefinition } from '../image'
+import { LinkDefinition } from '../link'
+import { ListDefinition } from '../list'
+import { NumberDefinition } from '../number'
+import { RichTextV1Definition } from '../rich-text'
+import { SelectConfig, SelectDefinition } from '../select'
+import { ShapeDefinition } from '../shape'
+import { SlotDefinition } from '../slot'
+import { StyleDefinition, StyleV2Definition } from '../style'
+import { TextAreaDefinition } from '../text-area'
+import { TextInputDefinition } from '../text-input'
+import { unstable_TypographyDefinition } from '../typography'
+
+import { ControlDefinitionVisitor } from './definition-visitor'
+
+abstract class MergeTranslationsVisitor extends ControlDefinitionVisitor<Data> {
+  ctx: MergeTranslatableDataContext
+
+  constructor(ctx: MergeTranslatableDataContext) {
+    super()
+    this.ctx = ctx
+  }
+
+  private noOpMerge(data: Data, _translatedData: Data): Data {
+    return data
+  }
+
+  private defaultMerge(data: Data, translatedData: Data): Data {
+    if (data == null || translatedData == null) return data
+    return translatedData
+  }
+
+  visitCheckbox(
+    _def: CheckboxDefinition,
+    data: DataType<CheckboxDefinition> | undefined,
+    translatedData: Data,
+  ): Data {
+    return this.noOpMerge(data, translatedData)
+  }
+
+  visitColor(
+    _def: ColorDefinition,
+    data: DataType<ColorDefinition> | undefined,
+    translatedData: Data,
+  ): Data {
+    return this.noOpMerge(data, translatedData)
+  }
+
+  visitCombobox(
+    _def: ComboboxDefinition,
+    data: DataType<ComboboxDefinition> | undefined,
+    translatedData: Data,
+  ): Data {
+    return this.noOpMerge(data, translatedData)
+  }
+
+  visitFont(
+    _def: FontDefinition,
+    data: DataType<FontDefinition> | undefined,
+    translatedData: Data,
+  ): Data {
+    return this.noOpMerge(data, translatedData)
+  }
+
+  visitGroup(
+    def: GroupDefinition,
+    data: DataType<GroupDefinition> | undefined,
+    translatedData: Record<string, Data>,
+  ): Data {
+    if (data == null || translatedData == null) return data
+
+    const propsData = GroupDefinition.propsData(data)
+
+    return mapValues(def.propDefs, (def, key) =>
+      def.accept(this, propsData[key], translatedData[key]),
+    )
+  }
+
+  visitIconRadioGroup<C extends IconRadioGroupConfig>(
+    _def: IconRadioGroupDefinition<C>,
+    data: DataType<IconRadioGroupDefinition<C>> | undefined,
+    translatedData: Data,
+  ): Data {
+    return this.noOpMerge(data, translatedData)
+  }
+
+  visitImage<C extends ImageConfig>(
+    _def: ImageDefinition<C>,
+    data: DataType<ImageDefinition<C>> | undefined,
+    translatedData: Data,
+  ): Data {
+    return this.noOpMerge(data, translatedData)
+  }
+
+  visitLink(
+    _def: LinkDefinition,
+    data: DataType<LinkDefinition> | undefined,
+    translatedData: Data,
+  ): Data {
+    return this.defaultMerge(data, translatedData)
+  }
+
+  visitList(
+    def: ListDefinition,
+    data: DataType<ListDefinition> | undefined,
+    translatedData: Record<string, Data>,
+  ): Data {
+    if (data == null || translatedData == null) return data
+    return data.map((item) => {
+      return {
+        ...item,
+        value: def.itemDef.accept(this, item.value, translatedData[item.id]),
+      }
+    })
+  }
+
+  visitNumber(
+    _def: NumberDefinition,
+    data: DataType<NumberDefinition> | undefined,
+    translatedData: Data,
+  ): Data {
+    return this.noOpMerge(data, translatedData)
+  }
+
+  visitRichTextV1(
+    _def: RichTextV1Definition<unknown, any>,
+    data: DataType<RichTextV1Definition<unknown, any>> | undefined,
+    translatedData: Data,
+  ): Data {
+    return this.noOpMerge(data, translatedData)
+  }
+
+  visitSelect<C extends SelectConfig>(
+    _def: SelectDefinition<C>,
+    data: DataType<SelectDefinition<C>> | undefined,
+    translatedData: Data,
+  ): Data {
+    return this.noOpMerge(data, translatedData)
+  }
+
+  visitShape(
+    def: ShapeDefinition,
+    data: DataType<ShapeDefinition> | undefined,
+    translatedData: Record<string, Data>,
+  ): Data {
+    if (data == null || translatedData == null) return data
+    return mapValues(def.keyDefs, (def, key) =>
+      def.accept(this, data[key], translatedData[key]),
+    )
+  }
+
+  visitSlot<RuntimeNode>(
+    _def: SlotDefinition<RuntimeNode>,
+    data: DataType<SlotDefinition<RuntimeNode>> | undefined,
+    _translatedData: Data,
+  ): Data {
+    if (data == null) return data
+    return {
+      ...data,
+      elements: data.elements.map((element) =>
+        this.ctx.mergeTranslatedData(element),
+      ),
+    }
+  }
+
+  visitStyleV1(
+    _def: StyleDefinition,
+    data: DataType<StyleDefinition> | undefined,
+    translatedData: Data,
+  ): Data {
+    return this.noOpMerge(data, translatedData)
+  }
+
+  visitStyleV2(
+    _def: StyleV2Definition<ControlDefinition, unknown>,
+    data: DataType<StyleV2Definition<ControlDefinition, unknown>> | undefined,
+    translatedData: Data,
+  ): Data {
+    return this.noOpMerge(data, translatedData)
+  }
+
+  visitTextInput(
+    _def: TextInputDefinition,
+    data: DataType<TextInputDefinition> | undefined,
+    translatedData: Data,
+  ): Data {
+    return this.defaultMerge(data, translatedData)
+  }
+
+  visitTextArea(
+    _def: TextAreaDefinition,
+    data: DataType<TextAreaDefinition> | undefined,
+    translatedData: Data,
+  ): Data {
+    return this.defaultMerge(data, translatedData)
+  }
+
+  visitTypography(
+    _def: unstable_TypographyDefinition,
+    data: DataType<unstable_TypographyDefinition> | undefined,
+    translatedData: Data,
+  ): Data {
+    return this.noOpMerge(data, translatedData)
+  }
+}
+
+export { MergeTranslationsVisitor }

--- a/packages/controls/src/testing/test-merge-translation-visitor.ts
+++ b/packages/controls/src/testing/test-merge-translation-visitor.ts
@@ -1,0 +1,10 @@
+import { MergeTranslationsVisitor } from '../controls'
+
+export class TestMergeTranslationsVisitor extends MergeTranslationsVisitor {
+  visitRichTextV2() {
+    console.error(
+      '`visitRichTextV2` not implemented for TestMergeTranslationsVisitor',
+    )
+    return null
+  }
+}

--- a/packages/runtime/src/controls/control.ts
+++ b/packages/runtime/src/controls/control.ts
@@ -15,6 +15,7 @@ import {
 import { Descriptor, isLegacyDescriptor } from '../prop-controllers/descriptors'
 import { copy as propControllerCopy } from '../prop-controllers/copy'
 import { DELETED_PROP_CONTROLLER_TYPES, PropControllerDescriptor } from '../prop-controllers'
+import { ReactMergeTranslationsVisitor } from './visitors/merge-translations-visitor'
 
 export function copy(definition: Descriptor, value: any, context: CopyContext) {
   if (!isLegacyDescriptor(definition)) {
@@ -83,7 +84,8 @@ export function mergeTranslatedData(
 ): Data {
   if (data == null) return data
   if (!isLegacyDescriptor(definition)) {
-    return definition.mergeTranslatedData(data, translatedData, context)
+    const mergeTranslationsVisitor = new ReactMergeTranslationsVisitor(context)
+    return definition.accept(mergeTranslationsVisitor, data, translatedData)
   }
 
   switch (definition.type) {

--- a/packages/runtime/src/controls/rich-text-v2/__tests__/translation.test.ts
+++ b/packages/runtime/src/controls/rich-text-v2/__tests__/translation.test.ts
@@ -4,6 +4,7 @@ import { RichText } from '../rich-text-v2'
 import * as Simple from './fixtures/simple'
 import * as SubSupCode from './fixtures/rearranged'
 import * as NestedParagraphEdgeCase from './fixtures/nested-paragraph-edge-case-3728'
+import { ReactMergeTranslationsVisitor } from '../../visitors/merge-translations-visitor'
 
 describe('GIVEN merging translations for RichTextV2', () => {
   const mergeContext: MergeTranslatableDataContext = {
@@ -11,21 +12,19 @@ describe('GIVEN merging translations for RichTextV2', () => {
     mergeTranslatedData: element => element,
   }
 
+  const visitor = new ReactMergeTranslationsVisitor(mergeContext)
+
   test('WHEN merging simple strings THEN correct string is returned', () => {
-    const result = RichText().mergeTranslatedData(
-      Simple.sourceElementTree,
-      Simple.translatedData,
-      mergeContext,
-    )
+    const result = RichText().accept(visitor, Simple.sourceElementTree, Simple.translatedData)
 
     expect(result).toEqual(Simple.targetElementTree)
   })
 
   test('WHEN merging rearranged strings THEN correct string is returned', () => {
-    const result = RichText().mergeTranslatedData(
+    const result = RichText().accept(
+      visitor,
       SubSupCode.sourceElementTree,
       SubSupCode.translatedData,
-      mergeContext,
     )
 
     expect(result).toEqual(SubSupCode.targetElementTree)

--- a/packages/runtime/src/controls/rich-text-v2/rich-text-v2.ts
+++ b/packages/runtime/src/controls/rich-text-v2/rich-text-v2.ts
@@ -17,7 +17,6 @@ import {
   type DeserializedRecord,
   type SchemaType,
   type SchemaTypeAny,
-  type MergeTranslatableDataContext,
   type RichTextPluginControl,
   type ResourceResolver,
   type Stylesheet,
@@ -36,11 +35,7 @@ import { renderRichTextV2 } from '../../runtimes/react/controls/rich-text-v2'
 
 import { RichTextV2Plugin, Plugin } from './plugin'
 import { RichTextV2Control } from './control'
-import {
-  getTranslatableData,
-  mergeTranslatedNodes,
-  type RichTextTranslationDto,
-} from './translation'
+import { getTranslatableData } from './translations/get-translations'
 
 type DataType = z.infer<typeof Definition.schema.data>
 type DataV2Type = z.infer<typeof Definition.schema.dataV2>
@@ -145,24 +140,6 @@ class Definition extends BaseRichTextDefinition<ReactNode, Config, InstanceType>
   getTranslatableData(data: DataType | undefined): Data {
     if (data == null) return null
     return getTranslatableData(Definition.dataToNodes(data), this.config.plugins)
-  }
-
-  mergeTranslatedData(
-    data: DataType | undefined,
-    translatedData: Data,
-    _context: MergeTranslatableDataContext,
-  ): Data {
-    if (data == null || translatedData == null) return data as Data
-
-    const { descendants, ...rest } = Definition.normalizeData(data)
-    return {
-      ...rest,
-      descendants: mergeTranslatedNodes(
-        descendants,
-        translatedData as RichTextTranslationDto,
-        this.config.plugins,
-      ),
-    }
   }
 
   serialize(): [SerializedRecord, Transferable[]] {

--- a/packages/runtime/src/controls/rich-text-v2/translations/get-translations.ts
+++ b/packages/runtime/src/controls/rich-text-v2/translations/get-translations.ts
@@ -1,0 +1,83 @@
+import escapeHtml from 'escape-html'
+import { Descendant, Editor, Text } from 'slate'
+
+import { type TranslationDto, Slate } from '@makeswift/controls'
+
+import { RichTextV2Plugin } from '../plugin'
+import { InlineType } from '../../../slate/types'
+import { createEditorWithPlugins, pathToString, RichTextTranslationDto } from './translations-core'
+
+function getDescendantTranslatableData(descendant: Descendant, path: number[]): TranslationDto {
+  if (Text.isText(descendant)) {
+    return {}
+  }
+
+  if (Slate.isList(descendant) || Slate.isListItem(descendant)) {
+    return descendant.children.reduce(
+      (acc, d, j) => ({ ...acc, ...getDescendantTranslatableData(d, [...path, j]) }),
+      {},
+    )
+  }
+
+  const text = getInlineOrTextTranslatableData(descendant)
+  if (text == null) return {}
+
+  return { [pathToString(path)]: text }
+}
+
+function getInlineOrTextTranslatableData(
+  descendant: Descendant,
+  path: number[] = [],
+): string | null {
+  if (Text.isText(descendant)) {
+    let string = escapeHtml(descendant.text)
+
+    if (string === '') return null
+
+    if (descendant.typography === undefined) return string
+
+    return `<span key="${pathToString(path)}">${string}</span>`
+  }
+
+  const children = descendant.children
+    .map((child: Descendant, i: number) => getInlineOrTextTranslatableData(child, [...path, i]))
+    .join('')
+
+  if (children === '') return null
+
+  switch (descendant.type) {
+    case InlineType.Link:
+      return `<a key="${pathToString(path)}">${children}</a>`
+
+    case InlineType.SuperScript:
+      return `<sup key="${pathToString(path)}">${children}</sup>`
+
+    case InlineType.SubScript:
+      return `<sub key="${pathToString(path)}">${children}</sub>`
+
+    case InlineType.Code:
+      return `<code key="${pathToString(path)}">${children}</code>`
+
+    default:
+      return children
+  }
+}
+
+export function getTranslatableData(
+  nodes: Slate.Descendant[],
+  plugins: RichTextV2Plugin[],
+): RichTextTranslationDto {
+  const editor = createEditorWithPlugins(plugins)
+
+  editor.children = nodes
+  editor.typographyNormalizationDirection = 'up'
+  Editor.normalize(editor, { force: true })
+
+  return editor.children.reduce(
+    (acc, descendant: Descendant, i) => ({
+      ...acc,
+      ...getDescendantTranslatableData(descendant, [i]),
+    }),
+    {},
+  )
+}

--- a/packages/runtime/src/controls/rich-text-v2/translations/merge-translations.ts
+++ b/packages/runtime/src/controls/rich-text-v2/translations/merge-translations.ts
@@ -1,104 +1,12 @@
-import escapeHtml from 'escape-html'
-import { Descendant, Editor, Element, Node, Text, Transforms, createEditor } from 'slate'
+import { Descendant, Editor, Element, Node, Text, Transforms } from 'slate'
 import { jsx } from 'slate-hyperscript'
 import { parseFragment, DefaultTreeAdapterTypes } from 'parse5'
 
-import { type TranslationDto, Slate } from '@makeswift/controls'
+import { Slate } from '@makeswift/controls'
 
-import { RichTextV2Plugin } from './plugin'
-import { type MakeswiftEditor, BlockType, InlineType } from '../../slate/types'
-
-function createEditorWithPlugins(plugins: RichTextV2Plugin[]): MakeswiftEditor {
-  return plugins.reduceRight(
-    (editor, plugin) => plugin?.withPlugin?.(editor) ?? editor,
-    createEditor(),
-  )
-}
-
-function pathToString(path: number[]): string {
-  return path.join(':')
-}
-
-function stringToPath(s: string): number[] {
-  return s.split(':').map(a => parseInt(a))
-}
-
-function getDescendantTranslatableData(descendant: Descendant, path: number[]): TranslationDto {
-  if (Text.isText(descendant)) {
-    return {}
-  }
-
-  if (Slate.isList(descendant) || Slate.isListItem(descendant)) {
-    return descendant.children.reduce(
-      (acc, d, j) => ({ ...acc, ...getDescendantTranslatableData(d, [...path, j]) }),
-      {},
-    )
-  }
-
-  const text = getInlineOrTextTranslatableData(descendant)
-  if (text == null) return {}
-
-  return { [pathToString(path)]: text }
-}
-
-function getInlineOrTextTranslatableData(
-  descendant: Descendant,
-  path: number[] = [],
-): string | null {
-  if (Text.isText(descendant)) {
-    let string = escapeHtml(descendant.text)
-
-    if (string === '') return null
-
-    if (descendant.typography === undefined) return string
-
-    return `<span key="${pathToString(path)}">${string}</span>`
-  }
-
-  const children = descendant.children
-    .map((child: Descendant, i: number) => getInlineOrTextTranslatableData(child, [...path, i]))
-    .join('')
-
-  if (children === '') return null
-
-  switch (descendant.type) {
-    case InlineType.Link:
-      return `<a key="${pathToString(path)}">${children}</a>`
-
-    case InlineType.SuperScript:
-      return `<sup key="${pathToString(path)}">${children}</sup>`
-
-    case InlineType.SubScript:
-      return `<sub key="${pathToString(path)}">${children}</sub>`
-
-    case InlineType.Code:
-      return `<code key="${pathToString(path)}">${children}</code>`
-
-    default:
-      return children
-  }
-}
-
-export type RichTextTranslationDto = Record<string, string>
-
-export function getTranslatableData(
-  nodes: Slate.Descendant[],
-  plugins: RichTextV2Plugin[],
-): RichTextTranslationDto {
-  const editor = createEditorWithPlugins(plugins)
-
-  editor.children = nodes
-  editor.typographyNormalizationDirection = 'up'
-  Editor.normalize(editor, { force: true })
-
-  return editor.children.reduce(
-    (acc, descendant: Descendant, i) => ({
-      ...acc,
-      ...getDescendantTranslatableData(descendant, [i]),
-    }),
-    {},
-  )
-}
+import { RichTextV2Plugin } from '../plugin'
+import { BlockType, InlineType } from '../../../slate/types'
+import { createEditorWithPlugins, RichTextTranslationDto, stringToPath } from './translations-core'
 
 function deserializeTranslationHtmlString(
   el: DefaultTreeAdapterTypes.ChildNode | DefaultTreeAdapterTypes.DocumentFragment,

--- a/packages/runtime/src/controls/rich-text-v2/translations/translations-core.ts
+++ b/packages/runtime/src/controls/rich-text-v2/translations/translations-core.ts
@@ -1,0 +1,20 @@
+import { createEditor } from 'slate'
+import { MakeswiftEditor } from '../../../slate'
+import { RichTextV2Plugin } from '../plugin'
+
+export function createEditorWithPlugins(plugins: RichTextV2Plugin[]): MakeswiftEditor {
+  return plugins.reduceRight(
+    (editor, plugin) => plugin?.withPlugin?.(editor) ?? editor,
+    createEditor(),
+  )
+}
+
+export function pathToString(path: number[]): string {
+  return path.join(':')
+}
+
+export function stringToPath(s: string): number[] {
+  return s.split(':').map(a => parseInt(a))
+}
+
+export type RichTextTranslationDto = Record<string, string>

--- a/packages/runtime/src/controls/visitors/merge-translations-visitor.ts
+++ b/packages/runtime/src/controls/visitors/merge-translations-visitor.ts
@@ -1,0 +1,26 @@
+import { Data, DataType, MergeTranslationsVisitor } from '@makeswift/controls'
+
+import { RichTextV2Definition } from '../rich-text-v2'
+import { RichTextTranslationDto } from '../rich-text-v2/translations/translations-core'
+import { mergeTranslatedNodes } from '../rich-text-v2/translations/merge-translations'
+
+export class ReactMergeTranslationsVisitor extends MergeTranslationsVisitor {
+  visitRichTextV2(
+    def: RichTextV2Definition,
+    data: DataType<RichTextV2Definition> | undefined,
+    translatedData: Data,
+  ): Data {
+    if (data == null || translatedData == null) return data
+
+    const { descendants, ...rest } = RichTextV2Definition.normalizeData(data)
+
+    return {
+      ...rest,
+      descendants: mergeTranslatedNodes(
+        descendants,
+        translatedData as RichTextTranslationDto,
+        def.config.plugins,
+      ),
+    }
+  }
+}


### PR DESCRIPTION
Pulls out logic related to merging translatable data from the control interface in favor of consolidating this behavior in a visitor class.