### PR TITLE
feat: add warning when `previewMode` is disabled

### DIFF
--- a/.changeset/famous-bees-unite.md
+++ b/.changeset/famous-bees-unite.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/next-plugin": minor
+---
+
+Replace `previewMode` config option with `disableBuiltInPreview`, which is set to `false` by default. Also adds logging when this option is enabled.

--- a/packages/makeswift-next-plugin/index.d.ts
+++ b/packages/makeswift-next-plugin/index.d.ts
@@ -1,9 +1,24 @@
 import type { NextConfig } from 'next'
 
 type MakeswiftNextPluginOptions = {
+  /**
+   * Whether to resolve symlinks in webpack
+   *
+   */
   resolveSymlinks?: boolean
+  /**
+   * The origin of the Makeswift builder. Used for CORS headers to allow the
+   * builder to communicate with your site
+   *
+   */
   appOrigin?: string
-  previewMode?: boolean
+  /**
+   * Whether to disable Makeswift's built-in preview mode. When true, you must
+   * implement a custom preview mode for visual editing to work. Defaults to
+   * `false`.
+   *
+   */
+  disableBuiltInPreview?: boolean
 }
 
 declare function MakeswiftNextPlugin(

--- a/packages/makeswift-next-plugin/index.js
+++ b/packages/makeswift-next-plugin/index.js
@@ -1,9 +1,23 @@
 // @ts-check
 
 /** @typedef {import('next').NextConfig} NextConfig */
-/** @typedef {{ resolveSymlinks?: boolean; appOrigin?: string; previewMode?: boolean }} MakeswiftNextPluginOptions */
 /** @typedef {NonNullable<import('next').NextConfig['images']>} ImageConfig */
 /** @typedef {ImageConfig['remotePatterns']} ImageConfigRemotePatterns */
+
+/**
+ * Configuration options for the Makeswift Next.js plugin
+ * @typedef {Object} MakeswiftNextPluginOptions
+ * 
+ * @property {boolean} [resolveSymlinks] - Whether to resolve symlinks in
+ * webpack.
+ * 
+ * @property {string} [appOrigin] - The origin of the Makeswift builder. Used
+ * for CORS headers to allow the builder to communicate with your site
+ * 
+ * @property {boolean} [disableBuiltInPreview] - Whether to disable Makeswift's
+ * built-in preview mode. When true, you must implement a custom preview mode
+ * for visual editing to work
+ */
 
 const { satisfies } = require('semver')
 
@@ -32,7 +46,7 @@ module.exports =
   ({
     resolveSymlinks,
     appOrigin = 'https://app.makeswift.com',
-    previewMode = true,
+    disableBuiltInPreview = false,
   } = {}) =>
     (nextConfig = {}) => {
       /** @type {NextConfig} */
@@ -76,7 +90,7 @@ module.exports =
           ]
           return {
             beforeFiles: [
-              ...(previewMode ? previewModeRewrites : []),
+              ...(!disableBuiltInPreview ? previewModeRewrites : []),
               ...(Array.isArray(rewrites) ? [] : rewrites?.beforeFiles ?? []),
             ],
             afterFiles: Array.isArray(rewrites)
@@ -114,6 +128,12 @@ module.exports =
 
       if (satisfies(nextVersion, '<13.4.0')) {
         throw new Error('Makeswift requires a minimum Next.js version of 13.4.0.')
+      }
+
+      if (disableBuiltInPreview) {
+        console.log(
+          "\nMakeswift's built-in preview mode is disabled. Check that a custom preview mode is implemented to enable visual editing.\n",
+        )
       }
 
       return {


### PR DESCRIPTION
Add a warning message that appears during the build/start or dev process if the user has explicitly disabled the `previewMode`.