### PR TITLE
fix: zoom bug for custom breakpoints

### DIFF
--- a/packages/runtime/src/next/components/tests/__snapshots__/global-element-rendering.test.tsx.snap
+++ b/packages/runtime/src/next/components/tests/__snapshots__/global-element-rendering.test.tsx.snap
@@ -5,13 +5,13 @@ exports[`Page correctly renders a global element 1`] = `
   max-width: 100%;
 }
 
-@media only screen and (min-width: 769px) {
+@media only screen {
   .emotion-0 {
     width: 700px;
   }
 }
 
-@media only screen and (min-width: 576px) and (max-width: 768px) {
+@media only screen and (max-width: 768px) {
   .emotion-0 {
     width: 700px;
   }
@@ -23,7 +23,7 @@ exports[`Page correctly renders a global element 1`] = `
   }
 }
 
-@media only screen and (min-width: 769px) {
+@media only screen {
   .emotion-1 {
     margin-top: 40px;
     margin-right: auto;
@@ -32,7 +32,7 @@ exports[`Page correctly renders a global element 1`] = `
   }
 }
 
-@media only screen and (min-width: 576px) and (max-width: 768px) {
+@media only screen and (max-width: 768px) {
   .emotion-1 {
     margin-top: 40px;
     margin-right: auto;
@@ -54,7 +54,7 @@ exports[`Page correctly renders a global element 1`] = `
   margin: 0;
 }
 
-@media only screen and (min-width: 769px) {
+@media only screen {
   .emotion-4 {
     font-family: Lato;
     font-size: 30px;
@@ -64,7 +64,7 @@ exports[`Page correctly renders a global element 1`] = `
   }
 }
 
-@media only screen and (min-width: 576px) and (max-width: 768px) {
+@media only screen and (max-width: 768px) {
   .emotion-4 {
     font-family: Lato;
     font-size: 30px;
@@ -109,13 +109,13 @@ exports[`Page correctly renders a localized global element 1`] = `
   max-width: 100%;
 }
 
-@media only screen and (min-width: 769px) {
+@media only screen {
   .emotion-0 {
     width: 700px;
   }
 }
 
-@media only screen and (min-width: 576px) and (max-width: 768px) {
+@media only screen and (max-width: 768px) {
   .emotion-0 {
     width: 700px;
   }
@@ -131,13 +131,13 @@ exports[`Page correctly renders a localized global element 1`] = `
   max-width: 100%;
 }
 
-@media only screen and (min-width: 769px) {
+@media only screen {
   .emotion-0 {
     width: 700px;
   }
 }
 
-@media only screen and (min-width: 576px) and (max-width: 768px) {
+@media only screen and (max-width: 768px) {
   .emotion-0 {
     width: 700px;
   }
@@ -149,7 +149,7 @@ exports[`Page correctly renders a localized global element 1`] = `
   }
 }
 
-@media only screen and (min-width: 769px) {
+@media only screen {
   .emotion-1 {
     margin-top: 40px;
     margin-right: auto;
@@ -158,7 +158,7 @@ exports[`Page correctly renders a localized global element 1`] = `
   }
 }
 
-@media only screen and (min-width: 576px) and (max-width: 768px) {
+@media only screen and (max-width: 768px) {
   .emotion-1 {
     margin-top: 40px;
     margin-right: auto;
@@ -176,7 +176,7 @@ exports[`Page correctly renders a localized global element 1`] = `
   }
 }
 
-@media only screen and (min-width: 769px) {
+@media only screen {
   .emotion-1 {
     margin-top: 40px;
     margin-right: auto;
@@ -185,7 +185,7 @@ exports[`Page correctly renders a localized global element 1`] = `
   }
 }
 
-@media only screen and (min-width: 576px) and (max-width: 768px) {
+@media only screen and (max-width: 768px) {
   .emotion-1 {
     margin-top: 40px;
     margin-right: auto;
@@ -211,7 +211,7 @@ exports[`Page correctly renders a localized global element 1`] = `
   margin: 0;
 }
 
-@media only screen and (min-width: 769px) {
+@media only screen {
   .emotion-4 {
     color: hsla(238,87%,49%,1);
     font-family: Lato;
@@ -222,7 +222,7 @@ exports[`Page correctly renders a localized global element 1`] = `
   }
 }
 
-@media only screen and (min-width: 576px) and (max-width: 768px) {
+@media only screen and (max-width: 768px) {
   .emotion-4 {
     color: hsla(238,87%,49%,1);
     font-family: Lato;

--- a/packages/runtime/src/next/components/tests/components/__snapshots__/box-component-rendering.test.tsx.snap
+++ b/packages/runtime/src/next/components/tests/components/__snapshots__/box-component-rendering.test.tsx.snap
@@ -18,13 +18,13 @@ exports[`correctly renders box component with background image 1`] = `
   max-width: 100%;
 }
 
-@media only screen and (min-width: 769px) {
+@media only screen {
   .emotion-1 {
     width: 1160px;
   }
 }
 
-@media only screen and (min-width: 576px) and (max-width: 768px) {
+@media only screen and (max-width: 768px) {
   .emotion-1 {
     width: 1160px;
   }
@@ -36,7 +36,7 @@ exports[`correctly renders box component with background image 1`] = `
   }
 }
 
-@media only screen and (min-width: 769px) {
+@media only screen {
   .emotion-2 {
     margin-top: 40px;
     margin-right: auto;
@@ -45,7 +45,7 @@ exports[`correctly renders box component with background image 1`] = `
   }
 }
 
-@media only screen and (min-width: 576px) and (max-width: 768px) {
+@media only screen and (max-width: 768px) {
   .emotion-2 {
     margin-top: 40px;
     margin-right: auto;
@@ -63,7 +63,7 @@ exports[`correctly renders box component with background image 1`] = `
   }
 }
 
-@media only screen and (min-width: 769px) {
+@media only screen {
   .emotion-3 {
     border-top-left-radius: 0px;
     border-top-right-radius: 0px;
@@ -72,7 +72,7 @@ exports[`correctly renders box component with background image 1`] = `
   }
 }
 
-@media only screen and (min-width: 576px) and (max-width: 768px) {
+@media only screen and (max-width: 768px) {
   .emotion-3 {
     border-top-left-radius: 0px;
     border-top-right-radius: 0px;
@@ -94,7 +94,7 @@ exports[`correctly renders box component with background image 1`] = `
   display: flex;
 }
 
-@media only screen and (min-width: 769px) {
+@media only screen {
   .emotion-5 {
     -webkit-align-self: auto;
     -ms-flex-item-align: auto;
@@ -102,7 +102,7 @@ exports[`correctly renders box component with background image 1`] = `
   }
 }
 
-@media only screen and (min-width: 576px) and (max-width: 768px) {
+@media only screen and (max-width: 768px) {
   .emotion-5 {
     -webkit-align-self: auto;
     -ms-flex-item-align: auto;
@@ -140,13 +140,13 @@ exports[`correctly renders box component with background image 1`] = `
   overflow: hidden;
 }
 
-@media only screen and (min-width: 769px) {
+@media only screen {
   .emotion-7 {
     display: block;
   }
 }
 
-@media only screen and (min-width: 576px) and (max-width: 768px) {
+@media only screen and (max-width: 768px) {
   .emotion-7 {
     display: block;
   }
@@ -158,7 +158,7 @@ exports[`correctly renders box component with background image 1`] = `
   }
 }
 
-@media only screen and (min-width: 769px) {
+@media only screen {
   .emotion-8 {
     padding-top: 10px;
     padding-right: 10px;
@@ -167,7 +167,7 @@ exports[`correctly renders box component with background image 1`] = `
   }
 }
 
-@media only screen and (min-width: 576px) and (max-width: 768px) {
+@media only screen and (max-width: 768px) {
   .emotion-8 {
     padding-top: 10px;
     padding-right: 10px;
@@ -185,7 +185,7 @@ exports[`correctly renders box component with background image 1`] = `
   }
 }
 
-@media only screen and (min-width: 769px) {
+@media only screen {
   .emotion-10 {
     border-top: 0px solid black;
     border-right: 0px solid black;
@@ -194,7 +194,7 @@ exports[`correctly renders box component with background image 1`] = `
   }
 }
 
-@media only screen and (min-width: 576px) and (max-width: 768px) {
+@media only screen and (max-width: 768px) {
   .emotion-10 {
     border-top: 0px solid black;
     border-right: 0px solid black;
@@ -221,7 +221,7 @@ exports[`correctly renders box component with background image 1`] = `
   width: 100%;
 }
 
-@media only screen and (min-width: 769px) {
+@media only screen {
   .emotion-12 {
     -webkit-align-content: flex-start;
     -ms-flex-line-pack: flex-start;
@@ -229,7 +229,7 @@ exports[`correctly renders box component with background image 1`] = `
   }
 }
 
-@media only screen and (min-width: 576px) and (max-width: 768px) {
+@media only screen and (max-width: 768px) {
   .emotion-12 {
     -webkit-align-content: flex-start;
     -ms-flex-line-pack: flex-start;

--- a/packages/runtime/src/next/components/tests/components/__snapshots__/button-component-rendering.test.tsx.snap
+++ b/packages/runtime/src/next/components/tests/components/__snapshots__/button-component-rendering.test.tsx.snap
@@ -198,13 +198,13 @@ exports[`correctly renders button component with link 1`] = `
   max-width: 100%;
 }
 
-@media only screen and (min-width: 769px) {
+@media only screen {
   .emotion-1 {
     width: auto;
   }
 }
 
-@media only screen and (min-width: 576px) and (max-width: 768px) {
+@media only screen and (max-width: 768px) {
   .emotion-1 {
     width: auto;
   }
@@ -216,7 +216,7 @@ exports[`correctly renders button component with link 1`] = `
   }
 }
 
-@media only screen and (min-width: 769px) {
+@media only screen {
   .emotion-2 {
     margin-top: 60px;
     margin-right: auto;
@@ -225,7 +225,7 @@ exports[`correctly renders button component with link 1`] = `
   }
 }
 
-@media only screen and (min-width: 576px) and (max-width: 768px) {
+@media only screen and (max-width: 768px) {
   .emotion-2 {
     margin-top: 60px;
     margin-right: auto;
@@ -243,7 +243,7 @@ exports[`correctly renders button component with link 1`] = `
   }
 }
 
-@media only screen and (min-width: 769px) {
+@media only screen {
   .emotion-3 {
     color: hsla(0,0%,100%,1);
     border-radius: 4px;
@@ -264,7 +264,7 @@ exports[`correctly renders button component with link 1`] = `
   }
 }
 
-@media only screen and (min-width: 576px) and (max-width: 768px) {
+@media only screen and (max-width: 768px) {
   .emotion-3 {
     color: hsla(0,0%,100%,1);
     border-radius: 4px;

--- a/packages/runtime/src/next/components/tests/components/__snapshots__/image-component-rendering.test.tsx.snap
+++ b/packages/runtime/src/next/components/tests/components/__snapshots__/image-component-rendering.test.tsx.snap
@@ -10,13 +10,13 @@ exports[`correctly renders image component 1`] = `
   max-width: 100%;
 }
 
-@media only screen and (min-width: 769px) {
+@media only screen {
   .emotion-1 {
     width: 90%;
   }
 }
 
-@media only screen and (min-width: 576px) and (max-width: 768px) {
+@media only screen and (max-width: 768px) {
   .emotion-1 {
     width: 90%;
   }
@@ -28,13 +28,13 @@ exports[`correctly renders image component 1`] = `
   }
 }
 
-@media only screen and (min-width: 769px) {
+@media only screen {
   .emotion-2 {
     opacity: 1;
   }
 }
 
-@media only screen and (min-width: 576px) and (max-width: 768px) {
+@media only screen and (max-width: 768px) {
   .emotion-2 {
     opacity: 1;
   }
@@ -46,7 +46,7 @@ exports[`correctly renders image component 1`] = `
   }
 }
 
-@media only screen and (min-width: 769px) {
+@media only screen {
   .emotion-3 {
     margin-top: 20px;
     margin-right: auto;
@@ -55,7 +55,7 @@ exports[`correctly renders image component 1`] = `
   }
 }
 
-@media only screen and (min-width: 576px) and (max-width: 768px) {
+@media only screen and (max-width: 768px) {
   .emotion-3 {
     margin-top: 20px;
     margin-right: auto;
@@ -73,7 +73,7 @@ exports[`correctly renders image component 1`] = `
   }
 }
 
-@media only screen and (min-width: 769px) {
+@media only screen {
   .emotion-4 {
     padding-top: 5px;
     padding-right: 5px;
@@ -82,7 +82,7 @@ exports[`correctly renders image component 1`] = `
   }
 }
 
-@media only screen and (min-width: 576px) and (max-width: 768px) {
+@media only screen and (max-width: 768px) {
   .emotion-4 {
     padding-top: 5px;
     padding-right: 5px;
@@ -100,7 +100,7 @@ exports[`correctly renders image component 1`] = `
   }
 }
 
-@media only screen and (min-width: 769px) {
+@media only screen {
   .emotion-5 {
     border-top: 2px solid hsla(360,97.873924%,52.965%,1);
     border-right: 2px solid hsla(360,97.873924%,52.965%,1);
@@ -109,7 +109,7 @@ exports[`correctly renders image component 1`] = `
   }
 }
 
-@media only screen and (min-width: 576px) and (max-width: 768px) {
+@media only screen and (max-width: 768px) {
   .emotion-5 {
     border-top: 2px solid hsla(360,97.873924%,52.965%,1);
     border-right: 2px solid hsla(360,97.873924%,52.965%,1);
@@ -127,7 +127,7 @@ exports[`correctly renders image component 1`] = `
   }
 }
 
-@media only screen and (min-width: 769px) {
+@media only screen {
   .emotion-6 {
     border-top-left-radius: 6px;
     border-top-right-radius: 6px;
@@ -136,7 +136,7 @@ exports[`correctly renders image component 1`] = `
   }
 }
 
-@media only screen and (min-width: 576px) and (max-width: 768px) {
+@media only screen and (max-width: 768px) {
   .emotion-6 {
     border-top-left-radius: 6px;
     border-top-right-radius: 6px;

--- a/packages/runtime/src/next/components/tests/controls/__snapshots__/slot-control.test.tsx.snap
+++ b/packages/runtime/src/next/components/tests/controls/__snapshots__/slot-control.test.tsx.snap
@@ -117,7 +117,7 @@ NodeList [
   display: flex;
 }
 
-@media only screen and (min-width: 769px) {
+@media only screen {
   .emotion-1 {
     -webkit-flex-basis: calc(100% * 1.00000);
     -ms-flex-preferred-size: calc(100% * 1.00000);
@@ -126,7 +126,7 @@ NodeList [
   }
 }
 
-@media only screen and (min-width: 576px) and (max-width: 768px) {
+@media only screen and (max-width: 768px) {
   .emotion-1 {
     -webkit-flex-basis: calc(100% * 1.00000);
     -ms-flex-preferred-size: calc(100% * 1.00000);

--- a/packages/runtime/src/next/components/tests/controls/rich-text-v2-control/__snapshots__/client.test.tsx.snap
+++ b/packages/runtime/src/next/components/tests/controls/rich-text-v2-control/__snapshots__/client.test.tsx.snap
@@ -168,7 +168,7 @@ NodeList [
   text-decoration: none;
 }
 
-@media only screen and (min-width: 769px) {
+@media only screen {
   .emotion-4 {
     color: hsla(238,87%,49%,1);
     font-family: Lato;
@@ -176,7 +176,7 @@ NodeList [
   }
 }
 
-@media only screen and (min-width: 576px) and (max-width: 768px) {
+@media only screen and (max-width: 768px) {
   .emotion-4 {
     color: hsla(238,87%,49%,1);
     font-family: Lato;

--- a/packages/runtime/src/next/components/tests/controls/rich-text-v2-control/__snapshots__/server.test.tsx.snap
+++ b/packages/runtime/src/next/components/tests/controls/rich-text-v2-control/__snapshots__/server.test.tsx.snap
@@ -42,7 +42,7 @@ NodeList [
 
 exports[`renders provided text content: component styles 1`] = `
 [
-  ".mswft-ytumd6{-webkit-text-decoration:none;text-decoration:none;}.mswft-1uk1gs8{margin:0;}.mswft-vz2etd{padding:0.5em 10px;font-size:1.25em;font-weight:300;border-left:5px solid rgba(0, 0, 0, 0.1);}.mswft-99zmsg{list-style-position:inside;-webkit-padding-start:20px;padding-inline-start:20px;list-style-type:disc;}.mswft-99zmsg ul{list-style-type:circle;}.mswft-99zmsg ul ul{list-style-type:square;}.mswft-dgqoak{list-style-position:inside;-webkit-padding-start:20px;padding-inline-start:20px;list-style-type:decimal;}@media only screen and (min-width: 769px){.mswft-144fjko{color:hsla(238,87%,49%,1);font-family:Lato;font-size:16px;}}@media only screen and (min-width: 576px) and (max-width: 768px){.mswft-144fjko{color:hsla(238,87%,49%,1);font-family:Lato;font-size:16px;}}@media only screen and (max-width: 575px){.mswft-144fjko{color:hsla(238,87%,49%,1);font-family:Lato;font-size:16px;}}",
+  ".mswft-ytumd6{-webkit-text-decoration:none;text-decoration:none;}.mswft-1uk1gs8{margin:0;}.mswft-vz2etd{padding:0.5em 10px;font-size:1.25em;font-weight:300;border-left:5px solid rgba(0, 0, 0, 0.1);}.mswft-99zmsg{list-style-position:inside;-webkit-padding-start:20px;padding-inline-start:20px;list-style-type:disc;}.mswft-99zmsg ul{list-style-type:circle;}.mswft-99zmsg ul ul{list-style-type:square;}.mswft-dgqoak{list-style-position:inside;-webkit-padding-start:20px;padding-inline-start:20px;list-style-type:decimal;}@media only screen{.mswft-1tp2dn6{color:hsla(238,87%,49%,1);font-family:Lato;font-size:16px;}}@media only screen and (max-width: 768px){.mswft-1tp2dn6{color:hsla(238,87%,49%,1);font-family:Lato;font-size:16px;}}@media only screen and (max-width: 575px){.mswft-1tp2dn6{color:hsla(238,87%,49%,1);font-family:Lato;font-size:16px;}}",
 ]
 `;
 
@@ -52,10 +52,10 @@ NodeList [
     style="position:relative;white-space:pre-wrap;word-wrap:break-word"
   >
     <p
-      class="mswft-1uk1gs8 mswft-1olq3mu"
+      class="mswft-1uk1gs8 mswft-1defts5"
     >
       <span
-        class="mswft-1olq3mu"
+        class="mswft-1defts5"
       >
         ﻿
       </span>
@@ -65,22 +65,22 @@ NodeList [
         target="_blank"
       >
         <span
-          class="mswft-144fjko"
+          class="mswft-1tp2dn6"
         >
           Adyen
         </span>
       </a>
       <span
-        class="mswft-1olq3mu"
+        class="mswft-1defts5"
       >
         ﻿
       </span>
     </p>
     <p
-      class="mswft-1uk1gs8 mswft-1olq3mu"
+      class="mswft-1uk1gs8 mswft-1defts5"
     >
       <span
-        class="mswft-1olq3mu"
+        class="mswft-1defts5"
       >
         ﻿
       </span>
@@ -90,22 +90,22 @@ NodeList [
         target="_blank"
       >
         <span
-          class="mswft-144fjko"
+          class="mswft-1tp2dn6"
         >
           Authorize.net
         </span>
       </a>
       <span
-        class="mswft-1olq3mu"
+        class="mswft-1defts5"
       >
         ﻿
       </span>
     </p>
     <p
-      class="mswft-1uk1gs8 mswft-1olq3mu"
+      class="mswft-1uk1gs8 mswft-1defts5"
     >
       <span
-        class="mswft-1olq3mu"
+        class="mswft-1defts5"
       >
         ﻿
       </span>
@@ -115,22 +115,22 @@ NodeList [
         target="_blank"
       >
         <span
-          class="mswft-144fjko"
+          class="mswft-1tp2dn6"
         >
           BlueSnap
         </span>
       </a>
       <span
-        class="mswft-1olq3mu"
+        class="mswft-1defts5"
       >
         ﻿
       </span>
     </p>
     <p
-      class="mswft-1uk1gs8 mswft-1olq3mu"
+      class="mswft-1uk1gs8 mswft-1defts5"
     >
       <span
-        class="mswft-1olq3mu"
+        class="mswft-1defts5"
       >
         ﻿
       </span>
@@ -140,22 +140,22 @@ NodeList [
         target="_blank"
       >
         <span
-          class="mswft-144fjko"
+          class="mswft-1tp2dn6"
         >
           Checkout.com
         </span>
       </a>
       <span
-        class="mswft-1olq3mu"
+        class="mswft-1defts5"
       >
         ﻿
       </span>
     </p>
     <p
-      class="mswft-1uk1gs8 mswft-1olq3mu"
+      class="mswft-1uk1gs8 mswft-1defts5"
     >
       <span
-        class="mswft-1olq3mu"
+        class="mswft-1defts5"
       >
         ﻿
       </span>
@@ -165,13 +165,13 @@ NodeList [
         target="_blank"
       >
         <span
-          class="mswft-144fjko"
+          class="mswft-1tp2dn6"
         >
           CyberSource Direct
         </span>
       </a>
       <span
-        class="mswft-1olq3mu"
+        class="mswft-1defts5"
       >
         ﻿
       </span>

--- a/packages/runtime/src/next/components/tests/controls/style-control/__snapshots__/client.test.tsx.snap
+++ b/packages/runtime/src/next/components/tests/controls/style-control/__snapshots__/client.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders a style: resolvedValue 1`] = `"mswft-1cny9vj u-_r_2_-propKey"`;
+exports[`renders a style: resolvedValue 1`] = `"mswft-cndtt2 u-_r_2_-propKey"`;
 
 exports[`renders a style: snapshot 1`] = `
 {

--- a/packages/runtime/src/next/components/tests/controls/style-control/__snapshots__/server.test.tsx.snap
+++ b/packages/runtime/src/next/components/tests/controls/style-control/__snapshots__/server.test.tsx.snap
@@ -2,8 +2,8 @@
 
 exports[`renders a style: component styles 1`] = `
 [
-  ".mswft-1cny9vj{max-width:100%;}@media only screen and (min-width: 769px){.mswft-1cny9vj{width:80%;margin-top:4px;margin-right:auto;margin-bottom:0px;margin-left:auto;}}@media only screen and (min-width: 576px) and (max-width: 768px){.mswft-1cny9vj{width:80%;margin-top:4px;margin-right:auto;margin-bottom:0px;margin-left:auto;}}@media only screen and (max-width: 575px){.mswft-1cny9vj{width:80%;margin-top:4px;margin-right:auto;margin-bottom:0px;margin-left:auto;}}",
+  ".mswft-cndtt2{max-width:100%;}@media only screen{.mswft-cndtt2{width:80%;margin-top:4px;margin-right:auto;margin-bottom:0px;margin-left:auto;}}@media only screen and (max-width: 768px){.mswft-cndtt2{width:80%;margin-top:4px;margin-right:auto;margin-bottom:0px;margin-left:auto;}}@media only screen and (max-width: 575px){.mswft-cndtt2{width:80%;margin-top:4px;margin-right:auto;margin-bottom:0px;margin-left:auto;}}",
 ]
 `;
 
-exports[`renders a style: resolvedValue 1`] = `"mswft-1cny9vj u-_R_1_-propKey"`;
+exports[`renders a style: resolvedValue 1`] = `"mswft-cndtt2 u-_R_1_-propKey"`;

--- a/packages/runtime/src/next/testing/breakpoints.ts
+++ b/packages/runtime/src/next/testing/breakpoints.ts
@@ -1,3 +1,4 @@
-export const DESKTOP_MEDIA_QUERY = 'only screen and (min-width: 769px)'
-export const TABLET_MEDIA_QUERY = 'only screen and (min-width: 769px)'
-export const MOBILE_MEDIA_QUERY = 'only screen and (min-width: 769px)'
+// Desktop-first cascading: base breakpoint has no conditions, smaller breakpoints use max-width only
+export const DESKTOP_MEDIA_QUERY = 'only screen'
+export const TABLET_MEDIA_QUERY = 'only screen and (max-width: 768px)'
+export const MOBILE_MEDIA_QUERY = 'only screen and (max-width: 575px)'

--- a/packages/runtime/src/state/modules/breakpoints.test.ts
+++ b/packages/runtime/src/state/modules/breakpoints.test.ts
@@ -1,6 +1,9 @@
 import { parseBreakpointsInput } from './breakpoints'
 
 describe('parseBreakpointsInput', () => {
+  // Desktop-first cascading: base breakpoint (Desktop) has no maxWidth,
+  // other breakpoints use only maxWidth for proper CSS cascading without gaps.
+  // Desktop's minWidth is for display/canvas purposes only, NOT used in media queries.
   test('adds the base breakpoint', async () => {
     // Arrange
     const input = {
@@ -13,8 +16,8 @@ describe('parseBreakpointsInput', () => {
 
     // Assert
     expect(result).toEqual([
-      { id: 'desktop', label: 'Desktop', minWidth: 769 },
-      { id: 'tablet', minWidth: 576, maxWidth: 768, viewportWidth: 768 },
+      { id: 'desktop', label: 'Desktop', minWidth: 768 },
+      { id: 'tablet', maxWidth: 768, viewportWidth: 768 },
       { id: 'mobile', maxWidth: 575, viewportWidth: 575 },
     ])
   })
@@ -31,8 +34,8 @@ describe('parseBreakpointsInput', () => {
 
     // Assert
     expect(result).toEqual([
-      { id: 'desktop', label: 'Desktop', minWidth: 769 },
-      { id: 'tablet', minWidth: 576, maxWidth: 768, viewportWidth: 768 },
+      { id: 'desktop', label: 'Desktop', minWidth: 768 },
+      { id: 'tablet', maxWidth: 768, viewportWidth: 768 },
       { id: 'mobile', maxWidth: 575, viewportWidth: 575 },
     ])
   })
@@ -51,10 +54,10 @@ describe('parseBreakpointsInput', () => {
 
     // Assert
     expect(result).toEqual([
-      { id: 'desktop', label: 'Desktop', minWidth: 769 },
-      { id: 'tablet', minWidth: 576, maxWidth: 768, viewportWidth: 768 },
-      { id: 'mobile', minWidth: 301, maxWidth: 575, viewportWidth: 575 },
-      { id: 'pager', minWidth: 101, maxWidth: 300, viewportWidth: 300 },
+      { id: 'desktop', label: 'Desktop', minWidth: 768 },
+      { id: 'tablet', maxWidth: 768, viewportWidth: 768 },
+      { id: 'mobile', maxWidth: 575, viewportWidth: 575 },
+      { id: 'pager', maxWidth: 300, viewportWidth: 300 },
       { id: 'ant', maxWidth: 100, viewportWidth: 100 },
     ])
   })
@@ -71,8 +74,8 @@ describe('parseBreakpointsInput', () => {
 
     // Assert
     expect(result).toEqual([
-      { id: 'desktop', label: 'Desktop', minWidth: 769 },
-      { id: 'tablet', label: 'iPad', minWidth: 576, maxWidth: 768, viewportWidth: 768 },
+      { id: 'desktop', label: 'Desktop', minWidth: 768 },
+      { id: 'tablet', label: 'iPad', maxWidth: 768, viewportWidth: 768 },
       { id: 'mobile', label: 'iPhone 76', maxWidth: 575, viewportWidth: 575 },
     ])
   })
@@ -89,8 +92,8 @@ describe('parseBreakpointsInput', () => {
 
     // Assert
     expect(result).toEqual([
-      { id: 'desktop', label: 'Desktop', minWidth: 769 },
-      { id: 'tablet', minWidth: 576, maxWidth: 768, viewportWidth: 700 },
+      { id: 'desktop', label: 'Desktop', minWidth: 768 },
+      { id: 'tablet', maxWidth: 768, viewportWidth: 700 },
       { id: 'mobile', maxWidth: 575, viewportWidth: 300 },
     ])
   })

--- a/packages/runtime/src/state/modules/breakpoints.ts
+++ b/packages/runtime/src/state/modules/breakpoints.ts
@@ -19,16 +19,20 @@ export const DefaultBreakpointID = {
 
 type DefaultBreakpointID = (typeof DefaultBreakpointID)[keyof typeof DefaultBreakpointID]
 
+// Desktop-first cascading breakpoints: base breakpoint (Desktop) has no maxWidth,
+// smaller breakpoints use only maxWidth for proper CSS cascading without gaps.
+// Desktop's minWidth is for display (">768px") and canvas width only, NOT used in media queries.
 export const DEFAULT_BREAKPOINTS: Breakpoints = [
   {
     id: DefaultBreakpointID.Desktop,
     label: 'Desktop',
-    minWidth: 769,
+    // No maxWidth = base breakpoint, styles always apply
+    // minWidth matches Tablet for display purposes only
+    minWidth: 768,
   },
   {
     id: DefaultBreakpointID.Tablet,
     label: 'Tablet',
-    minWidth: 576,
     maxWidth: 768,
     viewportWidth: 760,
   },
@@ -70,15 +74,17 @@ export function parseBreakpointsInput(input: BreakpointsInput): Breakpoints {
     .map(([id, value]) => ({ ...value, id }))
     .sort((a, b) => b.width - a.width) // Sort by width in descending order
 
+  // Desktop-first cascading: base breakpoint has no maxWidth,
+  // other breakpoints use only maxWidth for proper CSS cascading without gaps.
+  // Note: minWidth on Desktop is for display/canvas purposes only - NOT used in media queries.
   const transformed = sorted.reduce(
-    (prev, curr, index, array) => {
+    (prev, curr) => {
       const { width, viewport, id, label } = curr
-      const next = array[index + 1]
 
       const breakpoint: Breakpoint = {
         id,
         ...(label && { label }),
-        ...(next && { minWidth: next.width + 1 }),
+        // Only maxWidth for cascading - no minWidth to avoid dead zones in media queries
         maxWidth: width,
         viewportWidth: viewport ?? width,
       }
@@ -86,7 +92,13 @@ export function parseBreakpointsInput(input: BreakpointsInput): Breakpoints {
       return [...prev, breakpoint]
     },
     [
-      { id: DefaultBreakpointID.Desktop, label: 'Desktop', minWidth: sorted[0].width + 1 },
+      // Base breakpoint (Desktop) has no maxWidth - styles always apply.
+      // minWidth is for display (">Npx") and builder canvas width only, NOT used in media queries.
+      {
+        id: DefaultBreakpointID.Desktop,
+        label: 'Desktop',
+        minWidth: sorted[0].width,
+      },
     ] as Breakpoints,
   )
 


### PR DESCRIPTION
This pull request refactors how breakpoints and media queries are handled for responsive styles, shifting from a min-width-based approach to a desktop-first cascading model using only max-width for non-base breakpoints. This change improves style application consistency, especially when browser zoom levels introduce fractional pixel "dead zones."

**Breakpoints and Media Query Refactor**

* Refactored `sortBreakpoints` in `breakpoints.ts` to order breakpoints for desktop-first cascading: the base breakpoint (no maxWidth) comes first, followed by others sorted by descending maxWidth.
* Changed `getBreakpointMediaQuery` to use only max-width for non-base breakpoints, eliminating min-width conditions and preventing dead zones in responsive styling.

**Responsive Value Matching**

* Updated `useMediaQuery.ts` to sort device queries by ascending maxWidth and to select the most specific matching breakpoint when multiple queries apply. This ensures correct style overrides for the smallest applicable device. [[1]](diffhunk://#diff-31957d5a18f0215c561182731f2118415e2d8b3144eeafdcd7cc117b7ad29da6R12-R26) [[2]](diffhunk://#diff-31957d5a18f0215c561182731f2118415e2d8b3144eeafdcd7cc117b7ad29da6L36-R56)

**Test and Snapshot Updates**

* Updated all relevant Jest snapshots to reflect the new media query logic, replacing `min-width`/`max-width` combinations with desktop-first queries using only `max-width` for smaller breakpoints and base queries for desktop. [[1]](diffhunk://#diff-2784d7b1ea666626942212a8c40d1544f1c8fef075aa12c4b9fa2f7e098a3340L8-R14) [[2]](diffhunk://#diff-2784d7b1ea666626942212a8c40d1544f1c8fef075aa12c4b9fa2f7e098a3340L26-R26) [[3]](diffhunk://#diff-2784d7b1ea666626942212a8c40d1544f1c8fef075aa12c4b9fa2f7e098a3340L35-R35) [[4]](diffhunk://#diff-2784d7b1ea666626942212a8c40d1544f1c8fef075aa12c4b9fa2f7e098a3340L57-R57) [[5]](diffhunk://#diff-2784d7b1ea666626942212a8c40d1544f1c8fef075aa12c4b9fa2f7e098a3340L67-R67) [[6]](diffhunk://#diff-2784d7b1ea666626942212a8c40d1544f1c8fef075aa12c4b9fa2f7e098a3340L112-R118) [[7]](diffhunk://#diff-2784d7b1ea666626942212a8c40d1544f1c8fef075aa12c4b9fa2f7e098a3340L134-R140) [[8]](diffhunk://#diff-2784d7b1ea666626942212a8c40d1544f1c8fef075aa12c4b9fa2f7e098a3340L152-R152) [[9]](diffhunk://#diff-2784d7b1ea666626942212a8c40d1544f1c8fef075aa12c4b9fa2f7e098a3340L161-R161) [[10]](diffhunk://#diff-2784d7b1ea666626942212a8c40d1544f1c8fef075aa12c4b9fa2f7e098a3340L179-R179) [[11]](diffhunk://#diff-2784d7b1ea666626942212a8c40d1544f1c8fef075aa12c4b9fa2f7e098a3340L188-R188) [[12]](diffhunk://#diff-2784d7b1ea666626942212a8c40d1544f1c8fef075aa12c4b9fa2f7e098a3340L214-R214) [[13]](diffhunk://#diff-2784d7b1ea666626942212a8c40d1544f1c8fef075aa12c4b9fa2f7e098a3340L225-R225) [[14]](diffhunk://#diff-e84de08fec3ae53340a2a2aca2f639f988e56c79209766118fabc0d8fb502688L21-R27) [[15]](diffhunk://#diff-e84de08fec3ae53340a2a2aca2f639f988e56c79209766118fabc0d8fb502688L39-R39) [[16]](diffhunk://#diff-e84de08fec3ae53340a2a2aca2f639f988e56c79209766118fabc0d8fb502688L48-R48) [[17]](diffhunk://#diff-e84de08fec3ae53340a2a2aca2f639f988e56c79209766118fabc0d8fb502688L66-R66) [[18]](diffhunk://#diff-e84de08fec3ae53340a2a2aca2f639f988e56c79209766118fabc0d8fb502688L75-R75) [[19]](diffhunk://#diff-e84de08fec3ae53340a2a2aca2f639f988e56c79209766118fabc0d8fb502688L97-R105) [[20]](diffhunk://#diff-e84de08fec3ae53340a2a2aca2f639f988e56c79209766118fabc0d8fb502688L143-R149) [[21]](diffhunk://#diff-e84de08fec3ae53340a2a2aca2f639f988e56c79209766118fabc0d8fb502688L161-R161) [[22]](diffhunk://#diff-e84de08fec3ae53340a2a2aca2f639f988e56c79209766118fabc0d8fb502688L170-R170) [[23]](diffhunk://#diff-e84de08fec3ae53340a2a2aca2f639f988e56c79209766118fabc0d8fb502688L188-R188) [[24]](diffhunk://#diff-e84de08fec3ae53340a2a2aca2f639f988e56c79209766118fabc0d8fb502688L197-R197) [[25]](diffhunk://#diff-e84de08fec3ae53340a2a2aca2f639f988e56c79209766118fabc0d8fb502688L224-R232) [[26]](diffhunk://#diff-e83df1e23e7accf6619abb46543f81e80c9fd10bcadacd75608c1eff8ca7ca2bL201-R207) [[27]](diffhunk://#diff-e83df1e23e7accf6619abb46543f81e80c9fd10bcadacd75608c1eff8ca7ca2bL219-R219)

**Viewport Calculation Improvements**

* Enhanced `getViewportStyle` to derive the minWidth for base breakpoints from the next smaller breakpoint, supporting better builder canvas behavior and accurate display for desktop.