### PR TITLE
fix: skip bundle analysis on example apps

### DIFF
--- a/.github/workflows/nextjs-bundle-analysis.yml
+++ b/.github/workflows/nextjs-bundle-analysis.yml
@@ -3,11 +3,11 @@ name: Next.js Bundle Analysis
 on:
   push:
     branches: [main]
+  pull_request:
+    types: [opened, synchronize]
     paths-ignore:
       - examples/**
       - .changeset/**
-  pull_request:
-    types: [opened, synchronize]
 
 concurrency: ${{ github.workflow}}-${{ github.ref }}
 


### PR DESCRIPTION
Fix a configuration error in the workflow for bundle analysis that results in bundle analysis still running on PRs for example apps.