### PR TITLE
feat: `builtinSuspense` option in `registerComponent`

### DIFF
--- a/.changeset/good-shoes-join.md
+++ b/.changeset/good-shoes-join.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+feat: add `builtinSuspense` option in `registerComponent` to control whether the runtime wraps the component in a default `<Suspense>` boundary

--- a/packages/runtime/src/next/testing/element-data.ts
+++ b/packages/runtime/src/next/testing/element-data.ts
@@ -67,7 +67,7 @@ export function createMakeswiftPageSnapshot(
 }
 
 export function createMakeswiftComponentSnapshot(
-  elementData: ElementData,
+  elementData: ElementData | null,
   {
     cacheData = {},
     locale = null,

--- a/packages/runtime/src/runtimes/react/components/ElementData.tsx
+++ b/packages/runtime/src/runtimes/react/components/ElementData.tsx
@@ -1,5 +1,6 @@
-import { Ref, Suspense, forwardRef, memo } from 'react'
+import { Ref, Suspense, Fragment, forwardRef, memo } from 'react'
 import { ElementData as ReactPageElementData } from '../../../state/react-page'
+import { useBuiltinSuspense } from '../hooks/use-builtin-suspense'
 import { useComponent } from '../hooks/use-component'
 import { canAcceptRef } from '../utils/can-accept-ref'
 import { FallbackComponent } from '../../../components/shared/FallbackComponent'
@@ -15,6 +16,7 @@ export const ElementData = memo(
     ref: Ref<unknown>,
   ): JSX.Element {
     const Component = useComponent(elementData.type)
+    const builtinSuspense = useBuiltinSuspense(elementData.type)
 
     if (Component == null) {
       console.warn(`Unknown component '${elementData.type}'`, { elementData })
@@ -22,9 +24,10 @@ export const ElementData = memo(
     }
 
     const forwardRef = canAcceptRef(Component)
+    const SuspenseOrFragment = builtinSuspense ? Suspense : Fragment
 
     return (
-      <Suspense>
+      <SuspenseOrFragment>
         <ResolveProps element={elementData}>
           {props =>
             forwardRef ? (
@@ -34,7 +37,7 @@ export const ElementData = memo(
             )
           }
         </ResolveProps>
-      </Suspense>
+      </SuspenseOrFragment>
     )
   }),
 )

--- a/packages/runtime/src/runtimes/react/components/MakeswiftComponent.tsx
+++ b/packages/runtime/src/runtimes/react/components/MakeswiftComponent.tsx
@@ -1,13 +1,18 @@
 'use client'
 
-import { memo, Suspense, useMemo } from 'react'
+import { Suspense, Fragment, memo, useMemo } from 'react'
+
 import {
   componentDocumentToRootEmbeddedDocument,
   MakeswiftComponentSnapshot,
 } from '../../../client'
-import { DocumentRoot } from './DocumentRoot'
+import { getRootElement } from '../../../state/react-page'
+
 import { useCacheData } from '../hooks/use-cache-data'
 import { useRegisterDocument } from '../hooks/use-register-document'
+import { useBuiltinSuspense } from '../hooks/use-builtin-suspense'
+
+import { DocumentRoot } from './DocumentRoot'
 
 type Props = {
   snapshot: MakeswiftComponentSnapshot
@@ -34,9 +39,12 @@ export const MakeswiftComponent = memo(({ snapshot, label, type, description }: 
 
   useRegisterDocument(rootDocument)
 
+  const builtinSuspense = useBuiltinSuspense(getRootElement(rootDocument).type)
+  const SuspenseOrFragment = builtinSuspense ? Suspense : Fragment
+
   return (
-    <Suspense>
+    <SuspenseOrFragment>
       <DocumentRoot rootDocument={rootDocument} />
-    </Suspense>
+    </SuspenseOrFragment>
   )
 })

--- a/packages/runtime/src/runtimes/react/hooks/use-builtin-suspense.ts
+++ b/packages/runtime/src/runtimes/react/hooks/use-builtin-suspense.ts
@@ -1,0 +1,6 @@
+import { useComponentMeta } from './use-component'
+
+export function useBuiltinSuspense(type: string): boolean {
+  const { builtinSuspense } = useComponentMeta(type) ?? {}
+  return builtinSuspense ?? true
+}

--- a/packages/runtime/src/runtimes/react/hooks/use-component.ts
+++ b/packages/runtime/src/runtimes/react/hooks/use-component.ts
@@ -1,6 +1,15 @@
-import { ComponentType, getReactComponent } from '../../../state/react-page'
+import {
+  type ComponentType,
+  type ComponentMeta,
+  getReactComponent,
+  getComponentMeta,
+} from '../../../state/react-page'
 import { useSelector } from './use-selector'
 
 export function useComponent(type: string): ComponentType | null {
   return useSelector(state => getReactComponent(state, type))
+}
+
+export function useComponentMeta(type: string): ComponentMeta | null {
+  return useSelector(state => getComponentMeta(state, type))
 }

--- a/packages/runtime/src/runtimes/react/react-runtime.ts
+++ b/packages/runtime/src/runtimes/react/react-runtime.ts
@@ -31,14 +31,27 @@ export class ReactRuntime extends RuntimeCore {
       label,
       icon = ComponentIcon.Cube,
       hidden = false,
-      props,
       description,
-    }: { type: string; label: string; icon?: ComponentIcon; hidden?: boolean; props?: P; description?: string },
+      builtinSuspense,
+      props,
+    }: {
+      type: string
+      label: string
+      icon?: ComponentIcon
+      hidden?: boolean
+      description?: string
+      builtinSuspense?: boolean
+      props?: P
+    },
   ): () => void {
     validateComponentType(type, component as unknown as ComponentType)
 
     const unregisterComponent = this.store.dispatch(
-      registerComponentEffect(type, { label, icon, hidden, description }, props ?? {}),
+      registerComponentEffect(
+        type,
+        { label, icon, hidden, description, builtinSuspense },
+        props ?? {},
+      ),
     )
 
     const unregisterReactComponent = this.store.dispatch(

--- a/packages/runtime/src/state/modules/components-meta.ts
+++ b/packages/runtime/src/state/modules/components-meta.ts
@@ -32,6 +32,7 @@ export type ComponentMeta = {
   icon: ComponentIcon
   hidden: boolean
   description?: string
+  builtinSuspense?: boolean
 }
 
 export type State = Map<string, ComponentMeta>
@@ -44,6 +45,10 @@ export function getInitialState({
 
 export function getComponentsMeta(state: State): Map<string, ComponentMeta> {
   return state
+}
+
+export function getComponentMeta(state: State, type: string): ComponentMeta | null {
+  return getComponentsMeta(state).get(type) ?? null
 }
 
 export function reducer(state: State = getInitialState(), action: Action | UnknownAction): State {

--- a/packages/runtime/src/state/react-page.ts
+++ b/packages/runtime/src/state/react-page.ts
@@ -57,6 +57,7 @@ export {
 } from './modules/read-only-documents'
 
 export type { ComponentType } from './modules/react-components'
+export type { ComponentMeta } from './modules/components-meta'
 
 const reducer = combineReducers({
   documents: Documents.reducer,
@@ -109,6 +110,14 @@ export function getReactComponent(
   type: string,
 ): ReactComponents.ComponentType | null {
   return ReactComponents.getReactComponent(getReactComponentsStateSlice(state), type)
+}
+
+function getComponentsMetaStateSlice(state: State): ComponentsMeta.State {
+  return state.componentsMeta
+}
+
+export function getComponentMeta(state: State, type: string): ComponentsMeta.ComponentMeta | null {
+  return ComponentsMeta.getComponentMeta(getComponentsMetaStateSlice(state), type)
 }
 
 function getPropControllersStateSlice(state: State): PropControllers.State {


### PR DESCRIPTION
Add `builtinSuspense` option in `registerComponent` to control whether the runtime wraps the component in a default `<Suspense>` boundary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce builtinSuspense in registerComponent to control default React Suspense wrapping, wired through component meta and used by renderers, with tests added.
> 
> - **Runtime API**:
>   - Add `builtinSuspense?: boolean` to `ReactRuntime.registerComponent` and pass via component meta.
> - **Rendering Behavior**:
>   - `MakeswiftComponent` and `ElementData` now conditionally wrap children with React Suspense or Fragment based on `builtinSuspense` (default true).
>   - New hook `useBuiltinSuspense` reads `builtinSuspense` from component meta.
> - **State/Selectors**:
>   - Extend `ComponentMeta` with `builtinSuspense`; add `getComponentMeta` selector and export related types.
>   - `use-component` hook now exposes `useComponentMeta`.
> - **Testing/Fixtures**:
>   - Update tests to cover suspended components and behavior when `builtinSuspense` is false (component-provided fallback renders).
>   - Testing helpers allow `null` element data when creating component snapshots and add simple element builders.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 199acfa6d4eedb21bc9d97918bd202b289717eb1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->