### PR TITLE
Runtime package.json corrections

### DIFF
--- a/.changeset/brown-crabs-visit.md
+++ b/.changeset/brown-crabs-visit.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+Fix incorrect file extension for client export

--- a/.changeset/fuzzy-ways-destroy.md
+++ b/.changeset/fuzzy-ways-destroy.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+Move module declarations ahead of require condition for `package.json` exports

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -70,8 +70,8 @@
     },
     "./next/document": {
       "types": "./dist/types/next/document.d.ts",
-      "require": "./dist/cjs/next/document.js",
-      "module": "./dist/esm/next/document.js"
+      "module": "./dist/esm/next/document.js",
+      "require": "./dist/cjs/next/document.js"
     },
     "./next/middleware": {
       "types": "./dist/types/next/middleware/index.d.ts",
@@ -80,8 +80,8 @@
     },
     "./next/server": {
       "types": "./dist/types/next/server.d.ts",
-      "require": "./dist/cjs/next/server.js",
-      "module": "./dist/esm/next/server.js"
+      "module": "./dist/esm/next/server.js",
+      "require": "./dist/cjs/next/server.js"
     },
     "./next/plugin": {
       "types": "./next/plugin/index.d.ts",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -45,8 +45,8 @@
     },
     "./client": {
       "types": "./dist/types/client/index.d.ts",
-      "require": "./dist/cjs/client/index.cjs",
-      "import": "./dist/esm/client/index.mjs"
+      "require": "./dist/cjs/client/index.js",
+      "import": "./dist/esm/client/index.js"
     },
     "./components": {
       "types": "./dist/types/components/index.d.ts",


### PR DESCRIPTION
Fixes errors shown by [Publint](https://publint.dev/@makeswift/runtime@0.0.0-snapshot-20250925223243):
- `module` should come before `require`: https://publint.dev/@makeswift/runtime@0.0.0-snapshot-20250925223243
- Incorrect file paths exposed for the client export