### PR TITLE
fix: export necessary internal types for builder

### DIFF
--- a/.changeset/nice-guests-kiss.md
+++ b/.changeset/nice-guests-kiss.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+Export builder-required types from internal `builder` entry point

--- a/packages/runtime/src/builder/breakpoints/index.ts
+++ b/packages/runtime/src/builder/breakpoints/index.ts
@@ -5,4 +5,5 @@ export {
   type State,
   type BreakpointId,
   type Breakpoint,
+  type Breakpoints,
 } from '../../state/modules/breakpoints'

--- a/packages/runtime/src/builder/index.ts
+++ b/packages/runtime/src/builder/index.ts
@@ -21,6 +21,8 @@ export {
   setLocalizedResourceId,
 } from '../state/actions'
 
+export { type Operation } from '../state/modules/read-write-documents'
+
 export { createBaseDocument } from '../state/react-page'
 
 export type {


### PR DESCRIPTION
Export some previously removed types that are used by the builder. These types are exposed via the internal `builder` entry point.