### PR TITLE
fix: readme to navigate to correct route / URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 ## Getting Started
 
-Visit our [getting started guide](https://www.makeswift.com/docs/guides/getting-started) to get started with Makeswift Code Components.
+Visit our [getting started guide](https://docs.makeswift.com/developer/quickstart) to get started with Makeswift Code Components.
 
 ## API Reference
 
-Visit our [API Reference](https://www.makeswift.com/docs/controls/checkbox) to learn more about Makeswift Code Components API.
+Visit our [API Reference](https://docs.makeswift.com/developer/reference/controls/checkbox) to learn more about Makeswift Code Components API.
 
 ## Auto-generated wiki
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -6,8 +6,8 @@
 
 ## Getting Started
 
-Visit our [getting started guide](https://www.makeswift.com/docs/guides/getting-started) to get started with Makeswift Code Components.
+Visit our [getting started guide](https://docs.makeswift.com/developer/quickstart) to get started with Makeswift Code Components.
 
 ## API Reference
 
-Visit our [API Reference](https://www.makeswift.com/docs/controls/checkbox) to learn more about Makeswift Code Components API.
+Visit our [API Reference](https://docs.makeswift.com/developer/reference/controls/checkbox) to learn more about Makeswift Code Components API.


### PR DESCRIPTION
Redirects on the marketing site's next.config redirects to a 404 route