### PR TITLE
feat: library to convert jsx + tailwind into makeswift controls and page schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ storybook-static
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+
+# AI
+.features

--- a/packages/jsx-to-makeswift/README.md
+++ b/packages/jsx-to-makeswift/README.md
@@ -1,0 +1,441 @@
+# @makeswift/jsx-to-makeswift
+
+Bidirectional transformation between JSX with Tailwind CSS and Makeswift control schemas.
+
+## Overview
+
+This library provides two-way conversion:
+- **JSX → Schema**: Parse JSX with Tailwind CSS classes and generate Makeswift control schemas
+- **Schema → JSX**: Convert Makeswift control schemas back to JSX with Tailwind classes
+- **Makeswift Runtime → JSX**: Convert actual Makeswift page data (runtime schema) to JSX
+
+This enables round-trip workflows, code export from Makeswift, and AI agent integration.
+
+## Installation
+
+```bash
+pnpm add @makeswift/jsx-to-makeswift
+```
+
+## Usage
+
+### Basic Transform
+
+```typescript
+import { transformJSX } from '@makeswift/jsx-to-makeswift'
+
+const jsx = `
+  <div className="m-4 p-6 bg-blue-500 rounded-lg">
+    <h1 className="text-2xl font-bold text-white">Welcome</h1>
+    <p className="text-gray-100">This is a description</p>
+  </div>
+`
+
+const result = transformJSX(jsx)
+
+console.log(result.schemas[0])
+// {
+//   type: 'Container',
+//   tagName: 'div',
+//   controls: {
+//     style: { type: 'Style', properties: ['margin', 'padding', 'borderRadius'], ... },
+//     backgroundColor: { type: 'Color', property: 'backgroundColor', ... },
+//     ...
+//   },
+//   children: { type: 'Slot', elements: [...] }
+// }
+```
+
+### Get JSON Output
+
+```typescript
+import { transformJSXToJSON } from '@makeswift/jsx-to-makeswift'
+
+const json = transformJSXToJSON(jsx)
+console.log(json) // Pretty-printed JSON string
+```
+
+### Reverse Transform (Schema → JSX)
+
+```typescript
+import { transformSchemaToJSX } from '@makeswift/jsx-to-makeswift'
+
+const schema = {
+  type: 'Container',
+  tagName: 'div',
+  controls: {
+    style: {
+      type: 'Style',
+      properties: ['padding'],
+      value: [{ deviceId: 'mobile', value: { padding: '1rem' } }]
+    },
+    backgroundColor: {
+      type: 'Color',
+      property: 'backgroundColor',
+      value: [{ deviceId: 'mobile', value: { color: '#3b82f6', alpha: 1 } }]
+    },
+    content: { type: 'TextInput', value: 'Hello World' }
+  }
+}
+
+const result = transformSchemaToJSX(schema)
+console.log(result.jsx)
+// <div className="p-4 bg-blue-500">Hello World</div>
+```
+
+### Round-Trip Conversion
+
+```typescript
+import { transformJSX, transformSchemaToJSX } from '@makeswift/jsx-to-makeswift'
+
+// JSX → Schema
+const jsx = '<div className="m-4 p-6 bg-blue-500">Hello</div>'
+const { schemas } = transformJSX(jsx)
+
+// Schema → JSX
+const { jsx: regenerated } = transformSchemaToJSX(schemas[0])
+console.log(regenerated)
+// <div className="m-4 p-6 bg-blue-500">Hello</div>
+```
+
+### Makeswift Runtime Schema → JSX
+
+Convert actual Makeswift page data (the format stored in the database) to JSX:
+
+```typescript
+import { transformRuntimeToJSX } from '@makeswift/jsx-to-makeswift'
+
+const runtimeSchema = {
+  key: "abc123",
+  type: "./components/Box/index.js",
+  props: {
+    padding: [{ deviceId: "desktop", value: { paddingTop: { value: 20, unit: "px" }, ... } }],
+    children: { elements: [...] }
+  }
+}
+
+const result = transformRuntimeToJSX(runtimeSchema)
+console.log(result.jsx)
+// <div className="lg:p-5">...</div>
+```
+
+The CLI auto-detects the schema format:
+
+```bash
+# Works with both ElementSchema and Makeswift Runtime formats
+npx jsx-to-makeswift reverse makeswift-page.json
+```
+
+### Options
+
+```typescript
+const result = transformJSX(jsx, {
+  // Include original Tailwind classes in metadata
+  preserveOriginalClasses: true,
+
+  // Include hover:, focus:, etc. variants in metadata
+  includeStateVariants: true,
+
+  // Infer content control types (TextInput, TextArea, RichText)
+  inferContentControls: true,
+})
+```
+
+## Features
+
+### Tailwind Class Resolution
+
+Maps Tailwind utility classes to CSS properties:
+
+- **Spacing**: `m-*`, `p-*`, `gap-*` → Style control (margin, padding, gap)
+- **Sizing**: `w-*`, `h-*`, `min-*`, `max-*` → Style control
+- **Colors**: `text-*`, `bg-*`, `border-*` → Color control
+- **Typography**: `font-*`, `text-*`, `leading-*` → Typography control
+- **Layout**: `flex`, `grid`, `block`, position utilities → Style control
+- **Borders**: `border-*`, `rounded-*`, `shadow-*` → Style control
+
+### Responsive Support
+
+Handles Tailwind responsive prefixes and maps them to Makeswift's three-device model:
+
+| Tailwind | Makeswift Device |
+|----------|------------------|
+| (base)   | `mobile`         |
+| `sm:`    | `tablet`         |
+| `md:`, `lg:`, `xl:`, `2xl:` | `desktop` |
+
+When multiple breakpoints map to the same device (e.g., `md:` and `lg:` both → `desktop`), the largest breakpoint takes precedence.
+
+```jsx
+<div className="p-4 sm:p-6 md:p-8 lg:p-12">
+```
+
+Maps to:
+- `mobile` → padding: 1rem
+- `tablet` → padding: 1.5rem
+- `desktop` → padding: 3rem (lg: wins over md:)
+
+### Content Type Inference
+
+Automatically infers appropriate content control types:
+
+- `<h1>Short title</h1>` → TextInput
+- `<p>Longer paragraph content...</p>` → TextArea
+- `<p>Text with <strong>formatting</strong></p>` → RichText
+
+### Arbitrary Values
+
+Supports Tailwind arbitrary value syntax:
+
+```jsx
+<div className="w-[300px] bg-[#ff0000]">
+```
+
+### Image Detection
+
+Automatically detects `<img>` elements and extracts image attributes:
+
+```jsx
+<img src="/hero.jpg" alt="Hero image" width={800} height={600} className="rounded-lg" />
+```
+
+Generates:
+- `image` control with `src`, `alt`, `width`, `height`
+- `style` control for Tailwind classes
+
+### Link Detection
+
+Detects `<a>` elements and extracts link attributes:
+
+```jsx
+<a href="/about" target="_blank" className="text-blue-500">About Us</a>
+```
+
+Generates:
+- `link` control with `href`, `target`
+- `content` control for link text
+- `textColor` control for Tailwind color classes
+
+### Button Detection
+
+Handles `<button>` elements with optional link attributes:
+
+```jsx
+<button className="bg-blue-500 text-white px-4 py-2 rounded-lg">Click Me</button>
+```
+
+Generates:
+- `content` control for button text
+- `style`, `backgroundColor`, `textColor` controls for styling
+- `link` control if `href` attribute is present
+
+### Video Detection
+
+Extracts video source and poster from `<video>` elements:
+
+```jsx
+<video src="/intro.mp4" poster="/thumbnail.jpg" className="w-full" />
+```
+
+Generates:
+- `video` control with source URL
+- `poster` control (Image type) for thumbnail
+
+## API Reference
+
+### `transformJSX(source, options?)`
+
+Parses JSX source and returns transform results.
+
+**Parameters:**
+- `source: string` - JSX source code
+- `options?: TransformJSXOptions` - Transform options
+
+**Returns:** `TransformJSXResult`
+- `schemas: ElementSchema[]` - Generated schemas
+- `errors: string[]` - Parse errors
+- `warnings: string[]` - Transform warnings
+- `unmappedClasses: string[]` - Tailwind classes that couldn't be mapped
+
+### `transformJSXToJSON(source, options?)`
+
+Same as `transformJSX` but returns a JSON string.
+
+### `transformSchemaToJSX(input, options?)`
+
+Transforms a Makeswift control schema back to JSX with Tailwind classes.
+
+- `input` - Schema object, array of schemas, or JSON string
+- `options.preferShorthand` - Use shorthand classes (e.g., `p-4` vs `pt-4 pr-4 pb-4 pl-4`)
+- `options.selfClosingTags` - Use self-closing tags for empty elements
+- Returns `{ jsx: string, warnings: string[], unmappedValues: string[] }`
+
+### `schemaToJSXString(input, options?)`
+
+Same as `transformSchemaToJSX` but returns just the JSX string.
+
+### `transformRuntimeToJSX(input, options?)`
+
+Transforms a Makeswift runtime schema (actual page data) to JSX with Tailwind.
+
+- `input` - Makeswift runtime schema object or JSON string
+- `options.indent` - Indentation string (default: 2 spaces)
+- `options.includeKeys` - Include `data-key` attributes for debugging
+- Returns `{ jsx: string, warnings: string[] }`
+
+Auto-detects the format: works with both ElementSchema and Makeswift runtime formats.
+
+### `parseJSX(source)`
+
+Low-level JSX parsing using Babel.
+
+### `tokenizeTailwindClasses(className)`
+
+Tokenizes Tailwind class string into structured tokens.
+
+### `buildSchema(elements, options?)`
+
+Builds control schemas from parsed JSX elements.
+
+## Output Schema
+
+```typescript
+type ElementSchema = {
+  type: string           // Inferred element type (Container, Heading, Button, etc.)
+  tagName: string        // Original HTML tag name
+  controls: Record<string, ControlValue>
+  children?: SlotControlValue
+  metadata?: {
+    originalClassName?: string
+    stateVariants?: Record<string, string[]>
+  }
+}
+```
+
+## Control Types
+
+| Control | Description |
+|---------|-------------|
+| `Style` | CSS styling properties (margin, padding, layout, etc.) |
+| `Color` | Color values with swatch support |
+| `Typography` | Font properties (size, weight, family, etc.) |
+| `TextInput` | Single-line text content |
+| `TextArea` | Multi-line text content |
+| `RichText` | Formatted text with inline elements |
+| `Image` | Image with src, alt, width, height |
+| `Link` | Link with href, target |
+| `Slot` | Container for child elements |
+
+## CLI Usage
+
+The package includes a CLI tool for bidirectional conversion:
+
+### Convert JSX to Schema
+
+```bash
+# Convert a single file
+npx jsx-to-makeswift convert src/components/Hero.tsx
+
+# Convert multiple files
+npx jsx-to-makeswift convert src/components/*.tsx
+
+# Read from stdin
+echo '<div className="p-4">Hello</div>' | npx jsx-to-makeswift convert --stdin
+
+# Compact output (no pretty-printing)
+npx jsx-to-makeswift convert --compact src/components/Card.tsx
+```
+
+### Convert Schema to JSX (Reverse)
+
+```bash
+# Convert a JSON schema file to JSX
+npx jsx-to-makeswift reverse schema.json
+
+# Read schema from stdin
+cat schema.json | npx jsx-to-makeswift reverse --stdin
+
+# Round-trip: JSX → Schema → JSX
+echo '<div className="p-4 bg-blue-500">Hello</div>' | \
+  npx jsx-to-makeswift convert --stdin | \
+  npx jsx-to-makeswift reverse --stdin
+```
+
+### Help
+
+```bash
+npx jsx-to-makeswift --help
+```
+
+### CLI Options
+
+| Option | Description |
+|--------|-------------|
+| `--help, -h` | Show help message |
+| `--version, -v` | Show version number |
+| `--stdin` | Read input from stdin |
+| `--pretty` | Pretty-print JSON output (default) |
+| `--compact` | Compact JSON output |
+| `--fragment` | Treat input as JSX fragment |
+
+### Exit Codes
+
+- `0` - Success
+- `1` - Error (parse error, file not found, etc.)
+
+## Documentation
+
+For detailed documentation, see:
+
+- [Mapping Reference](./docs/mapping-reference.md) - Complete Tailwind to Control mapping
+- [Examples](./docs/examples.md) - Common component patterns and usage examples
+
+## Development
+
+```bash
+# Install dependencies
+pnpm install
+
+# Run tests
+pnpm test
+
+# Build
+pnpm build
+
+# Development mode
+pnpm dev
+```
+
+### Local CLI Setup with pnpm link
+
+To test the CLI locally as if it were installed globally:
+
+```bash
+# 1. Build the package
+pnpm build
+
+# 2. Link globally
+pnpm link --global
+
+# 3. Now use the CLI from anywhere
+jsx-to-makeswift --help
+jsx-to-makeswift convert path/to/component.tsx
+echo '<div className="p-4">Hello</div>' | jsx-to-makeswift convert --stdin
+
+# To unlink later
+pnpm unlink --global @makeswift/jsx-to-makeswift
+```
+
+Alternatively, run without linking:
+
+```bash
+# Using pnpm exec within the package directory
+pnpm exec jsx-to-makeswift --help
+
+# Or run the built file directly
+node dist/cli.js convert path/to/file.tsx
+```
+
+## License
+
+MIT

--- a/packages/jsx-to-makeswift/docs/examples.md
+++ b/packages/jsx-to-makeswift/docs/examples.md
@@ -1,0 +1,679 @@
+# JSX to Makeswift Controls - Examples
+
+This document provides examples of common component patterns and their transformed output.
+
+## Basic Container
+
+**Input:**
+
+```jsx
+<div className="m-4 p-6 bg-blue-500 rounded-lg">
+  Hello World
+</div>
+```
+
+**Output:**
+
+```json
+{
+  "type": "Container",
+  "tagName": "div",
+  "controls": {
+    "style": {
+      "type": "Style",
+      "properties": ["margin", "padding", "borderRadius"],
+      "value": [
+        {
+          "deviceId": "mobile",
+          "value": {
+            "margin": "1rem",
+            "padding": "1.5rem",
+            "borderRadius": "0.5rem"
+          }
+        }
+      ]
+    },
+    "backgroundColor": {
+      "type": "Color",
+      "property": "backgroundColor",
+      "value": [
+        {
+          "deviceId": "mobile",
+          "value": { "color": "#3b82f6", "alpha": 1 }
+        }
+      ]
+    },
+    "content": {
+      "type": "TextInput",
+      "value": "Hello World"
+    }
+  }
+}
+```
+
+---
+
+## Hero Section
+
+**Input:**
+
+```jsx
+<section className="bg-gray-100 p-8 md:p-16">
+  <h1 className="text-4xl md:text-6xl font-bold text-gray-900">
+    Welcome to Our Site
+  </h1>
+  <p className="text-xl text-gray-600 mt-4">
+    The best place to find what you need.
+  </p>
+  <button className="bg-blue-500 text-white px-6 py-3 rounded-lg mt-6">
+    Get Started
+  </button>
+</section>
+```
+
+**Output:**
+
+```json
+{
+  "type": "Container",
+  "tagName": "section",
+  "controls": {
+    "style": {
+      "type": "Style",
+      "properties": ["padding"],
+      "value": [
+        { "deviceId": "mobile", "value": { "padding": "2rem" } },
+        { "deviceId": "desktop", "value": { "padding": "4rem" } }
+      ]
+    },
+    "backgroundColor": {
+      "type": "Color",
+      "property": "backgroundColor",
+      "value": [
+        { "deviceId": "mobile", "value": { "color": "#f3f4f6", "alpha": 1 } }
+      ]
+    }
+  },
+  "children": {
+    "type": "Slot",
+    "elements": [
+      {
+        "type": "Heading",
+        "tagName": "h1",
+        "controls": {
+          "typography": {
+            "type": "Typography",
+            "value": [
+              { "deviceId": "mobile", "value": { "fontSize": "2.25rem", "fontWeight": 700 } },
+              { "deviceId": "desktop", "value": { "fontSize": "3.75rem" } }
+            ]
+          },
+          "textColor": {
+            "type": "Color",
+            "property": "textColor",
+            "value": [
+              { "deviceId": "mobile", "value": { "color": "#111827", "alpha": 1 } }
+            ]
+          },
+          "content": { "type": "TextInput", "value": "Welcome to Our Site" }
+        }
+      },
+      {
+        "type": "Paragraph",
+        "tagName": "p",
+        "controls": {
+          "style": {
+            "type": "Style",
+            "properties": ["marginTop"],
+            "value": [
+              { "deviceId": "mobile", "value": { "marginTop": "1rem" } }
+            ]
+          },
+          "typography": {
+            "type": "Typography",
+            "value": [
+              { "deviceId": "mobile", "value": { "fontSize": "1.25rem" } }
+            ]
+          },
+          "textColor": {
+            "type": "Color",
+            "property": "textColor",
+            "value": [
+              { "deviceId": "mobile", "value": { "color": "#4b5563", "alpha": 1 } }
+            ]
+          },
+          "content": { "type": "TextInput", "value": "The best place to find what you need." }
+        }
+      },
+      {
+        "type": "Button",
+        "tagName": "button",
+        "controls": {
+          "style": {
+            "type": "Style",
+            "properties": ["paddingLeft", "paddingRight", "paddingTop", "paddingBottom", "borderRadius", "marginTop"],
+            "value": [
+              {
+                "deviceId": "mobile",
+                "value": {
+                  "paddingLeft": "1.5rem",
+                  "paddingRight": "1.5rem",
+                  "paddingTop": "0.75rem",
+                  "paddingBottom": "0.75rem",
+                  "borderRadius": "0.5rem",
+                  "marginTop": "1.5rem"
+                }
+              }
+            ]
+          },
+          "backgroundColor": {
+            "type": "Color",
+            "property": "backgroundColor",
+            "value": [
+              { "deviceId": "mobile", "value": { "color": "#3b82f6", "alpha": 1 } }
+            ]
+          },
+          "textColor": {
+            "type": "Color",
+            "property": "textColor",
+            "value": [
+              { "deviceId": "mobile", "value": { "color": "#ffffff", "alpha": 1 } }
+            ]
+          },
+          "content": { "type": "TextInput", "value": "Get Started" }
+        }
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Card Component
+
+**Input:**
+
+```jsx
+<div className="bg-white rounded-lg shadow-md p-6">
+  <img src="/card-image.jpg" alt="Card" className="w-full rounded-t-lg" />
+  <h2 className="text-xl font-bold mt-4">Card Title</h2>
+  <p className="text-gray-600 mt-2">Card description goes here.</p>
+  <a href="/read-more" className="text-blue-500 mt-4 inline-block">Read More</a>
+</div>
+```
+
+**Output:**
+
+```json
+{
+  "type": "Container",
+  "tagName": "div",
+  "controls": {
+    "style": {
+      "type": "Style",
+      "properties": ["padding", "borderRadius", "boxShadow"],
+      "value": [
+        {
+          "deviceId": "mobile",
+          "value": {
+            "padding": "1.5rem",
+            "borderRadius": "0.5rem",
+            "boxShadow": "0 4px 6px -1px rgba(0, 0, 0, 0.1)"
+          }
+        }
+      ]
+    },
+    "backgroundColor": {
+      "type": "Color",
+      "property": "backgroundColor",
+      "value": [
+        { "deviceId": "mobile", "value": { "color": "#ffffff", "alpha": 1 } }
+      ]
+    }
+  },
+  "children": {
+    "type": "Slot",
+    "elements": [
+      {
+        "type": "Image",
+        "tagName": "img",
+        "controls": {
+          "image": {
+            "type": "Image",
+            "value": { "src": "/card-image.jpg", "alt": "Card" }
+          },
+          "style": {
+            "type": "Style",
+            "properties": ["width", "borderRadius"],
+            "value": [
+              { "deviceId": "mobile", "value": { "width": "100%", "borderRadius": "0.5rem 0.5rem 0 0" } }
+            ]
+          }
+        }
+      },
+      {
+        "type": "Heading",
+        "tagName": "h2",
+        "controls": {
+          "style": {
+            "type": "Style",
+            "properties": ["marginTop"],
+            "value": [{ "deviceId": "mobile", "value": { "marginTop": "1rem" } }]
+          },
+          "typography": {
+            "type": "Typography",
+            "value": [
+              { "deviceId": "mobile", "value": { "fontSize": "1.25rem", "fontWeight": 700 } }
+            ]
+          },
+          "content": { "type": "TextInput", "value": "Card Title" }
+        }
+      },
+      {
+        "type": "Paragraph",
+        "tagName": "p",
+        "controls": {
+          "style": {
+            "type": "Style",
+            "properties": ["marginTop"],
+            "value": [{ "deviceId": "mobile", "value": { "marginTop": "0.5rem" } }]
+          },
+          "textColor": {
+            "type": "Color",
+            "property": "textColor",
+            "value": [{ "deviceId": "mobile", "value": { "color": "#4b5563", "alpha": 1 } }]
+          },
+          "content": { "type": "TextInput", "value": "Card description goes here." }
+        }
+      },
+      {
+        "type": "Link",
+        "tagName": "a",
+        "controls": {
+          "link": { "type": "Link", "value": { "href": "/read-more" } },
+          "style": {
+            "type": "Style",
+            "properties": ["marginTop", "display"],
+            "value": [{ "deviceId": "mobile", "value": { "marginTop": "1rem", "display": "inline-block" } }]
+          },
+          "textColor": {
+            "type": "Color",
+            "property": "textColor",
+            "value": [{ "deviceId": "mobile", "value": { "color": "#3b82f6", "alpha": 1 } }]
+          },
+          "content": { "type": "TextInput", "value": "Read More" }
+        }
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Navigation Bar
+
+**Input:**
+
+```jsx
+<nav className="flex justify-between items-center p-4 bg-white shadow">
+  <a href="/" className="text-xl font-bold">Logo</a>
+  <div className="flex gap-6">
+    <a href="/about" className="text-gray-600 hover:text-gray-900">About</a>
+    <a href="/services" className="text-gray-600 hover:text-gray-900">Services</a>
+    <a href="/contact" className="text-gray-600 hover:text-gray-900">Contact</a>
+  </div>
+</nav>
+```
+
+**Output:**
+
+```json
+{
+  "type": "Nav",
+  "tagName": "nav",
+  "controls": {
+    "style": {
+      "type": "Style",
+      "properties": ["display", "justifyContent", "alignItems", "padding", "boxShadow"],
+      "value": [
+        {
+          "deviceId": "mobile",
+          "value": {
+            "display": "flex",
+            "justifyContent": "space-between",
+            "alignItems": "center",
+            "padding": "1rem"
+          }
+        }
+      ]
+    },
+    "backgroundColor": {
+      "type": "Color",
+      "property": "backgroundColor",
+      "value": [{ "deviceId": "mobile", "value": { "color": "#ffffff", "alpha": 1 } }]
+    }
+  },
+  "children": {
+    "type": "Slot",
+    "elements": [
+      {
+        "type": "Link",
+        "tagName": "a",
+        "controls": {
+          "link": { "type": "Link", "value": { "href": "/" } },
+          "typography": {
+            "type": "Typography",
+            "value": [{ "deviceId": "mobile", "value": { "fontSize": "1.25rem", "fontWeight": 700 } }]
+          },
+          "content": { "type": "TextInput", "value": "Logo" }
+        }
+      },
+      {
+        "type": "Container",
+        "tagName": "div",
+        "controls": {
+          "style": {
+            "type": "Style",
+            "properties": ["display", "gap"],
+            "value": [{ "deviceId": "mobile", "value": { "display": "flex", "gap": "1.5rem" } }]
+          }
+        },
+        "children": {
+          "type": "Slot",
+          "elements": [
+            {
+              "type": "Link",
+              "tagName": "a",
+              "controls": {
+                "link": { "type": "Link", "value": { "href": "/about" } },
+                "textColor": {
+                  "type": "Color",
+                  "property": "textColor",
+                  "value": [{ "deviceId": "mobile", "value": { "color": "#4b5563", "alpha": 1 } }]
+                },
+                "content": { "type": "TextInput", "value": "About" }
+              }
+            },
+            {
+              "type": "Link",
+              "tagName": "a",
+              "controls": {
+                "link": { "type": "Link", "value": { "href": "/services" } },
+                "textColor": {
+                  "type": "Color",
+                  "property": "textColor",
+                  "value": [{ "deviceId": "mobile", "value": { "color": "#4b5563", "alpha": 1 } }]
+                },
+                "content": { "type": "TextInput", "value": "Services" }
+              }
+            },
+            {
+              "type": "Link",
+              "tagName": "a",
+              "controls": {
+                "link": { "type": "Link", "value": { "href": "/contact" } },
+                "textColor": {
+                  "type": "Color",
+                  "property": "textColor",
+                  "value": [{ "deviceId": "mobile", "value": { "color": "#4b5563", "alpha": 1 } }]
+                },
+                "content": { "type": "TextInput", "value": "Contact" }
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Responsive Layout
+
+**Input:**
+
+```jsx
+<div className="flex flex-col md:flex-row gap-4 md:gap-8 p-4 md:p-8">
+  <div className="w-full md:w-1/2">Left Column</div>
+  <div className="w-full md:w-1/2">Right Column</div>
+</div>
+```
+
+**Output:**
+
+```json
+{
+  "type": "Container",
+  "tagName": "div",
+  "controls": {
+    "style": {
+      "type": "Style",
+      "properties": ["display", "flexDirection", "gap", "padding"],
+      "value": [
+        {
+          "deviceId": "mobile",
+          "value": {
+            "display": "flex",
+            "flexDirection": "column",
+            "gap": "1rem",
+            "padding": "1rem"
+          }
+        },
+        {
+          "deviceId": "desktop",
+          "value": {
+            "flexDirection": "row",
+            "gap": "2rem",
+            "padding": "2rem"
+          }
+        }
+      ]
+    }
+  },
+  "children": {
+    "type": "Slot",
+    "elements": [
+      {
+        "type": "Container",
+        "tagName": "div",
+        "controls": {
+          "style": {
+            "type": "Style",
+            "properties": ["width"],
+            "value": [
+              { "deviceId": "mobile", "value": { "width": "100%" } },
+              { "deviceId": "desktop", "value": { "width": "50%" } }
+            ]
+          },
+          "content": { "type": "TextInput", "value": "Left Column" }
+        }
+      },
+      {
+        "type": "Container",
+        "tagName": "div",
+        "controls": {
+          "style": {
+            "type": "Style",
+            "properties": ["width"],
+            "value": [
+              { "deviceId": "mobile", "value": { "width": "100%" } },
+              { "deviceId": "desktop", "value": { "width": "50%" } }
+            ]
+          },
+          "content": { "type": "TextInput", "value": "Right Column" }
+        }
+      }
+    ]
+  }
+}
+```
+
+---
+
+## CLI Usage Examples
+
+### Convert a single file
+
+```bash
+npx jsx-to-makeswift convert src/components/Hero.tsx
+```
+
+### Convert from stdin
+
+```bash
+echo '<div className="p-4 bg-blue-500">Hello</div>' | npx jsx-to-makeswift convert --stdin
+```
+
+### Convert with compact output
+
+```bash
+npx jsx-to-makeswift convert --compact src/components/Card.tsx
+```
+
+### Convert multiple files
+
+```bash
+npx jsx-to-makeswift convert src/components/*.tsx
+```
+
+### Use in a pipeline
+
+```bash
+cat Hero.jsx | npx jsx-to-makeswift convert --stdin | jq '.controls'
+```
+
+---
+
+## Programmatic Usage
+
+### Basic transformation
+
+```typescript
+import { transformJSX } from '@makeswift/jsx-to-makeswift'
+
+const jsx = `<div className="p-4 bg-blue-500">Hello</div>`
+const result = transformJSX(jsx)
+
+console.log(result.schemas[0])
+```
+
+### Handle errors
+
+```typescript
+import { transformJSX } from '@makeswift/jsx-to-makeswift'
+
+const result = transformJSX(invalidJsx)
+
+if (result.errors.length > 0) {
+  console.error('Parse errors:', result.errors)
+} else {
+  console.log('Schemas:', result.schemas)
+}
+```
+
+### Get JSON output
+
+```typescript
+import { transformJSXToJSON } from '@makeswift/jsx-to-makeswift'
+
+const json = transformJSXToJSON(`<div className="p-4">Hello</div>`)
+console.log(json) // Pretty-printed JSON string
+```
+
+### Transform a single element
+
+```typescript
+import { transformJSXElement } from '@makeswift/jsx-to-makeswift'
+
+const result = transformJSXElement(`<h1 className="text-2xl">Title</h1>`)
+
+if (result) {
+  console.log(result.schema.type) // 'Heading'
+  console.log(result.schema.controls.content.value) // 'Title'
+}
+```
+
+---
+
+## Reverse Transformation (Schema → JSX)
+
+### Basic reverse transformation
+
+```typescript
+import { transformSchemaToJSX } from '@makeswift/jsx-to-makeswift'
+
+const schema = {
+  type: 'Container',
+  tagName: 'div',
+  controls: {
+    style: {
+      type: 'Style',
+      properties: ['padding'],
+      value: [{ deviceId: 'mobile', value: { padding: '1rem' } }]
+    },
+    content: { type: 'TextInput', value: 'Hello' }
+  }
+}
+
+const result = transformSchemaToJSX(schema)
+console.log(result.jsx)
+// <div className="p-4">Hello</div>
+```
+
+### Reverse with responsive values
+
+```typescript
+const schema = {
+  type: 'Container',
+  tagName: 'div',
+  controls: {
+    style: {
+      type: 'Style',
+      properties: ['padding'],
+      value: [
+        { deviceId: 'mobile', value: { padding: '1rem' } },
+        { deviceId: 'tablet', value: { padding: '1.5rem' } },
+        { deviceId: 'desktop', value: { padding: '2rem' } }
+      ]
+    }
+  }
+}
+
+const result = transformSchemaToJSX(schema)
+console.log(result.jsx)
+// <div className="p-4 sm:p-6 lg:p-8" />
+```
+
+### CLI reverse command
+
+```bash
+# Convert schema file to JSX
+npx jsx-to-makeswift reverse schema.json
+
+# Read schema from stdin
+cat schema.json | npx jsx-to-makeswift reverse --stdin
+```
+
+### Round-trip conversion
+
+```bash
+# JSX → Schema → JSX
+echo '<div className="m-4 p-6 bg-blue-500 text-white">Hello</div>' | \
+  npx jsx-to-makeswift convert --stdin | \
+  npx jsx-to-makeswift reverse --stdin
+
+# Output: <div className="m-4 p-6 bg-blue-500 text-white">Hello</div>
+```
+
+### Get just the JSX string
+
+```typescript
+import { schemaToJSXString } from '@makeswift/jsx-to-makeswift'
+
+const jsx = schemaToJSXString(schema)
+console.log(jsx) // Just the JSX string, no metadata
+```

--- a/packages/jsx-to-makeswift/docs/mapping-reference.md
+++ b/packages/jsx-to-makeswift/docs/mapping-reference.md
@@ -1,0 +1,368 @@
+# Tailwind to Makeswift Controls Mapping Reference
+
+This document provides a complete reference of how Tailwind CSS classes map to Makeswift controls.
+
+## Control Types
+
+| Control | Description | Example Tailwind Classes |
+|---------|-------------|--------------------------|
+| `Style` | CSS layout, spacing, sizing, borders | `m-4`, `p-6`, `flex`, `rounded-lg` |
+| `Color` | Color values (text, background, border) | `text-blue-500`, `bg-gray-100` |
+| `Typography` | Font properties | `text-xl`, `font-bold`, `leading-relaxed` |
+| `TextInput` | Single-line text content | (inferred from short text) |
+| `TextArea` | Multi-line text content | (inferred from long text) |
+| `RichText` | Formatted text content | (inferred from nested inline elements) |
+| `Image` | Image with src/alt/dimensions | (from `<img>` elements) |
+| `Link` | URL with href/target | (from `<a>` elements) |
+| `Slot` | Container for nested elements | (from child elements) |
+
+---
+
+## Spacing Classes
+
+### Margin
+
+| Tailwind Class | CSS Property | Value |
+|----------------|--------------|-------|
+| `m-0` | margin | 0 |
+| `m-1` | margin | 0.25rem |
+| `m-2` | margin | 0.5rem |
+| `m-3` | margin | 0.75rem |
+| `m-4` | margin | 1rem |
+| `m-5` | margin | 1.25rem |
+| `m-6` | margin | 1.5rem |
+| `m-8` | margin | 2rem |
+| `m-10` | margin | 2.5rem |
+| `m-12` | margin | 3rem |
+| `m-16` | margin | 4rem |
+| `m-20` | margin | 5rem |
+| `m-24` | margin | 6rem |
+| `m-auto` | margin | auto |
+
+**Directional variants:** `mt-*`, `mr-*`, `mb-*`, `ml-*`, `mx-*`, `my-*`
+
+### Padding
+
+| Tailwind Class | CSS Property | Value |
+|----------------|--------------|-------|
+| `p-0` | padding | 0 |
+| `p-1` | padding | 0.25rem |
+| `p-2` | padding | 0.5rem |
+| `p-3` | padding | 0.75rem |
+| `p-4` | padding | 1rem |
+| `p-5` | padding | 1.25rem |
+| `p-6` | padding | 1.5rem |
+| `p-8` | padding | 2rem |
+| `p-10` | padding | 2.5rem |
+| `p-12` | padding | 3rem |
+| `p-16` | padding | 4rem |
+
+**Directional variants:** `pt-*`, `pr-*`, `pb-*`, `pl-*`, `px-*`, `py-*`
+
+### Gap
+
+| Tailwind Class | CSS Property | Value |
+|----------------|--------------|-------|
+| `gap-0` | gap | 0 |
+| `gap-1` | gap | 0.25rem |
+| `gap-2` | gap | 0.5rem |
+| `gap-4` | gap | 1rem |
+| `gap-6` | gap | 1.5rem |
+| `gap-8` | gap | 2rem |
+
+**Directional variants:** `gap-x-*`, `gap-y-*`
+
+---
+
+## Sizing Classes
+
+### Width
+
+| Tailwind Class | CSS Property | Value |
+|----------------|--------------|-------|
+| `w-0` | width | 0 |
+| `w-1` | width | 0.25rem |
+| `w-2` | width | 0.5rem |
+| `w-4` | width | 1rem |
+| `w-8` | width | 2rem |
+| `w-16` | width | 4rem |
+| `w-32` | width | 8rem |
+| `w-64` | width | 16rem |
+| `w-auto` | width | auto |
+| `w-full` | width | 100% |
+| `w-screen` | width | 100vw |
+| `w-1/2` | width | 50% |
+| `w-1/3` | width | 33.333333% |
+| `w-2/3` | width | 66.666667% |
+| `w-1/4` | width | 25% |
+| `w-3/4` | width | 75% |
+
+### Height
+
+| Tailwind Class | CSS Property | Value |
+|----------------|--------------|-------|
+| `h-0` | height | 0 |
+| `h-1` | height | 0.25rem |
+| `h-4` | height | 1rem |
+| `h-8` | height | 2rem |
+| `h-16` | height | 4rem |
+| `h-auto` | height | auto |
+| `h-full` | height | 100% |
+| `h-screen` | height | 100vh |
+
+### Max Width
+
+| Tailwind Class | CSS Property | Value |
+|----------------|--------------|-------|
+| `max-w-xs` | maxWidth | 20rem |
+| `max-w-sm` | maxWidth | 24rem |
+| `max-w-md` | maxWidth | 28rem |
+| `max-w-lg` | maxWidth | 32rem |
+| `max-w-xl` | maxWidth | 36rem |
+| `max-w-2xl` | maxWidth | 42rem |
+| `max-w-4xl` | maxWidth | 56rem |
+| `max-w-6xl` | maxWidth | 72rem |
+| `max-w-full` | maxWidth | 100% |
+
+---
+
+## Color Classes
+
+### Text Colors
+
+| Tailwind Class | CSS Property | Hex Value |
+|----------------|--------------|-----------|
+| `text-black` | color | #000000 |
+| `text-white` | color | #ffffff |
+| `text-gray-50` | color | #f9fafb |
+| `text-gray-100` | color | #f3f4f6 |
+| `text-gray-200` | color | #e5e7eb |
+| `text-gray-300` | color | #d1d5db |
+| `text-gray-400` | color | #9ca3af |
+| `text-gray-500` | color | #6b7280 |
+| `text-gray-600` | color | #4b5563 |
+| `text-gray-700` | color | #374151 |
+| `text-gray-800` | color | #1f2937 |
+| `text-gray-900` | color | #111827 |
+| `text-blue-500` | color | #3b82f6 |
+| `text-red-500` | color | #ef4444 |
+| `text-green-500` | color | #22c55e |
+
+### Background Colors
+
+| Tailwind Class | CSS Property | Hex Value |
+|----------------|--------------|-----------|
+| `bg-white` | backgroundColor | #ffffff |
+| `bg-black` | backgroundColor | #000000 |
+| `bg-gray-50` | backgroundColor | #f9fafb |
+| `bg-gray-100` | backgroundColor | #f3f4f6 |
+| `bg-gray-200` | backgroundColor | #e5e7eb |
+| `bg-blue-500` | backgroundColor | #3b82f6 |
+| `bg-blue-600` | backgroundColor | #2563eb |
+| `bg-red-500` | backgroundColor | #ef4444 |
+| `bg-green-500` | backgroundColor | #22c55e |
+
+---
+
+## Typography Classes
+
+### Font Size
+
+| Tailwind Class | CSS Property | Value |
+|----------------|--------------|-------|
+| `text-xs` | fontSize | 0.75rem |
+| `text-sm` | fontSize | 0.875rem |
+| `text-base` | fontSize | 1rem |
+| `text-lg` | fontSize | 1.125rem |
+| `text-xl` | fontSize | 1.25rem |
+| `text-2xl` | fontSize | 1.5rem |
+| `text-3xl` | fontSize | 1.875rem |
+| `text-4xl` | fontSize | 2.25rem |
+| `text-5xl` | fontSize | 3rem |
+| `text-6xl` | fontSize | 3.75rem |
+
+### Font Weight
+
+| Tailwind Class | CSS Property | Value |
+|----------------|--------------|-------|
+| `font-thin` | fontWeight | 100 |
+| `font-extralight` | fontWeight | 200 |
+| `font-light` | fontWeight | 300 |
+| `font-normal` | fontWeight | 400 |
+| `font-medium` | fontWeight | 500 |
+| `font-semibold` | fontWeight | 600 |
+| `font-bold` | fontWeight | 700 |
+| `font-extrabold` | fontWeight | 800 |
+| `font-black` | fontWeight | 900 |
+
+### Line Height
+
+| Tailwind Class | CSS Property | Value |
+|----------------|--------------|-------|
+| `leading-none` | lineHeight | 1 |
+| `leading-tight` | lineHeight | 1.25 |
+| `leading-snug` | lineHeight | 1.375 |
+| `leading-normal` | lineHeight | 1.5 |
+| `leading-relaxed` | lineHeight | 1.625 |
+| `leading-loose` | lineHeight | 2 |
+
+### Text Align
+
+| Tailwind Class | CSS Property | Value |
+|----------------|--------------|-------|
+| `text-left` | textAlign | left |
+| `text-center` | textAlign | center |
+| `text-right` | textAlign | right |
+| `text-justify` | textAlign | justify |
+
+---
+
+## Layout Classes
+
+### Display
+
+| Tailwind Class | CSS Property | Value |
+|----------------|--------------|-------|
+| `block` | display | block |
+| `inline-block` | display | inline-block |
+| `inline` | display | inline |
+| `flex` | display | flex |
+| `inline-flex` | display | inline-flex |
+| `grid` | display | grid |
+| `hidden` | display | none |
+
+### Flex Direction
+
+| Tailwind Class | CSS Property | Value |
+|----------------|--------------|-------|
+| `flex-row` | flexDirection | row |
+| `flex-row-reverse` | flexDirection | row-reverse |
+| `flex-col` | flexDirection | column |
+| `flex-col-reverse` | flexDirection | column-reverse |
+
+### Justify Content
+
+| Tailwind Class | CSS Property | Value |
+|----------------|--------------|-------|
+| `justify-start` | justifyContent | flex-start |
+| `justify-end` | justifyContent | flex-end |
+| `justify-center` | justifyContent | center |
+| `justify-between` | justifyContent | space-between |
+| `justify-around` | justifyContent | space-around |
+| `justify-evenly` | justifyContent | space-evenly |
+
+### Align Items
+
+| Tailwind Class | CSS Property | Value |
+|----------------|--------------|-------|
+| `items-start` | alignItems | flex-start |
+| `items-end` | alignItems | flex-end |
+| `items-center` | alignItems | center |
+| `items-baseline` | alignItems | baseline |
+| `items-stretch` | alignItems | stretch |
+
+### Position
+
+| Tailwind Class | CSS Property | Value |
+|----------------|--------------|-------|
+| `static` | position | static |
+| `fixed` | position | fixed |
+| `absolute` | position | absolute |
+| `relative` | position | relative |
+| `sticky` | position | sticky |
+
+---
+
+## Border Classes
+
+### Border Radius
+
+| Tailwind Class | CSS Property | Value |
+|----------------|--------------|-------|
+| `rounded-none` | borderRadius | 0 |
+| `rounded-sm` | borderRadius | 0.125rem |
+| `rounded` | borderRadius | 0.25rem |
+| `rounded-md` | borderRadius | 0.375rem |
+| `rounded-lg` | borderRadius | 0.5rem |
+| `rounded-xl` | borderRadius | 0.75rem |
+| `rounded-2xl` | borderRadius | 1rem |
+| `rounded-3xl` | borderRadius | 1.5rem |
+| `rounded-full` | borderRadius | 9999px |
+
+### Border Width
+
+| Tailwind Class | CSS Property | Value |
+|----------------|--------------|-------|
+| `border-0` | borderWidth | 0 |
+| `border` | borderWidth | 1px |
+| `border-2` | borderWidth | 2px |
+| `border-4` | borderWidth | 4px |
+| `border-8` | borderWidth | 8px |
+
+---
+
+## Responsive Breakpoints
+
+| Tailwind Prefix | Makeswift Device | Min Width |
+|-----------------|------------------|-----------|
+| (none) | `mobile` | 0px |
+| `sm:` | `tablet` | 640px |
+| `md:` | `desktop` | 768px |
+| `lg:` | `desktop` | 1024px |
+| `xl:` | `desktop` | 1280px |
+| `2xl:` | `desktop` | 1536px |
+
+When multiple Tailwind breakpoints map to `desktop` (md, lg, xl, 2xl), the largest breakpoint takes precedence.
+
+**Example:**
+
+```jsx
+<div className="p-4 sm:p-6 md:p-8 lg:p-12">
+```
+
+Maps to:
+
+```json
+{
+  "style": {
+    "type": "Style",
+    "properties": ["padding"],
+    "value": [
+      { "deviceId": "mobile", "value": { "padding": "1rem" } },
+      { "deviceId": "tablet", "value": { "padding": "1.5rem" } },
+      { "deviceId": "desktop", "value": { "padding": "3rem" } }
+    ]
+  }
+}
+```
+
+---
+
+## Element Type Inference
+
+| HTML Tag | Inferred Type | Suggested Controls |
+|----------|---------------|-------------------|
+| `div`, `section`, `article` | Container | Style, Slot |
+| `h1`-`h6` | Heading | TextInput, Typography, Style |
+| `p` | Paragraph | TextArea, Typography, Style |
+| `span` | Text | TextInput, Typography, Style |
+| `a` | Link | Link, TextInput, Style |
+| `button` | Button | TextInput, Link, Style, Color |
+| `img` | Image | Image, Style |
+| `video` | Video | TextInput (src), Image (poster), Style |
+| `nav`, `header`, `footer` | Nav/Header/Footer | Style, Slot |
+| `ul`, `ol` | List | List, Style |
+
+---
+
+## Content Control Inference
+
+| Condition | Inferred Control |
+|-----------|------------------|
+| Short text (≤50 chars) | TextInput |
+| Medium text (51-200 chars) | TextArea |
+| Long text (>200 chars) | TextArea |
+| Text with newlines | TextArea |
+| Contains inline HTML (`<strong>`, `<em>`, etc.) | RichText |
+| Heading tags (`h1`-`h6`) with short text | TextInput |
+| Button or label elements | TextInput |

--- a/packages/jsx-to-makeswift/jest.config.json
+++ b/packages/jsx-to-makeswift/jest.config.json
@@ -1,0 +1,8 @@
+{
+  "transform": {
+    "^.+\\.(t|j)sx?$": "@swc/jest"
+  },
+  "testEnvironment": "node",
+  "testMatch": ["**/*.test.ts"],
+  "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json"]
+}

--- a/packages/jsx-to-makeswift/package.json
+++ b/packages/jsx-to-makeswift/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@makeswift/jsx-to-makeswift",
+  "version": "0.0.1",
+  "description": "Transform JSX with Tailwind CSS into Makeswift control schemas",
+  "license": "MIT",
+  "repository": {
+    "url": "makeswift/makeswift",
+    "directory": "packages/jsx-to-makeswift"
+  },
+  "keywords": [
+    "makeswift",
+    "jsx",
+    "tailwind",
+    "controls",
+    "schema",
+    "ai",
+    "cli"
+  ],
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/types/index.d.ts",
+  "bin": {
+    "jsx-to-makeswift": "./dist/cli.js"
+  },
+  "scripts": {
+    "dev": "concurrently -k 'tsc --watch --preserveWatchOutput' 'tsup --watch'",
+    "clean": "rm -rf dist",
+    "build": "tsc && tsup",
+    "format": "prettier --write .",
+    "test": "jest",
+    "test:updateSnapshot": "jest --updateSnapshot"
+  },
+  "dependencies": {
+    "@babel/parser": "^7.24.0",
+    "@babel/traverse": "^7.24.0",
+    "@babel/types": "^7.24.0",
+    "zod": "^3.21.4"
+  },
+  "devDependencies": {
+    "@ianvs/prettier-plugin-sort-imports": "^4.3.1",
+    "@swc/jest": "^0.2.36",
+    "@types/babel__traverse": "^7.20.5",
+    "@types/jest": "^29.5.12",
+    "concurrently": "^8.2.2",
+    "jest": "^29.7.0",
+    "tsup": "^8.0.2",
+    "typescript": "^5.1.6"
+  },
+  "peerDependencies": {
+    "@makeswift/controls": "workspace:*"
+  }
+}

--- a/packages/jsx-to-makeswift/src/__tests__/jsx-parser.test.ts
+++ b/packages/jsx-to-makeswift/src/__tests__/jsx-parser.test.ts
@@ -1,0 +1,101 @@
+import { parseJSX, parseJSXFragment } from '../parser/jsx-parser'
+
+describe('parseJSX', () => {
+  it('parses a simple element', () => {
+    const result = parseJSX('<div className="m-4">Hello</div>')
+
+    expect(result.errors).toHaveLength(0)
+    expect(result.elements).toHaveLength(1)
+    expect(result.elements[0].tagName).toBe('div')
+    expect(result.elements[0].className).toBe('m-4')
+    expect(result.elements[0].textContent).toBe('Hello')
+  })
+
+  it('parses nested elements', () => {
+    const result = parseJSX(`
+      <div className="container">
+        <h1>Title</h1>
+        <p>Content</p>
+      </div>
+    `)
+
+    expect(result.errors).toHaveLength(0)
+    expect(result.elements).toHaveLength(1)
+    expect(result.elements[0].children).toHaveLength(2)
+  })
+
+  it('extracts attributes', () => {
+    const result = parseJSX('<img src="/image.png" alt="An image" />')
+
+    expect(result.errors).toHaveLength(0)
+    expect(result.elements[0].attributes.src).toBe('/image.png')
+    expect(result.elements[0].attributes.alt).toBe('An image')
+  })
+
+  it('detects rich content', () => {
+    const result = parseJSX('<p>Hello <strong>world</strong></p>')
+
+    expect(result.errors).toHaveLength(0)
+    expect(result.elements[0].hasRichContent).toBe(true)
+  })
+
+  it('handles self-closing elements', () => {
+    const result = parseJSX('<input type="text" />')
+
+    expect(result.errors).toHaveLength(0)
+    expect(result.elements).toHaveLength(1)
+    expect(result.elements[0].tagName).toBe('input')
+    expect(result.elements[0].attributes.type).toBe('text')
+  })
+
+  it('handles JSX expressions in className', () => {
+    const result = parseJSX('<div className={"m-4"}>Hello</div>')
+
+    expect(result.errors).toHaveLength(0)
+    expect(result.elements[0].className).toBe('m-4')
+  })
+
+  it('handles custom components', () => {
+    const result = parseJSX('<MyComponent prop="value">Content</MyComponent>')
+
+    expect(result.errors).toHaveLength(0)
+    expect(result.elements[0].tagName).toBe('MyComponent')
+  })
+
+  it('handles member expression components', () => {
+    const result = parseJSX('<UI.Button>Click</UI.Button>')
+
+    expect(result.errors).toHaveLength(0)
+    expect(result.elements[0].tagName).toBe('UI.Button')
+  })
+
+  it('reports errors for invalid JSX', () => {
+    const result = parseJSX('<div className="m-4"')
+
+    expect(result.errors.length).toBeGreaterThan(0)
+  })
+
+  it('handles boolean attributes', () => {
+    const result = parseJSX('<input disabled />')
+
+    expect(result.elements[0].attributes.disabled).toBe(true)
+  })
+
+  it('handles numeric attributes', () => {
+    const result = parseJSX('<input tabIndex={5} />')
+
+    expect(result.elements[0].attributes.tabIndex).toBe(5)
+  })
+})
+
+describe('parseJSXFragment', () => {
+  it('parses multiple sibling elements', () => {
+    const result = parseJSXFragment(`
+      <div>First</div>
+      <div>Second</div>
+    `)
+
+    expect(result.errors).toHaveLength(0)
+    expect(result.elements).toHaveLength(2)
+  })
+})

--- a/packages/jsx-to-makeswift/src/__tests__/reverse.test.ts
+++ b/packages/jsx-to-makeswift/src/__tests__/reverse.test.ts
@@ -1,0 +1,382 @@
+import { transformSchemaToJSX, schemaToJSXString } from '../reverse/schema-to-jsx'
+import {
+  mapStyleToClasses,
+  mapColorToClass,
+  mapTypographyToClasses,
+  addResponsivePrefix,
+} from '../reverse/reverse-mapper'
+import type { ElementSchema } from '../types'
+
+describe('reverse-mapper', () => {
+  describe('mapStyleToClasses', () => {
+    it('maps margin values to Tailwind classes', () => {
+      const result = mapStyleToClasses({ margin: '1rem' })
+      expect(result.classes).toContain('m-4')
+    })
+
+    it('maps padding values to Tailwind classes', () => {
+      const result = mapStyleToClasses({ padding: '1.5rem' })
+      expect(result.classes).toContain('p-6')
+    })
+
+    it('maps directional margin values', () => {
+      const result = mapStyleToClasses({
+        marginTop: '0.5rem',
+        marginBottom: '1rem',
+      })
+      expect(result.classes).toContain('mt-2')
+      expect(result.classes).toContain('mb-4')
+    })
+
+    it('maps width values', () => {
+      const result = mapStyleToClasses({ width: '100%' })
+      expect(result.classes).toContain('w-full')
+    })
+
+    it('maps height values', () => {
+      const result = mapStyleToClasses({ height: '100vh' })
+      expect(result.classes).toContain('h-screen')
+    })
+
+    it('maps gap values', () => {
+      const result = mapStyleToClasses({ gap: '2rem' })
+      expect(result.classes).toContain('gap-8')
+    })
+
+    it('maps border radius values', () => {
+      const result = mapStyleToClasses({ borderRadius: '0.5rem' })
+      expect(result.classes).toContain('rounded-lg')
+    })
+
+    it('maps display values', () => {
+      const result = mapStyleToClasses({ display: 'flex' })
+      expect(result.classes).toContain('flex')
+    })
+
+    it('maps flex direction values', () => {
+      const result = mapStyleToClasses({ flexDirection: 'column' })
+      expect(result.classes).toContain('flex-col')
+    })
+
+    it('maps justify content values', () => {
+      const result = mapStyleToClasses({ justifyContent: 'space-between' })
+      expect(result.classes).toContain('justify-between')
+    })
+
+    it('maps align items values', () => {
+      const result = mapStyleToClasses({ alignItems: 'center' })
+      expect(result.classes).toContain('items-center')
+    })
+
+    it('maps position values', () => {
+      const result = mapStyleToClasses({ position: 'absolute' })
+      expect(result.classes).toContain('absolute')
+    })
+
+    it('creates arbitrary classes for unmapped values', () => {
+      const result = mapStyleToClasses({ margin: '17px' })
+      expect(result.classes).toContain('m-[17px]')
+    })
+  })
+
+  describe('mapColorToClass', () => {
+    it('maps text color hex to Tailwind class', () => {
+      const result = mapColorToClass('#3b82f6', 'textColor')
+      expect(result).toBe('text-blue-500')
+    })
+
+    it('maps background color hex to Tailwind class', () => {
+      const result = mapColorToClass('#f3f4f6', 'backgroundColor')
+      expect(result).toBe('bg-gray-100')
+    })
+
+    it('maps border color hex to Tailwind class', () => {
+      const result = mapColorToClass('#ef4444', 'borderColor')
+      expect(result).toBe('border-red-500')
+    })
+
+    it('creates arbitrary class for unknown colors', () => {
+      const result = mapColorToClass('#abcdef', 'textColor')
+      expect(result).toBe('text-[#abcdef]')
+    })
+  })
+
+  describe('mapTypographyToClasses', () => {
+    it('maps font size to Tailwind class', () => {
+      const result = mapTypographyToClasses({ fontSize: '1.5rem' })
+      expect(result.classes).toContain('text-2xl')
+    })
+
+    it('maps font weight to Tailwind class', () => {
+      const result = mapTypographyToClasses({ fontWeight: 700 })
+      expect(result.classes).toContain('font-bold')
+    })
+
+    it('maps line height to Tailwind class', () => {
+      const result = mapTypographyToClasses({ lineHeight: '1.625' })
+      expect(result.classes).toContain('leading-relaxed')
+    })
+
+    it('maps text align to Tailwind class', () => {
+      const result = mapTypographyToClasses({ textAlign: 'center' })
+      expect(result.classes).toContain('text-center')
+    })
+
+    it('maps font style italic', () => {
+      const result = mapTypographyToClasses({ fontStyle: 'italic' })
+      expect(result.classes).toContain('italic')
+    })
+
+    it('maps text decoration underline', () => {
+      const result = mapTypographyToClasses({ textDecoration: 'underline' })
+      expect(result.classes).toContain('underline')
+    })
+
+    it('maps text transform uppercase', () => {
+      const result = mapTypographyToClasses({ textTransform: 'uppercase' })
+      expect(result.classes).toContain('uppercase')
+    })
+  })
+
+  describe('addResponsivePrefix', () => {
+    it('adds no prefix for mobile', () => {
+      expect(addResponsivePrefix('p-4', 'mobile')).toBe('p-4')
+    })
+
+    it('adds sm: prefix for tablet', () => {
+      expect(addResponsivePrefix('p-4', 'tablet')).toBe('sm:p-4')
+    })
+
+    it('adds lg: prefix for desktop', () => {
+      expect(addResponsivePrefix('p-4', 'desktop')).toBe('lg:p-4')
+    })
+  })
+})
+
+describe('schema-to-jsx', () => {
+  describe('transformSchemaToJSX', () => {
+    it('transforms a simple container', () => {
+      const schema: ElementSchema = {
+        type: 'Container',
+        tagName: 'div',
+        controls: {
+          style: {
+            type: 'Style',
+            properties: ['padding'],
+            value: [{ deviceId: 'mobile', value: { padding: '1rem' } }],
+          },
+          content: { type: 'TextInput', value: 'Hello' },
+        },
+      }
+
+      const result = transformSchemaToJSX(schema)
+      expect(result.jsx).toBe('<div className="p-4">Hello</div>')
+    })
+
+    it('transforms with multiple style properties', () => {
+      const schema: ElementSchema = {
+        type: 'Container',
+        tagName: 'div',
+        controls: {
+          style: {
+            type: 'Style',
+            properties: ['margin', 'padding'],
+            value: [
+              { deviceId: 'mobile', value: { margin: '1rem', padding: '1.5rem' } },
+            ],
+          },
+        },
+      }
+
+      const result = transformSchemaToJSX(schema)
+      expect(result.jsx).toContain('m-4')
+      expect(result.jsx).toContain('p-6')
+    })
+
+    it('transforms with color controls', () => {
+      const schema: ElementSchema = {
+        type: 'Container',
+        tagName: 'div',
+        controls: {
+          backgroundColor: {
+            type: 'Color',
+            property: 'backgroundColor',
+            value: [{ deviceId: 'mobile', value: { color: '#3b82f6', alpha: 1 } }],
+          },
+        },
+      }
+
+      const result = transformSchemaToJSX(schema)
+      expect(result.jsx).toContain('bg-blue-500')
+    })
+
+    it('transforms with typography controls', () => {
+      const schema: ElementSchema = {
+        type: 'Heading',
+        tagName: 'h1',
+        controls: {
+          typography: {
+            type: 'Typography',
+            value: [
+              { deviceId: 'mobile', value: { fontSize: '2.25rem', fontWeight: 700 } },
+            ],
+          },
+          content: { type: 'TextInput', value: 'Title' },
+        },
+      }
+
+      const result = transformSchemaToJSX(schema)
+      expect(result.jsx).toContain('text-4xl')
+      expect(result.jsx).toContain('font-bold')
+      expect(result.jsx).toContain('Title')
+    })
+
+    it('transforms with responsive values', () => {
+      const schema: ElementSchema = {
+        type: 'Container',
+        tagName: 'div',
+        controls: {
+          style: {
+            type: 'Style',
+            properties: ['padding'],
+            value: [
+              { deviceId: 'mobile', value: { padding: '1rem' } },
+              { deviceId: 'tablet', value: { padding: '1.5rem' } },
+              { deviceId: 'desktop', value: { padding: '2rem' } },
+            ],
+          },
+        },
+      }
+
+      const result = transformSchemaToJSX(schema)
+      expect(result.jsx).toContain('p-4')
+      expect(result.jsx).toContain('sm:p-6')
+      expect(result.jsx).toContain('lg:p-8')
+    })
+
+    it('transforms image elements', () => {
+      const schema: ElementSchema = {
+        type: 'Image',
+        tagName: 'img',
+        controls: {
+          image: {
+            type: 'Image',
+            value: { src: '/image.jpg', alt: 'Description' },
+          },
+        },
+      }
+
+      const result = transformSchemaToJSX(schema)
+      expect(result.jsx).toContain('<img')
+      expect(result.jsx).toContain('src="/image.jpg"')
+      expect(result.jsx).toContain('alt="Description"')
+      expect(result.jsx).toContain('/>')
+    })
+
+    it('transforms link elements', () => {
+      const schema: ElementSchema = {
+        type: 'Link',
+        tagName: 'a',
+        controls: {
+          link: {
+            type: 'Link',
+            value: { href: '/about', target: '_blank' },
+          },
+          content: { type: 'TextInput', value: 'About Us' },
+        },
+      }
+
+      const result = transformSchemaToJSX(schema)
+      expect(result.jsx).toContain('<a')
+      expect(result.jsx).toContain('href="/about"')
+      expect(result.jsx).toContain('target="_blank"')
+      expect(result.jsx).toContain('About Us')
+    })
+
+    it('transforms nested children', () => {
+      const schema: ElementSchema = {
+        type: 'Container',
+        tagName: 'div',
+        controls: {
+          style: {
+            type: 'Style',
+            properties: ['padding'],
+            value: [{ deviceId: 'mobile', value: { padding: '1rem' } }],
+          },
+        },
+        children: {
+          type: 'Slot',
+          elements: [
+            {
+              type: 'Heading',
+              tagName: 'h1',
+              controls: {
+                content: { type: 'TextInput', value: 'Title' },
+              },
+            },
+            {
+              type: 'Paragraph',
+              tagName: 'p',
+              controls: {
+                content: { type: 'TextInput', value: 'Description' },
+              },
+            },
+          ],
+        },
+      }
+
+      const result = transformSchemaToJSX(schema)
+      expect(result.jsx).toContain('<div className="p-4">')
+      expect(result.jsx).toContain('<h1>Title</h1>')
+      expect(result.jsx).toContain('<p>Description</p>')
+      expect(result.jsx).toContain('</div>')
+    })
+
+    it('parses JSON string input', () => {
+      const jsonInput = JSON.stringify({
+        type: 'Container',
+        tagName: 'div',
+        controls: {
+          content: { type: 'TextInput', value: 'Hello' },
+        },
+      })
+
+      const result = transformSchemaToJSX(jsonInput)
+      expect(result.jsx).toBe('<div>Hello</div>')
+    })
+
+    it('handles array of schemas', () => {
+      const schemas: ElementSchema[] = [
+        {
+          type: 'Container',
+          tagName: 'div',
+          controls: { content: { type: 'TextInput', value: 'First' } },
+        },
+        {
+          type: 'Container',
+          tagName: 'div',
+          controls: { content: { type: 'TextInput', value: 'Second' } },
+        },
+      ]
+
+      const result = transformSchemaToJSX(schemas)
+      expect(result.jsx).toContain('<div>First</div>')
+      expect(result.jsx).toContain('<div>Second</div>')
+    })
+  })
+
+  describe('schemaToJSXString', () => {
+    it('returns just the JSX string', () => {
+      const schema: ElementSchema = {
+        type: 'Container',
+        tagName: 'div',
+        controls: {
+          content: { type: 'TextInput', value: 'Hello' },
+        },
+      }
+
+      const jsx = schemaToJSXString(schema)
+      expect(jsx).toBe('<div>Hello</div>')
+    })
+  })
+})

--- a/packages/jsx-to-makeswift/src/__tests__/runtime-to-jsx.test.ts
+++ b/packages/jsx-to-makeswift/src/__tests__/runtime-to-jsx.test.ts
@@ -1,0 +1,335 @@
+import {
+  transformRuntimeToJSX,
+  isMakeswiftRuntimeSchema,
+} from '../makeswift-runtime/runtime-to-jsx'
+import type { MakeswiftRuntimeSchema } from '../makeswift-runtime/types'
+
+describe('isMakeswiftRuntimeSchema', () => {
+  it('returns true for valid runtime schema', () => {
+    const schema = {
+      key: 'abc123',
+      type: './components/Box/index.js',
+      props: {},
+    }
+    expect(isMakeswiftRuntimeSchema(schema)).toBe(true)
+  })
+
+  it('returns false for ElementSchema format', () => {
+    const schema = {
+      type: 'Container',
+      tagName: 'div',
+      controls: {},
+    }
+    expect(isMakeswiftRuntimeSchema(schema)).toBe(false)
+  })
+
+  it('returns false for null', () => {
+    expect(isMakeswiftRuntimeSchema(null)).toBe(false)
+  })
+
+  it('returns false for primitives', () => {
+    expect(isMakeswiftRuntimeSchema('string')).toBe(false)
+    expect(isMakeswiftRuntimeSchema(123)).toBe(false)
+  })
+})
+
+describe('transformRuntimeToJSX', () => {
+  describe('basic elements', () => {
+    it('transforms a simple box', () => {
+      const schema: MakeswiftRuntimeSchema = {
+        key: 'abc',
+        type: './components/Box/index.js',
+        props: {
+          padding: [
+            {
+              deviceId: 'desktop',
+              value: {
+                paddingTop: { value: 20, unit: 'px' },
+                paddingRight: { value: 20, unit: 'px' },
+                paddingBottom: { value: 20, unit: 'px' },
+                paddingLeft: { value: 20, unit: 'px' },
+              },
+            },
+          ],
+        },
+      }
+
+      const result = transformRuntimeToJSX(schema)
+      expect(result.jsx).toContain('<div')
+      expect(result.jsx).toContain('lg:p-5')
+    })
+
+    it('transforms text with rich-text-v2', () => {
+      const schema: MakeswiftRuntimeSchema = {
+        key: 'abc',
+        type: './components/Text/index.js',
+        props: {
+          text: {
+            type: 'makeswift::controls::rich-text-v2',
+            version: 2,
+            descendants: [
+              {
+                type: 'default',
+                children: [
+                  {
+                    text: 'Hello World',
+                    typography: {
+                      style: [
+                        {
+                          deviceId: 'desktop',
+                          value: {
+                            fontWeight: 700,
+                            fontSize: { value: 24, unit: 'px' },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+                textAlign: [{ deviceId: 'desktop', value: 'center' }],
+              },
+            ],
+            key: 'text-key',
+          },
+        },
+      }
+
+      const result = transformRuntimeToJSX(schema)
+      expect(result.jsx).toContain('<p')
+      expect(result.jsx).toContain('Hello World')
+      expect(result.jsx).toContain('lg:text-center')
+      expect(result.jsx).toContain('lg:text-2xl')
+      expect(result.jsx).toContain('lg:font-bold')
+    })
+
+    it('transforms image element', () => {
+      const schema: MakeswiftRuntimeSchema = {
+        key: 'abc',
+        type: './components/Image/index.js',
+        props: {
+          image: 'https://example.com/image.jpg',
+          alt: 'Example image',
+          width: [
+            {
+              deviceId: 'desktop',
+              value: { value: 300, unit: 'px' },
+            },
+          ],
+        },
+      }
+
+      const result = transformRuntimeToJSX(schema)
+      expect(result.jsx).toContain('<img')
+      expect(result.jsx).toContain('src="https://example.com/image.jpg"')
+      expect(result.jsx).toContain('alt="Example image"')
+      expect(result.jsx).toContain('lg:w-[300px]')
+    })
+
+    it('transforms button with link', () => {
+      const schema: MakeswiftRuntimeSchema = {
+        key: 'abc',
+        type: './components/Button/index.js',
+        props: {
+          link: {
+            type: 'OPEN_URL',
+            payload: {
+              url: '/about',
+              openInNewTab: true,
+            },
+          },
+          children: 'Click Me',
+        },
+      }
+
+      const result = transformRuntimeToJSX(schema)
+      expect(result.jsx).toContain('<button')
+      expect(result.jsx).toContain('href="/about"')
+      expect(result.jsx).toContain('target="_blank"')
+      expect(result.jsx).toContain('Click Me')
+    })
+  })
+
+  describe('spacing classes', () => {
+    it('uses shorthand padding when all sides are equal', () => {
+      const schema: MakeswiftRuntimeSchema = {
+        key: 'abc',
+        type: './components/Box/index.js',
+        props: {
+          padding: [
+            {
+              deviceId: 'desktop',
+              value: {
+                paddingTop: { value: 16, unit: 'px' },
+                paddingRight: { value: 16, unit: 'px' },
+                paddingBottom: { value: 16, unit: 'px' },
+                paddingLeft: { value: 16, unit: 'px' },
+              },
+            },
+          ],
+        },
+      }
+
+      const result = transformRuntimeToJSX(schema)
+      expect(result.jsx).toContain('lg:p-4')
+    })
+
+    it('handles margin auto for centering', () => {
+      const schema: MakeswiftRuntimeSchema = {
+        key: 'abc',
+        type: './components/Box/index.js',
+        props: {
+          margin: [
+            {
+              deviceId: 'desktop',
+              value: {
+                marginLeft: 'auto',
+                marginRight: 'auto',
+              },
+            },
+          ],
+        },
+      }
+
+      const result = transformRuntimeToJSX(schema)
+      expect(result.jsx).toContain('lg:mx-auto')
+    })
+
+    it('handles row and column gaps', () => {
+      const schema: MakeswiftRuntimeSchema = {
+        key: 'abc',
+        type: './components/Box/index.js',
+        props: {
+          rowGap: [{ deviceId: 'desktop', value: { value: 24, unit: 'px' } }],
+          columnGap: [{ deviceId: 'desktop', value: { value: 16, unit: 'px' } }],
+        },
+      }
+
+      const result = transformRuntimeToJSX(schema)
+      expect(result.jsx).toContain('lg:gap-y-6')
+      expect(result.jsx).toContain('lg:gap-x-4')
+    })
+  })
+
+  describe('nested elements', () => {
+    it('transforms nested children', () => {
+      const schema: MakeswiftRuntimeSchema = {
+        key: 'parent',
+        type: './components/Box/index.js',
+        props: {
+          padding: [
+            {
+              deviceId: 'desktop',
+              value: {
+                paddingTop: { value: 20, unit: 'px' },
+                paddingRight: { value: 20, unit: 'px' },
+                paddingBottom: { value: 20, unit: 'px' },
+                paddingLeft: { value: 20, unit: 'px' },
+              },
+            },
+          ],
+          children: {
+            elements: [
+              {
+                key: 'child1',
+                type: './components/Text/index.js',
+                props: {
+                  text: {
+                    type: 'makeswift::controls::rich-text-v2',
+                    version: 2,
+                    descendants: [
+                      {
+                        type: 'default',
+                        children: [{ text: 'Child Text' }],
+                      },
+                    ],
+                    key: 'text-key',
+                  },
+                },
+              },
+            ],
+          },
+        },
+      }
+
+      const result = transformRuntimeToJSX(schema)
+      expect(result.jsx).toContain('<div')
+      expect(result.jsx).toContain('<p')
+      expect(result.jsx).toContain('Child Text')
+      expect(result.jsx).toContain('</div>')
+    })
+  })
+
+  describe('grid layout', () => {
+    it('handles grid columns', () => {
+      const schema: MakeswiftRuntimeSchema = {
+        key: 'grid',
+        type: './components/Box/index.js',
+        props: {
+          children: {
+            elements: [
+              {
+                key: 'col1',
+                type: './components/Box/index.js',
+                props: {},
+              },
+              {
+                key: 'col2',
+                type: './components/Box/index.js',
+                props: {},
+              },
+              {
+                key: 'col3',
+                type: './components/Box/index.js',
+                props: {},
+              },
+            ],
+            columns: [
+              {
+                deviceId: 'desktop',
+                value: {
+                  spans: [[4, 4, 4]],
+                  count: 12,
+                },
+              },
+            ],
+          },
+        },
+      }
+
+      const result = transformRuntimeToJSX(schema)
+      expect(result.jsx).toContain('lg:grid')
+      expect(result.jsx).toContain('lg:grid-cols-12')
+      expect(result.jsx).toContain('lg:col-span-4')
+    })
+  })
+
+  describe('JSON string input', () => {
+    it('parses JSON string input', () => {
+      const jsonInput = JSON.stringify({
+        key: 'abc',
+        type: './components/Box/index.js',
+        props: {
+          padding: [
+            {
+              deviceId: 'desktop',
+              value: {
+                paddingTop: { value: 16, unit: 'px' },
+                paddingRight: { value: 16, unit: 'px' },
+                paddingBottom: { value: 16, unit: 'px' },
+                paddingLeft: { value: 16, unit: 'px' },
+              },
+            },
+          ],
+        },
+      })
+
+      const result = transformRuntimeToJSX(jsonInput)
+      expect(result.jsx).toContain('lg:p-4')
+    })
+
+    it('returns warning for invalid JSON', () => {
+      const result = transformRuntimeToJSX('invalid json')
+      expect(result.warnings.length).toBeGreaterThan(0)
+    })
+  })
+})

--- a/packages/jsx-to-makeswift/src/__tests__/tailwind-tokenizer.test.ts
+++ b/packages/jsx-to-makeswift/src/__tests__/tailwind-tokenizer.test.ts
@@ -1,0 +1,76 @@
+import { tokenizeTailwindClasses } from '../tailwind/tokenizer'
+
+describe('tokenizeTailwindClasses', () => {
+  it('tokenizes basic classes', () => {
+    const result = tokenizeTailwindClasses('m-4 p-6 bg-blue-500')
+
+    expect(result.baseClasses).toHaveLength(3)
+    expect(result.baseClasses[0].utility).toBe('m')
+    expect(result.baseClasses[0].value).toBe('4')
+    expect(result.baseClasses[1].utility).toBe('p')
+    expect(result.baseClasses[1].value).toBe('6')
+    expect(result.baseClasses[2].utility).toBe('bg')
+    expect(result.baseClasses[2].value).toBe('blue-500')
+  })
+
+  it('parses responsive prefixes', () => {
+    const result = tokenizeTailwindClasses('p-4 md:p-8 lg:p-12')
+
+    expect(result.baseClasses).toHaveLength(1)
+    expect(result.responsiveClasses['desktop']).toHaveLength(2)
+  })
+
+  it('parses state variants', () => {
+    const result = tokenizeTailwindClasses('bg-blue-500 hover:bg-blue-600 focus:ring-2')
+
+    expect(result.baseClasses).toHaveLength(1)
+    expect(result.stateClasses['hover']).toHaveLength(1)
+    expect(result.stateClasses['focus']).toHaveLength(1)
+  })
+
+  it('parses arbitrary values', () => {
+    const result = tokenizeTailwindClasses('w-[300px] bg-[#ff0000]')
+
+    expect(result.baseClasses).toHaveLength(2)
+    expect(result.baseClasses[0].isArbitrary).toBe(true)
+    expect(result.baseClasses[0].value).toBe('300px')
+    expect(result.baseClasses[1].isArbitrary).toBe(true)
+    expect(result.baseClasses[1].value).toBe('#ff0000')
+  })
+
+  it('parses negative values', () => {
+    const result = tokenizeTailwindClasses('-mt-4 -ml-2')
+
+    expect(result.baseClasses).toHaveLength(2)
+    expect(result.baseClasses[0].isNegative).toBe(true)
+    expect(result.baseClasses[0].utility).toBe('mt')
+    expect(result.baseClasses[1].isNegative).toBe(true)
+    expect(result.baseClasses[1].utility).toBe('ml')
+  })
+
+  it('handles null input', () => {
+    const result = tokenizeTailwindClasses(null)
+
+    expect(result.baseClasses).toHaveLength(0)
+  })
+
+  it('handles empty string', () => {
+    const result = tokenizeTailwindClasses('')
+
+    expect(result.baseClasses).toHaveLength(0)
+  })
+
+  it('parses combined responsive and state variants', () => {
+    const result = tokenizeTailwindClasses('md:hover:bg-blue-600')
+
+    expect(result.baseClasses).toHaveLength(0)
+  })
+
+  it('parses utility-only classes', () => {
+    const result = tokenizeTailwindClasses('flex block hidden')
+
+    expect(result.baseClasses).toHaveLength(3)
+    expect(result.baseClasses[0].utility).toBe('flex')
+    expect(result.baseClasses[0].value).toBeNull()
+  })
+})

--- a/packages/jsx-to-makeswift/src/__tests__/transform.test.ts
+++ b/packages/jsx-to-makeswift/src/__tests__/transform.test.ts
@@ -1,0 +1,1327 @@
+import { transformJSX, transformJSXToJSON } from '../transform'
+import type { TextInputControlValue, TextAreaControlValue, RichTextControlValue } from '../types'
+
+describe('transformJSX', () => {
+  it('transforms a simple div with Tailwind classes', () => {
+    const jsx = `<div className="m-4 p-6 bg-blue-500 rounded-lg">Hello</div>`
+
+    const result = transformJSX(jsx)
+
+    expect(result.errors).toHaveLength(0)
+    expect(result.schemas).toHaveLength(1)
+
+    const schema = result.schemas[0]
+    expect(schema.type).toBe('Container')
+    expect(schema.tagName).toBe('div')
+    expect(schema.controls.style).toBeDefined()
+    expect(schema.controls.backgroundColor).toBeDefined()
+    expect(schema.controls.content).toBeDefined()
+    expect((schema.controls.content as TextInputControlValue).value).toBe('Hello')
+  })
+
+  it('transforms responsive Tailwind classes', () => {
+    const jsx = `<div className="p-4 md:p-8 lg:p-12">Content</div>`
+
+    const result = transformJSX(jsx)
+
+    expect(result.errors).toHaveLength(0)
+
+    const schema = result.schemas[0]
+    const styleControl = schema.controls.style
+
+    expect(styleControl).toBeDefined()
+    expect(styleControl?.type).toBe('Style')
+
+    if (styleControl?.type === 'Style') {
+      expect(styleControl.value.length).toBeGreaterThan(1)
+    }
+
+    expect((schema.controls.content as TextInputControlValue).value).toBe('Content')
+  })
+
+  it('transforms heading elements correctly', () => {
+    const jsx = `<h1 className="text-2xl font-bold text-gray-900">Welcome</h1>`
+
+    const result = transformJSX(jsx)
+
+    expect(result.errors).toHaveLength(0)
+
+    const schema = result.schemas[0]
+    expect(schema.type).toBe('Heading')
+    expect(schema.tagName).toBe('h1')
+    expect(schema.controls.typography).toBeDefined()
+    expect(schema.controls.textColor).toBeDefined()
+    expect(schema.controls.content).toBeDefined()
+    expect(schema.controls.content?.type).toBe('TextInput')
+    expect((schema.controls.content as TextInputControlValue).value).toBe('Welcome')
+  })
+
+  it('transforms nested elements with children', () => {
+    const jsx = `
+      <div className="flex flex-col gap-4">
+        <h1 className="text-xl">Title</h1>
+        <p className="text-gray-600">Description</p>
+      </div>
+    `
+
+    const result = transformJSX(jsx)
+
+    expect(result.errors).toHaveLength(0)
+
+    const schema = result.schemas[0]
+    expect(schema.children).toBeDefined()
+    expect(schema.children?.type).toBe('Slot')
+    expect(schema.children?.elements).toHaveLength(2)
+  })
+
+  it('preserves original class names when option is enabled', () => {
+    const jsx = `<div className="m-4 p-6">Hello</div>`
+
+    const result = transformJSX(jsx, { preserveOriginalClasses: true })
+
+    expect(result.schemas[0].metadata?.originalClassName).toBe('m-4 p-6')
+  })
+
+  it('handles state variants when option is enabled', () => {
+    const jsx = `<button className="bg-blue-500 hover:bg-blue-600">Click</button>`
+
+    const result = transformJSX(jsx, { includeStateVariants: true })
+
+    expect(result.schemas[0].metadata?.stateVariants).toBeDefined()
+    expect(result.schemas[0].metadata?.stateVariants?.hover).toBeDefined()
+    expect((result.schemas[0].controls.content as TextInputControlValue).value).toBe('Click')
+  })
+
+  it('handles images correctly', () => {
+    const jsx = `<img src="/image.png" alt="An image" className="w-full rounded" />`
+
+    const result = transformJSX(jsx)
+
+    expect(result.errors).toHaveLength(0)
+
+    const schema = result.schemas[0]
+    expect(schema.type).toBe('Image')
+    expect(schema.controls.style).toBeDefined()
+  })
+
+  it('handles buttons correctly', () => {
+    const jsx = `<button className="px-4 py-2 bg-blue-500 text-white rounded">Submit</button>`
+
+    const result = transformJSX(jsx)
+
+    expect(result.errors).toHaveLength(0)
+
+    const schema = result.schemas[0]
+    expect(schema.type).toBe('Button')
+    expect(schema.controls.style).toBeDefined()
+    expect(schema.controls.backgroundColor).toBeDefined()
+    expect(schema.controls.textColor).toBeDefined()
+    expect(schema.controls.content).toBeDefined()
+    expect(schema.controls.content?.type).toBe('TextInput')
+    expect((schema.controls.content as TextInputControlValue).value).toBe('Submit')
+  })
+
+  it('handles links correctly', () => {
+    const jsx = `<a href="/about" className="text-blue-500 underline">About Us</a>`
+
+    const result = transformJSX(jsx)
+
+    expect(result.errors).toHaveLength(0)
+
+    const schema = result.schemas[0]
+    expect(schema.type).toBe('Link')
+    expect(schema.controls.content).toBeDefined()
+    expect(schema.controls.content?.type).toBe('TextInput')
+    expect((schema.controls.content as TextInputControlValue).value).toBe('About Us')
+  })
+
+  it('reports parsing errors for invalid JSX', () => {
+    const jsx = `<div className="m-4"`
+
+    const result = transformJSX(jsx)
+
+    expect(result.errors).toHaveLength(1)
+    expect(result.schemas).toHaveLength(0)
+  })
+
+  it('handles arbitrary Tailwind values', () => {
+    const jsx = `<div className="w-[300px] h-[200px] bg-[#ff0000]">Custom</div>`
+
+    const result = transformJSX(jsx)
+
+    expect(result.errors).toHaveLength(0)
+
+    const schema = result.schemas[0]
+    expect(schema.controls.style).toBeDefined()
+    expect(schema.controls.backgroundColor).toBeDefined()
+    expect((schema.controls.content as TextInputControlValue).value).toBe('Custom')
+  })
+
+  it('handles negative margin values', () => {
+    const jsx = `<div className="-mt-4 -ml-2">Offset</div>`
+
+    const result = transformJSX(jsx)
+
+    expect(result.errors).toHaveLength(0)
+
+    const schema = result.schemas[0]
+    expect(schema.controls.style).toBeDefined()
+    expect((schema.controls.content as TextInputControlValue).value).toBe('Offset')
+  })
+
+  describe('paragraph and text elements', () => {
+    it('transforms a simple paragraph with short text as TextInput', () => {
+      const jsx = `<p className="text-gray-600">Short text</p>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+      expect(schema.type).toBe('Paragraph')
+      expect(schema.tagName).toBe('p')
+      expect(schema.controls.content).toBeDefined()
+      expect(schema.controls.content?.type).toBe('TextInput')
+      expect((schema.controls.content as TextInputControlValue).value).toBe('Short text')
+    })
+
+    it('transforms a paragraph with longer text as TextArea', () => {
+      const longText = 'This is a much longer paragraph that exceeds the short text threshold and should be treated as a TextArea control for better editing experience.'
+      const jsx = `<p className="text-gray-600 leading-relaxed">${longText}</p>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+      expect(schema.type).toBe('Paragraph')
+      expect(schema.controls.content).toBeDefined()
+      expect(schema.controls.content?.type).toBe('TextArea')
+      expect((schema.controls.content as TextAreaControlValue).value).toBe(longText)
+    })
+
+    it('transforms a paragraph with inline formatting as RichText', () => {
+      const jsx = `<p className="text-base">This has <strong>bold</strong> and <em>italic</em> text</p>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+      expect(schema.type).toBe('Paragraph')
+      expect(schema.controls.content).toBeDefined()
+      expect(schema.controls.content?.type).toBe('RichText')
+      expect((schema.controls.content as RichTextControlValue).value).toBe('This has bold and italic text')
+    })
+
+    it('transforms span with short text as TextInput', () => {
+      const jsx = `<span className="text-sm text-gray-500">Label text</span>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+      expect(schema.type).toBe('Text')
+      expect(schema.controls.content?.type).toBe('TextInput')
+      expect((schema.controls.content as TextInputControlValue).value).toBe('Label text')
+    })
+
+    it('transforms blockquote correctly', () => {
+      const jsx = `<blockquote className="border-l-4 border-gray-300 pl-4 italic">A wise quote</blockquote>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+      expect(schema.controls.style).toBeDefined()
+      expect(schema.controls.content).toBeDefined()
+      expect((schema.controls.content as TextInputControlValue).value).toBe('A wise quote')
+    })
+  })
+
+  describe('rich text scenarios', () => {
+    it('detects rich content with nested anchor tag', () => {
+      const jsx = `<p>Click <a href="/link">here</a> for more info</p>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+      expect(schema.controls.content?.type).toBe('RichText')
+      expect((schema.controls.content as RichTextControlValue).value).toBe('Click here for more info')
+    })
+
+    it('detects rich content with code tag', () => {
+      const jsx = `<p>Use the <code>console.log()</code> function</p>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+      expect(schema.controls.content?.type).toBe('RichText')
+      expect((schema.controls.content as RichTextControlValue).value).toBe('Use the console.log() function')
+    })
+
+    it('handles complex nested structure with multiple formatting', () => {
+      const jsx = `
+        <p className="text-lg leading-7">
+          This is <strong>important</strong> and this is <em>emphasized</em>.
+          Also check <a href="/docs" className="text-blue-500">the docs</a>.
+        </p>
+      `
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+      expect(schema.type).toBe('Paragraph')
+      expect(schema.controls.content?.type).toBe('RichText')
+      expect(schema.controls.typography).toBeDefined()
+      expect((schema.controls.content as RichTextControlValue).value).toContain('important')
+      expect((schema.controls.content as RichTextControlValue).value).toContain('emphasized')
+      expect((schema.controls.content as RichTextControlValue).value).toContain('the docs')
+    })
+
+    it('handles article with multiple paragraphs', () => {
+      const jsx = `
+        <article className="prose">
+          <h1>Title</h1>
+          <p>First paragraph</p>
+          <p>Second paragraph with <strong>bold</strong> text</p>
+        </article>
+      `
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+      expect(schema.type).toBe('Container')
+      expect(schema.children?.elements).toHaveLength(3)
+
+      const heading = schema.children?.elements[0]
+      expect((heading?.controls.content as TextInputControlValue).value).toBe('Title')
+
+      const firstPara = schema.children?.elements[1]
+      expect(firstPara?.controls.content?.type).toBe('TextInput')
+      expect((firstPara?.controls.content as TextInputControlValue).value).toBe('First paragraph')
+
+      const secondPara = schema.children?.elements[2]
+      expect(secondPara?.controls.content?.type).toBe('RichText')
+      expect((secondPara?.controls.content as RichTextControlValue).value).toBe('Second paragraph with bold text')
+    })
+
+    it('handles div with mixed content', () => {
+      const jsx = `
+        <div className="space-y-4">
+          <h2 className="text-xl font-semibold">Section Title</h2>
+          <p className="text-gray-600">Description text here</p>
+          <button className="bg-blue-500 text-white px-4 py-2">Action</button>
+        </div>
+      `
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+      expect(schema.children?.elements).toHaveLength(3)
+
+      expect(schema.children?.elements[0].type).toBe('Heading')
+      expect((schema.children?.elements[0].controls.content as TextInputControlValue).value).toBe('Section Title')
+
+      expect(schema.children?.elements[1].type).toBe('Paragraph')
+      expect((schema.children?.elements[1].controls.content as TextInputControlValue).value).toBe('Description text here')
+
+      expect(schema.children?.elements[2].type).toBe('Button')
+      expect((schema.children?.elements[2].controls.content as TextInputControlValue).value).toBe('Action')
+    })
+  })
+
+  describe('heading variations', () => {
+    it('transforms all heading levels correctly', () => {
+      const headings = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']
+
+      for (const tag of headings) {
+        const jsx = `<${tag} className="font-bold">Heading</${tag}>`
+        const result = transformJSX(jsx)
+
+        expect(result.errors).toHaveLength(0)
+        expect(result.schemas[0].type).toBe('Heading')
+        expect(result.schemas[0].tagName).toBe(tag)
+        expect((result.schemas[0].controls.content as TextInputControlValue).value).toBe('Heading')
+      }
+    })
+
+    it('transforms heading with link inside as RichText', () => {
+      const jsx = `<h2>Check out <a href="/page">this page</a></h2>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+      expect(schema.type).toBe('Heading')
+      expect(schema.controls.content?.type).toBe('RichText')
+      expect((schema.controls.content as RichTextControlValue).value).toBe('Check out this page')
+    })
+  })
+
+  describe('list elements', () => {
+    it('transforms unordered list correctly', () => {
+      const jsx = `
+        <ul className="list-disc pl-4">
+          <li>Item one</li>
+          <li>Item two</li>
+          <li>Item three</li>
+        </ul>
+      `
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+      expect(schema.type).toBe('List')
+      expect(schema.children?.elements).toHaveLength(3)
+
+      expect((schema.children?.elements[0].controls.content as TextInputControlValue).value).toBe('Item one')
+      expect((schema.children?.elements[1].controls.content as TextInputControlValue).value).toBe('Item two')
+      expect((schema.children?.elements[2].controls.content as TextInputControlValue).value).toBe('Item three')
+    })
+
+    it('transforms ordered list correctly', () => {
+      const jsx = `
+        <ol className="list-decimal pl-4">
+          <li>First step</li>
+          <li>Second step</li>
+        </ol>
+      `
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+      expect(schema.type).toBe('List')
+
+      expect((schema.children?.elements[0].controls.content as TextInputControlValue).value).toBe('First step')
+      expect((schema.children?.elements[1].controls.content as TextInputControlValue).value).toBe('Second step')
+    })
+
+    it('handles list items with rich content', () => {
+      const jsx = `
+        <ul>
+          <li>Simple item</li>
+          <li>Item with <strong>bold</strong> text</li>
+        </ul>
+      `
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const firstItem = result.schemas[0].children?.elements[0]
+      expect(firstItem?.controls.content?.type).toBe('TextInput')
+      expect((firstItem?.controls.content as TextInputControlValue).value).toBe('Simple item')
+
+      const secondItem = result.schemas[0].children?.elements[1]
+      expect(secondItem?.controls.content?.type).toBe('RichText')
+      expect((secondItem?.controls.content as RichTextControlValue).value).toBe('Item with bold text')
+    })
+  })
+
+  describe('typography styling', () => {
+    it('handles multiple text size classes', () => {
+      const jsx = `<p className="text-sm md:text-base lg:text-lg">Responsive text</p>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+      expect(schema.controls.typography).toBeDefined()
+      expect((schema.controls.content as TextInputControlValue).value).toBe('Responsive text')
+
+      if (schema.controls.typography?.type === 'Typography') {
+        expect(schema.controls.typography.value.length).toBeGreaterThan(1)
+      }
+    })
+
+    it('handles text alignment classes', () => {
+      const jsx = `<p className="text-center md:text-left">Aligned text</p>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+      expect(result.schemas[0].controls.typography).toBeDefined()
+      expect((result.schemas[0].controls.content as TextInputControlValue).value).toBe('Aligned text')
+    })
+
+    it('handles text decoration classes', () => {
+      const jsx = `<span className="underline">Underlined text</span>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+      expect(result.schemas[0].controls.typography).toBeDefined()
+      expect((result.schemas[0].controls.content as TextInputControlValue).value).toBe('Underlined text')
+    })
+
+    it('handles font weight variations', () => {
+      const jsx = `<p className="font-light md:font-normal lg:font-bold">Weight variation</p>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+      expect(result.schemas[0].controls.typography).toBeDefined()
+      expect((result.schemas[0].controls.content as TextInputControlValue).value).toBe('Weight variation')
+    })
+
+    it('handles line height and letter spacing', () => {
+      const jsx = `<p className="leading-loose tracking-wide">Spaced text</p>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+      expect(result.schemas[0].controls.typography).toBeDefined()
+      expect((result.schemas[0].controls.content as TextInputControlValue).value).toBe('Spaced text')
+    })
+
+    it('handles text transform classes', () => {
+      const jsx = `<span className="uppercase">uppercase text</span>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+      expect(result.schemas[0].controls.typography).toBeDefined()
+      expect((result.schemas[0].controls.content as TextInputControlValue).value).toBe('uppercase text')
+    })
+
+    it('handles italic text', () => {
+      const jsx = `<em className="italic text-gray-500">Emphasized text</em>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+      expect(result.schemas[0].controls.typography).toBeDefined()
+      expect((result.schemas[0].controls.content as TextInputControlValue).value).toBe('Emphasized text')
+    })
+  })
+
+  describe('responsive classes', () => {
+    it('handles responsive margin classes across all breakpoints', () => {
+      const jsx = `<div className="m-4 sm:m-3 md:m-2 lg:m-8 xl:m-12">Responsive margins</div>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+      expect(schema.controls.style).toBeDefined()
+      expect(schema.controls.style?.type).toBe('Style')
+
+      if (schema.controls.style?.type === 'Style') {
+        const styleValue = schema.controls.style.value
+
+        expect(styleValue.length).toBe(3)
+
+        const mobileStyle = styleValue.find(v => v.deviceId === 'mobile')
+        expect(mobileStyle).toBeDefined()
+        expect(mobileStyle?.value.margin).toBe('1rem')
+
+        const tabletStyle = styleValue.find(v => v.deviceId === 'tablet')
+        expect(tabletStyle).toBeDefined()
+        expect(tabletStyle?.value.margin).toBe('0.75rem')
+
+        const desktopStyle = styleValue.find(v => v.deviceId === 'desktop')
+        expect(desktopStyle).toBeDefined()
+        expect(desktopStyle?.value.margin).toBe('3rem')
+      }
+    })
+
+    it('handles responsive padding classes', () => {
+      const jsx = `<div className="p-2 sm:p-4 md:p-6 lg:p-8">Responsive padding</div>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+
+      if (schema.controls.style?.type === 'Style') {
+        const styleValue = schema.controls.style.value
+
+        expect(styleValue.length).toBe(3)
+
+        const mobileStyle = styleValue.find(v => v.deviceId === 'mobile')
+        expect(mobileStyle?.value.padding).toBe('0.5rem')
+
+        const tabletStyle = styleValue.find(v => v.deviceId === 'tablet')
+        expect(tabletStyle?.value.padding).toBe('1rem')
+
+        const desktopStyle = styleValue.find(v => v.deviceId === 'desktop')
+        expect(desktopStyle?.value.padding).toBe('2rem')
+      }
+    })
+
+    it('handles responsive gap classes', () => {
+      const jsx = `<div className="flex gap-2 md:gap-4 lg:gap-8">Responsive gap</div>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+
+      if (schema.controls.style?.type === 'Style') {
+        const styleValue = schema.controls.style.value
+
+        expect(styleValue.length).toBe(2)
+
+        const mobileStyle = styleValue.find(v => v.deviceId === 'mobile')
+        expect(mobileStyle?.value.gap).toBe('0.5rem')
+        expect(mobileStyle?.value.display).toBe('flex')
+
+        const desktopStyle = styleValue.find(v => v.deviceId === 'desktop')
+        expect(desktopStyle?.value.gap).toBe('2rem')
+      }
+    })
+
+    it('handles responsive width classes', () => {
+      const jsx = `<div className="w-full md:w-1/2 lg:w-1/3 xl:w-1/4">Responsive width</div>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+
+      if (schema.controls.style?.type === 'Style') {
+        const styleValue = schema.controls.style.value
+
+        expect(styleValue.length).toBe(2)
+
+        const mobileStyle = styleValue.find(v => v.deviceId === 'mobile')
+        expect(mobileStyle?.value.width).toBe('100%')
+
+        const desktopStyle = styleValue.find(v => v.deviceId === 'desktop')
+        expect(desktopStyle?.value.width).toBe('25%')
+      }
+    })
+
+    it('handles responsive flex direction', () => {
+      const jsx = `<div className="flex flex-col md:flex-row">Responsive direction</div>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+
+      if (schema.controls.style?.type === 'Style') {
+        const styleValue = schema.controls.style.value
+
+        expect(styleValue.length).toBe(2)
+
+        const mobileStyle = styleValue.find(v => v.deviceId === 'mobile')
+        expect(mobileStyle?.value.display).toBe('flex')
+        expect(mobileStyle?.value.flexDirection).toBe('column')
+
+        const desktopStyle = styleValue.find(v => v.deviceId === 'desktop')
+        expect(desktopStyle?.value.flexDirection).toBe('row')
+      }
+    })
+
+    it('handles responsive text colors', () => {
+      const jsx = `<p className="text-gray-600 md:text-gray-800 lg:text-black">Responsive color</p>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+      expect(schema.controls.textColor).toBeDefined()
+      expect(schema.controls.textColor?.type).toBe('Color')
+
+      if (schema.controls.textColor?.type === 'Color') {
+        const colorValue = schema.controls.textColor.value
+
+        expect(colorValue.length).toBe(2)
+
+        const mobileColor = colorValue.find(v => v.deviceId === 'mobile')
+        expect(mobileColor?.value.color).toBe('#4b5563')
+
+        const desktopColor = colorValue.find(v => v.deviceId === 'desktop')
+        expect(desktopColor?.value.color).toBe('#000000')
+      }
+    })
+
+    it('handles responsive background colors', () => {
+      const jsx = `<div className="bg-white md:bg-gray-100 lg:bg-gray-200">Responsive bg</div>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+      expect(schema.controls.backgroundColor).toBeDefined()
+
+      if (schema.controls.backgroundColor?.type === 'Color') {
+        const colorValue = schema.controls.backgroundColor.value
+
+        expect(colorValue.length).toBe(2)
+
+        const mobileColor = colorValue.find(v => v.deviceId === 'mobile')
+        expect(mobileColor?.value.color).toBe('#ffffff')
+
+        const desktopColor = colorValue.find(v => v.deviceId === 'desktop')
+        expect(desktopColor?.value.color).toBe('#e5e7eb')
+      }
+    })
+
+    it('handles responsive typography with font size', () => {
+      const jsx = `<h1 className="text-xl md:text-2xl lg:text-4xl xl:text-6xl">Big heading</h1>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+      expect(schema.controls.typography).toBeDefined()
+
+      if (schema.controls.typography?.type === 'Typography') {
+        const typographyValue = schema.controls.typography.value
+
+        expect(typographyValue.length).toBe(2)
+
+        const mobileTypo = typographyValue.find(v => v.deviceId === 'mobile')
+        expect(mobileTypo?.value.fontSize).toBe('1.25rem')
+
+        const desktopTypo = typographyValue.find(v => v.deviceId === 'desktop')
+        expect(desktopTypo?.value.fontSize).toBe('3.75rem')
+      }
+
+      expect((schema.controls.content as TextInputControlValue).value).toBe('Big heading')
+    })
+
+    it('handles responsive border radius', () => {
+      const jsx = `<div className="rounded md:rounded-lg lg:rounded-xl">Rounded box</div>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+
+      if (schema.controls.style?.type === 'Style') {
+        const styleValue = schema.controls.style.value
+
+        expect(styleValue.length).toBe(2)
+
+        const mobileStyle = styleValue.find(v => v.deviceId === 'mobile')
+        expect(mobileStyle?.value.borderRadius).toBe('0.25rem')
+
+        const desktopStyle = styleValue.find(v => v.deviceId === 'desktop')
+        expect(desktopStyle?.value.borderRadius).toBe('0.75rem')
+      }
+    })
+
+    it('handles 2xl breakpoint', () => {
+      const jsx = `<div className="p-4 2xl:p-16">Extra large padding</div>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+
+      if (schema.controls.style?.type === 'Style') {
+        const styleValue = schema.controls.style.value
+
+        expect(styleValue.length).toBe(2)
+
+        const mobileStyle = styleValue.find(v => v.deviceId === 'mobile')
+        expect(mobileStyle?.value.padding).toBe('1rem')
+
+        const desktopStyle = styleValue.find(v => v.deviceId === 'desktop')
+        expect(desktopStyle?.value.padding).toBe('4rem')
+      }
+    })
+
+    it('handles combined responsive layout classes', () => {
+      const jsx = `
+        <div className="flex flex-col gap-4 p-4 md:flex-row md:gap-8 md:p-8 lg:gap-12 lg:p-12">
+          Layout container
+        </div>
+      `
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+
+      if (schema.controls.style?.type === 'Style') {
+        const styleValue = schema.controls.style.value
+
+        expect(styleValue.length).toBe(2)
+
+        const mobileStyle = styleValue.find(v => v.deviceId === 'mobile')
+        expect(mobileStyle?.value.display).toBe('flex')
+        expect(mobileStyle?.value.flexDirection).toBe('column')
+        expect(mobileStyle?.value.gap).toBe('1rem')
+        expect(mobileStyle?.value.padding).toBe('1rem')
+
+        const desktopStyle = styleValue.find(v => v.deviceId === 'desktop')
+        expect(desktopStyle?.value.flexDirection).toBe('row')
+        expect(desktopStyle?.value.gap).toBe('3rem')
+        expect(desktopStyle?.value.padding).toBe('3rem')
+      }
+    })
+
+    it('handles responsive hidden/block display', () => {
+      const jsx = `<div className="hidden md:block lg:flex">Responsive visibility</div>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+
+      if (schema.controls.style?.type === 'Style') {
+        const styleValue = schema.controls.style.value
+
+        expect(styleValue.length).toBe(2)
+
+        const mobileStyle = styleValue.find(v => v.deviceId === 'mobile')
+        expect(mobileStyle?.value.display).toBe('none')
+
+        const desktopStyle = styleValue.find(v => v.deviceId === 'desktop')
+        expect(desktopStyle?.value.display).toBe('flex')
+      }
+    })
+
+    it('handles responsive max-width classes', () => {
+      const jsx = `<div className="max-w-sm md:max-w-md lg:max-w-xl xl:max-w-4xl">Responsive max-width</div>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+
+      if (schema.controls.style?.type === 'Style') {
+        const styleValue = schema.controls.style.value
+
+        expect(styleValue.length).toBe(2)
+
+        const mobileStyle = styleValue.find(v => v.deviceId === 'mobile')
+        expect(mobileStyle?.value.maxWidth).toBe('24rem')
+
+        const desktopStyle = styleValue.find(v => v.deviceId === 'desktop')
+        expect(desktopStyle?.value.maxWidth).toBe('56rem')
+      }
+    })
+
+    it('handles mixed responsive and non-responsive classes', () => {
+      const jsx = `<div className="bg-blue-500 text-white rounded-lg p-4 md:p-8 lg:p-12">Mixed classes</div>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+
+      expect(schema.controls.backgroundColor).toBeDefined()
+      if (schema.controls.backgroundColor?.type === 'Color') {
+        expect(schema.controls.backgroundColor.value.length).toBe(1)
+        expect(schema.controls.backgroundColor.value[0].deviceId).toBe('mobile')
+      }
+
+      expect(schema.controls.textColor).toBeDefined()
+
+      if (schema.controls.style?.type === 'Style') {
+        const styleValue = schema.controls.style.value
+
+        expect(styleValue.length).toBe(2)
+
+        const mobileStyle = styleValue.find(v => v.deviceId === 'mobile')
+        expect(mobileStyle?.value.borderRadius).toBe('0.5rem')
+        expect(mobileStyle?.value.padding).toBe('1rem')
+
+        const desktopStyle = styleValue.find(v => v.deviceId === 'desktop')
+        expect(desktopStyle?.value.padding).toBe('3rem')
+      }
+    })
+
+    it('larger Tailwind breakpoints override smaller ones for desktop', () => {
+      const jsx = `<div className="p-4 md:p-6 lg:p-8 xl:p-10 2xl:p-12">Breakpoint precedence</div>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+
+      if (schema.controls.style?.type === 'Style') {
+        const styleValue = schema.controls.style.value
+
+        expect(styleValue.length).toBe(2)
+
+        const desktopStyle = styleValue.find(v => v.deviceId === 'desktop')
+        expect(desktopStyle?.value.padding).toBe('3rem')
+      }
+    })
+
+    it('handles sm breakpoint mapping to tablet', () => {
+      const jsx = `<div className="p-2 sm:p-4">Tablet breakpoint</div>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+
+      if (schema.controls.style?.type === 'Style') {
+        const styleValue = schema.controls.style.value
+
+        expect(styleValue.length).toBe(2)
+
+        const mobileStyle = styleValue.find(v => v.deviceId === 'mobile')
+        expect(mobileStyle?.value.padding).toBe('0.5rem')
+
+        const tabletStyle = styleValue.find(v => v.deviceId === 'tablet')
+        expect(tabletStyle?.value.padding).toBe('1rem')
+      }
+    })
+  })
+
+  describe('image elements', () => {
+    it('extracts src and alt from img element', () => {
+      const jsx = `<img src="/hero.jpg" alt="Hero image" className="w-full rounded-lg" />`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+      expect(schema.type).toBe('Image')
+      expect(schema.tagName).toBe('img')
+
+      expect(schema.controls.image).toBeDefined()
+      expect(schema.controls.image?.type).toBe('Image')
+
+      if (schema.controls.image?.type === 'Image') {
+        expect(schema.controls.image.value.src).toBe('/hero.jpg')
+        expect(schema.controls.image.value.alt).toBe('Hero image')
+      }
+    })
+
+    it('extracts width and height from img element', () => {
+      const jsx = `<img src="/logo.png" width={200} height={100} />`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+
+      if (schema.controls.image?.type === 'Image') {
+        expect(schema.controls.image.value.src).toBe('/logo.png')
+        expect(schema.controls.image.value.width).toBe(200)
+        expect(schema.controls.image.value.height).toBe(100)
+      }
+    })
+
+    it('extracts width and height as strings', () => {
+      const jsx = `<img src="/photo.jpg" width="300" height="200" alt="Photo" />`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+
+      if (schema.controls.image?.type === 'Image') {
+        expect(schema.controls.image.value.width).toBe(300)
+        expect(schema.controls.image.value.height).toBe(200)
+      }
+    })
+
+    it('handles img with only src', () => {
+      const jsx = `<img src="/simple.jpg" />`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+
+      if (schema.controls.image?.type === 'Image') {
+        expect(schema.controls.image.value.src).toBe('/simple.jpg')
+        expect(schema.controls.image.value.alt).toBeUndefined()
+        expect(schema.controls.image.value.width).toBeUndefined()
+        expect(schema.controls.image.value.height).toBeUndefined()
+      }
+    })
+
+    it('combines image control with style controls', () => {
+      const jsx = `<img src="/styled.jpg" alt="Styled" className="w-full h-auto rounded-xl shadow-lg" />`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+
+      expect(schema.controls.image).toBeDefined()
+      expect(schema.controls.style).toBeDefined()
+
+      if (schema.controls.image?.type === 'Image') {
+        expect(schema.controls.image.value.src).toBe('/styled.jpg')
+      }
+
+      if (schema.controls.style?.type === 'Style') {
+        expect(schema.controls.style.properties).toContain('width')
+        expect(schema.controls.style.properties).toContain('borderRadius')
+      }
+    })
+
+    it('handles external image URLs', () => {
+      const jsx = `<img src="https://example.com/image.png" alt="External image" />`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      if (result.schemas[0].controls.image?.type === 'Image') {
+        expect(result.schemas[0].controls.image.value.src).toBe('https://example.com/image.png')
+      }
+    })
+  })
+
+  describe('link elements', () => {
+    it('extracts href from anchor element', () => {
+      const jsx = `<a href="/about">About Us</a>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+      expect(schema.type).toBe('Link')
+      expect(schema.tagName).toBe('a')
+
+      expect(schema.controls.link).toBeDefined()
+      expect(schema.controls.link?.type).toBe('Link')
+
+      if (schema.controls.link?.type === 'Link') {
+        expect(schema.controls.link.value.href).toBe('/about')
+      }
+
+      expect(schema.controls.content).toBeDefined()
+      expect((schema.controls.content as TextInputControlValue).value).toBe('About Us')
+    })
+
+    it('extracts href and target from anchor element', () => {
+      const jsx = `<a href="https://example.com" target="_blank">External Link</a>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+
+      if (schema.controls.link?.type === 'Link') {
+        expect(schema.controls.link.value.href).toBe('https://example.com')
+        expect(schema.controls.link.value.target).toBe('_blank')
+      }
+
+      expect((schema.controls.content as TextInputControlValue).value).toBe('External Link')
+    })
+
+    it('handles anchor with styles', () => {
+      const jsx = `<a href="/contact" className="text-blue-500 hover:underline font-bold">Contact</a>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+
+      expect(schema.controls.link).toBeDefined()
+      expect(schema.controls.textColor).toBeDefined()
+      expect(schema.controls.typography).toBeDefined()
+    })
+
+    it('handles internal page links', () => {
+      const jsx = `<a href="#section-1">Jump to Section</a>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      if (result.schemas[0].controls.link?.type === 'Link') {
+        expect(result.schemas[0].controls.link.value.href).toBe('#section-1')
+      }
+    })
+
+    it('handles mailto links', () => {
+      const jsx = `<a href="mailto:hello@example.com">Email Us</a>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      if (result.schemas[0].controls.link?.type === 'Link') {
+        expect(result.schemas[0].controls.link.value.href).toBe('mailto:hello@example.com')
+      }
+    })
+
+    it('handles tel links', () => {
+      const jsx = `<a href="tel:+1234567890">Call Us</a>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      if (result.schemas[0].controls.link?.type === 'Link') {
+        expect(result.schemas[0].controls.link.value.href).toBe('tel:+1234567890')
+      }
+    })
+  })
+
+  describe('button elements', () => {
+    it('extracts button content', () => {
+      const jsx = `<button>Click Me</button>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+      expect(schema.type).toBe('Button')
+      expect(schema.tagName).toBe('button')
+
+      expect(schema.controls.content).toBeDefined()
+      expect((schema.controls.content as TextInputControlValue).value).toBe('Click Me')
+    })
+
+    it('handles button with styles', () => {
+      const jsx = `<button className="bg-blue-500 text-white px-4 py-2 rounded-lg">Submit</button>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+
+      expect(schema.controls.content).toBeDefined()
+      expect(schema.controls.style).toBeDefined()
+      expect(schema.controls.backgroundColor).toBeDefined()
+      expect(schema.controls.textColor).toBeDefined()
+
+      expect((schema.controls.content as TextInputControlValue).value).toBe('Submit')
+    })
+
+    it('handles button with link attribute', () => {
+      const jsx = `<button href="/action">Action Button</button>`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+
+      if (schema.controls.link?.type === 'Link') {
+        expect(schema.controls.link.value.href).toBe('/action')
+      }
+
+      expect((schema.controls.content as TextInputControlValue).value).toBe('Action Button')
+    })
+  })
+
+  describe('video elements', () => {
+    it('extracts video src', () => {
+      const jsx = `<video src="/video.mp4" />`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+      expect(schema.tagName).toBe('video')
+
+      expect(schema.controls.video).toBeDefined()
+      expect(schema.controls.video?.type).toBe('TextInput')
+
+      if (schema.controls.video?.type === 'TextInput') {
+        expect(schema.controls.video.value).toBe('/video.mp4')
+      }
+    })
+
+    it('extracts video poster', () => {
+      const jsx = `<video src="/video.mp4" poster="/thumbnail.jpg" />`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+
+      expect(schema.controls.video).toBeDefined()
+      expect(schema.controls.poster).toBeDefined()
+
+      if (schema.controls.poster?.type === 'Image') {
+        expect(schema.controls.poster.value.src).toBe('/thumbnail.jpg')
+      }
+    })
+
+    it('handles video with styles', () => {
+      const jsx = `<video src="/intro.mp4" className="w-full rounded-lg" />`
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+
+      expect(schema.controls.video).toBeDefined()
+      expect(schema.controls.style).toBeDefined()
+
+      if (schema.controls.style?.type === 'Style') {
+        expect(schema.controls.style.properties).toContain('width')
+        expect(schema.controls.style.properties).toContain('borderRadius')
+      }
+    })
+  })
+
+  describe('complex nested structures', () => {
+    it('handles card with image and content', () => {
+      const jsx = `
+        <div className="bg-white rounded-lg shadow-md p-4">
+          <img src="/card-image.jpg" alt="Card" className="w-full rounded-t-lg" />
+          <h2 className="text-xl font-bold mt-4">Card Title</h2>
+          <p className="text-gray-600">Card description goes here.</p>
+          <a href="/read-more" className="text-blue-500">Read More</a>
+        </div>
+      `
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+      expect(schema.type).toBe('Container')
+      expect(schema.children).toBeDefined()
+
+      if (schema.children?.type === 'Slot') {
+        expect(schema.children.elements.length).toBe(4)
+
+        const imgElement = schema.children.elements[0]
+        expect(imgElement.type).toBe('Image')
+        expect(imgElement.controls.image).toBeDefined()
+
+        const headingElement = schema.children.elements[1]
+        expect(headingElement.type).toBe('Heading')
+        expect(headingElement.controls.content).toBeDefined()
+
+        const paragraphElement = schema.children.elements[2]
+        expect(paragraphElement.type).toBe('Paragraph')
+
+        const linkElement = schema.children.elements[3]
+        expect(linkElement.type).toBe('Link')
+        expect(linkElement.controls.link).toBeDefined()
+      }
+    })
+
+    it('handles navigation with multiple links', () => {
+      const jsx = `
+        <nav className="flex gap-4">
+          <a href="/">Home</a>
+          <a href="/about">About</a>
+          <a href="/contact">Contact</a>
+        </nav>
+      `
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+      expect(schema.tagName).toBe('nav')
+
+      if (schema.children?.type === 'Slot') {
+        expect(schema.children.elements.length).toBe(3)
+
+        for (const linkElement of schema.children.elements) {
+          expect(linkElement.type).toBe('Link')
+          expect(linkElement.controls.link).toBeDefined()
+          expect(linkElement.controls.content).toBeDefined()
+        }
+      }
+    })
+
+    it('handles hero section with image, heading, text, and CTA', () => {
+      const jsx = `
+        <section className="bg-gray-100 p-8">
+          <h1 className="text-4xl font-bold text-gray-900">Welcome to Our Site</h1>
+          <p className="text-xl text-gray-600 mt-4">The best place to find what you need.</p>
+          <button className="bg-blue-500 text-white px-6 py-3 rounded-lg mt-6">Get Started</button>
+        </section>
+      `
+
+      const result = transformJSX(jsx)
+
+      expect(result.errors).toHaveLength(0)
+
+      const schema = result.schemas[0]
+      expect(schema.type).toBe('Container')
+      expect(schema.tagName).toBe('section')
+
+      if (schema.children?.type === 'Slot') {
+        expect(schema.children.elements.length).toBe(3)
+
+        const h1 = schema.children.elements[0]
+        expect(h1.type).toBe('Heading')
+        expect((h1.controls.content as TextInputControlValue).value).toBe('Welcome to Our Site')
+
+        const p = schema.children.elements[1]
+        expect(p.type).toBe('Paragraph')
+
+        const button = schema.children.elements[2]
+        expect(button.type).toBe('Button')
+        expect((button.controls.content as TextInputControlValue).value).toBe('Get Started')
+      }
+    })
+  })
+})
+
+describe('transformJSXToJSON', () => {
+  it('returns valid JSON string', () => {
+    const jsx = `<div className="m-4">Hello</div>`
+
+    const json = transformJSXToJSON(jsx)
+
+    expect(() => JSON.parse(json)).not.toThrow()
+
+    const parsed = JSON.parse(json)
+    expect(parsed.type).toBe('Container')
+  })
+
+  it('returns error JSON for invalid input', () => {
+    const jsx = `<div className="m-4"`
+
+    const json = transformJSXToJSON(jsx)
+    const parsed = JSON.parse(json)
+
+    expect(parsed.errors).toBeDefined()
+    expect(parsed.errors.length).toBeGreaterThan(0)
+  })
+})

--- a/packages/jsx-to-makeswift/src/cli.ts
+++ b/packages/jsx-to-makeswift/src/cli.ts
@@ -1,0 +1,414 @@
+/**
+ * @fileoverview CLI tool for converting JSX with Tailwind to Makeswift control schemas.
+ *
+ * Usage:
+ *   npx jsx-to-makeswift convert <file>           Convert JSX to schema
+ *   npx jsx-to-makeswift reverse <file.json>      Convert schema back to JSX
+ *   npx jsx-to-makeswift convert --stdin          Read JSX from stdin
+ *   npx jsx-to-makeswift reverse --stdin          Read JSON schema from stdin
+ *
+ * Options:
+ *   --help, -h     Show help message
+ *   --version, -v  Show version number
+ *   --stdin        Read input from stdin instead of files
+ *   --pretty       Pretty-print output (default: true)
+ *   --compact      Compact output (no indentation)
+ *   --fragment     Treat input as JSX fragment (multiple root elements)
+ *
+ * Exit codes:
+ *   0  Success
+ *   1  Error (parse error, file not found, etc.)
+ *
+ * @module @makeswift/jsx-to-makeswift/cli
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+
+import { isMakeswiftRuntimeSchema, transformRuntimeToJSX } from './makeswift-runtime/runtime-to-jsx'
+import { transformSchemaToJSX } from './reverse/schema-to-jsx'
+import { transformJSX, type TransformJSXOptions } from './transform'
+
+type Command = 'convert' | 'reverse' | null
+
+type CLIOptions = {
+  command: Command
+  stdin: boolean
+  pretty: boolean
+  fragment: boolean
+  help: boolean
+  version: boolean
+  files: string[]
+}
+
+const VERSION = '0.0.1'
+
+const HELP_TEXT = `
+jsx-to-makeswift - Bidirectional conversion between JSX+Tailwind and Makeswift control schemas
+
+COMMANDS:
+  convert <file>     Convert JSX with Tailwind to Makeswift control schema (JSON)
+  reverse <file>     Convert Makeswift control schema (JSON) back to JSX with Tailwind
+
+USAGE:
+  npx jsx-to-makeswift convert <file>            Convert JSX file to schema
+  npx jsx-to-makeswift convert <file1> <file2>   Convert multiple JSX files
+  npx jsx-to-makeswift convert --stdin           Read JSX from stdin
+  npx jsx-to-makeswift reverse <file.json>       Convert JSON schema to JSX
+  npx jsx-to-makeswift reverse --stdin           Read JSON schema from stdin
+
+OPTIONS:
+  --help, -h      Show this help message
+  --version, -v   Show version number
+  --stdin         Read input from stdin instead of files
+  --pretty        Pretty-print output (default)
+  --compact       Compact output (no indentation)
+  --fragment      Treat JSX input as fragment (multiple root elements)
+
+EXAMPLES:
+  # Convert JSX to schema
+  npx jsx-to-makeswift convert src/components/Hero.tsx
+
+  # Convert schema back to JSX
+  npx jsx-to-makeswift reverse schema.json
+
+  # Round-trip: JSX → Schema → JSX
+  npx jsx-to-makeswift convert --stdin < Hero.jsx | npx jsx-to-makeswift reverse --stdin
+
+  # Pipe JSX and get schema
+  echo '<div className="p-4 bg-blue-500">Hello</div>' | npx jsx-to-makeswift convert --stdin
+
+  # Pipe schema and get JSX
+  echo '{"type":"Container","tagName":"div","controls":{"style":{"type":"Style","properties":["padding"],"value":[{"deviceId":"mobile","value":{"padding":"1rem"}}]}}}' | npx jsx-to-makeswift reverse --stdin
+
+EXIT CODES:
+  0  Success
+  1  Error (parse error, file not found, etc.)
+`
+
+function parseArgs(args: string[]): CLIOptions {
+  const options: CLIOptions = {
+    command: null,
+    stdin: false,
+    pretty: true,
+    fragment: false,
+    help: false,
+    version: false,
+    files: [],
+  }
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+
+    switch (arg) {
+      case '--help':
+      case '-h':
+        options.help = true
+        break
+      case '--version':
+      case '-v':
+        options.version = true
+        break
+      case '--stdin':
+        options.stdin = true
+        break
+      case '--pretty':
+        options.pretty = true
+        break
+      case '--compact':
+        options.pretty = false
+        break
+      case '--fragment':
+        options.fragment = true
+        break
+      case 'convert':
+        options.command = 'convert'
+        break
+      case 'reverse':
+        options.command = 'reverse'
+        break
+      default:
+        if (!arg.startsWith('-')) {
+          options.files.push(arg)
+        }
+    }
+  }
+
+  return options
+}
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = ''
+
+    process.stdin.setEncoding('utf8')
+
+    process.stdin.on('data', (chunk) => {
+      data += chunk
+    })
+
+    process.stdin.on('end', () => {
+      resolve(data)
+    })
+
+    process.stdin.on('error', (err) => {
+      reject(err)
+    })
+
+    if (process.stdin.isTTY) {
+      resolve('')
+    }
+  })
+}
+
+function readFile(filePath: string): string {
+  const absolutePath = path.resolve(process.cwd(), filePath)
+
+  if (!fs.existsSync(absolutePath)) {
+    throw new Error(`File not found: ${filePath}`)
+  }
+
+  return fs.readFileSync(absolutePath, 'utf8')
+}
+
+type CommandResult = {
+  success: boolean
+  file?: string
+  output?: unknown
+  error?: string
+}
+
+function convertJSXToSchema(
+  source: string,
+  options: Partial<TransformJSXOptions>,
+  file?: string,
+): CommandResult {
+  const result = transformJSX(source, options)
+
+  if (result.errors.length > 0) {
+    return {
+      success: false,
+      file,
+      error: result.errors.join('\n'),
+    }
+  }
+
+  const output = result.schemas.length === 1 ? result.schemas[0] : result.schemas
+
+  return {
+    success: true,
+    file,
+    output,
+  }
+}
+
+function convertSchemaToJSX(
+  source: string,
+  file?: string,
+): CommandResult {
+  try {
+    const parsed = JSON.parse(source)
+
+    if (isMakeswiftRuntimeSchema(parsed)) {
+      const result = transformRuntimeToJSX(parsed)
+
+      if (result.warnings.length > 0 && !result.jsx) {
+        return {
+          success: false,
+          file,
+          error: result.warnings.join('\n'),
+        }
+      }
+
+      return {
+        success: true,
+        file,
+        output: result.jsx,
+      }
+    }
+
+    const result = transformSchemaToJSX(parsed)
+
+    if (result.warnings.length > 0 && !result.jsx) {
+      return {
+        success: false,
+        file,
+        error: result.warnings.join('\n'),
+      }
+    }
+
+    return {
+      success: true,
+      file,
+      output: result.jsx,
+    }
+  } catch (err) {
+    return {
+      success: false,
+      file,
+      error: err instanceof Error ? err.message : String(err),
+    }
+  }
+}
+
+function formatConvertOutput(results: CommandResult[], pretty: boolean): string {
+  if (results.length === 1) {
+    const result = results[0]
+
+    if (!result.success) {
+      return JSON.stringify({ error: result.error }, null, pretty ? 2 : undefined)
+    }
+
+    return JSON.stringify(result.output, null, pretty ? 2 : undefined)
+  }
+
+  const output = results.map((result) => {
+    if (!result.success) {
+      return { file: result.file, error: result.error }
+    }
+    return { file: result.file, schema: result.output }
+  })
+
+  return JSON.stringify(output, null, pretty ? 2 : undefined)
+}
+
+function formatReverseOutput(results: CommandResult[]): string {
+  if (results.length === 1) {
+    const result = results[0]
+
+    if (!result.success) {
+      return `// Error: ${result.error}`
+    }
+
+    return result.output as string
+  }
+
+  return results
+    .map((result) => {
+      if (!result.success) {
+        return `// File: ${result.file}\n// Error: ${result.error}`
+      }
+      return `// File: ${result.file}\n${result.output}`
+    })
+    .join('\n\n')
+}
+
+async function runConvert(options: CLIOptions): Promise<number> {
+  const transformOptions: Partial<TransformJSXOptions> = {
+    fragment: options.fragment,
+  }
+
+  const results: CommandResult[] = []
+
+  if (options.stdin) {
+    const source = await readStdin()
+
+    if (!source.trim()) {
+      console.error('Error: No input received from stdin')
+      return 1
+    }
+
+    results.push(convertJSXToSchema(source, transformOptions, 'stdin'))
+  } else if (options.files.length > 0) {
+    for (const file of options.files) {
+      try {
+        const source = readFile(file)
+        results.push(convertJSXToSchema(source, transformOptions, file))
+      } catch (err) {
+        results.push({
+          success: false,
+          file,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+    }
+  } else {
+    console.error('Error: No input provided. Use --stdin or provide file paths.')
+    console.error('Run with --help for usage information.')
+    return 1
+  }
+
+  const output = formatConvertOutput(results, options.pretty)
+  console.log(output)
+
+  const hasErrors = results.some((r) => !r.success)
+  return hasErrors ? 1 : 0
+}
+
+async function runReverse(options: CLIOptions): Promise<number> {
+  const results: CommandResult[] = []
+
+  if (options.stdin) {
+    const source = await readStdin()
+
+    if (!source.trim()) {
+      console.error('Error: No input received from stdin')
+      return 1
+    }
+
+    results.push(convertSchemaToJSX(source, 'stdin'))
+  } else if (options.files.length > 0) {
+    for (const file of options.files) {
+      try {
+        const source = readFile(file)
+        results.push(convertSchemaToJSX(source, file))
+      } catch (err) {
+        results.push({
+          success: false,
+          file,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+    }
+  } else {
+    console.error('Error: No input provided. Use --stdin or provide file paths.')
+    console.error('Run with --help for usage information.')
+    return 1
+  }
+
+  const output = formatReverseOutput(results)
+  console.log(output)
+
+  const hasErrors = results.some((r) => !r.success)
+  return hasErrors ? 1 : 0
+}
+
+async function main(): Promise<number> {
+  const args = process.argv.slice(2)
+  const options = parseArgs(args)
+
+  if (options.help) {
+    console.log(HELP_TEXT)
+    return 0
+  }
+
+  if (options.version) {
+    console.log(VERSION)
+    return 0
+  }
+
+  if (!options.command) {
+    console.error('Error: No command specified. Use "convert" or "reverse".')
+    console.error('Run with --help for usage information.')
+    return 1
+  }
+
+  if (options.command === 'convert') {
+    return runConvert(options)
+  }
+
+  if (options.command === 'reverse') {
+    return runReverse(options)
+  }
+
+  return 1
+}
+
+main()
+  .then((exitCode) => {
+    process.exit(exitCode)
+  })
+  .catch((err) => {
+    console.error('Fatal error:', err)
+    process.exit(1)
+  })

--- a/packages/jsx-to-makeswift/src/controls/control-mapper.ts
+++ b/packages/jsx-to-makeswift/src/controls/control-mapper.ts
@@ -1,0 +1,384 @@
+import type {
+  ColorControlValue,
+  ControlValue,
+  ImageControlValue,
+  LinkControlValue,
+  ParsedJSXElement,
+  RichTextControlValue,
+  SlotControlValue,
+  StyleControlValue,
+  StyleProperty,
+  TextAreaControlValue,
+  TextInputControlValue,
+  TypographyControlValue,
+} from '../types'
+
+import { tokenizeTailwindClasses } from '../tailwind/tokenizer'
+import {
+  buildResponsiveValues,
+  type ResponsiveColorValue,
+  type ResponsiveStyleValue,
+  type ResponsiveTypographyValue,
+} from '../utils/responsive-value'
+
+import { inferContentControlType, inferElementType } from './type-inference'
+
+type ControlMappingResult = {
+  controls: Record<string, ControlValue>
+  unmappedClasses: string[]
+}
+
+const CSS_TO_STYLE_PROPERTY: Record<string, StyleProperty> = {
+  margin: 'margin',
+  marginTop: 'marginTop',
+  marginRight: 'marginRight',
+  marginBottom: 'marginBottom',
+  marginLeft: 'marginLeft',
+  marginInline: 'marginLeft',
+  marginBlock: 'marginTop',
+  marginInlineStart: 'marginLeft',
+  marginInlineEnd: 'marginRight',
+  padding: 'padding',
+  paddingTop: 'paddingTop',
+  paddingRight: 'paddingRight',
+  paddingBottom: 'paddingBottom',
+  paddingLeft: 'paddingLeft',
+  paddingInline: 'paddingLeft',
+  paddingBlock: 'paddingTop',
+  paddingInlineStart: 'paddingLeft',
+  paddingInlineEnd: 'paddingRight',
+  width: 'width',
+  height: 'height',
+  minWidth: 'minWidth',
+  minHeight: 'minHeight',
+  maxWidth: 'maxWidth',
+  maxHeight: 'maxHeight',
+  gap: 'gap',
+  rowGap: 'rowGap',
+  columnGap: 'columnGap',
+  display: 'display',
+  flexDirection: 'flexDirection',
+  justifyContent: 'justifyContent',
+  alignItems: 'alignItems',
+  flexWrap: 'flexWrap',
+  position: 'position',
+  top: 'top',
+  right: 'right',
+  bottom: 'bottom',
+  left: 'left',
+  zIndex: 'zIndex',
+  overflow: 'overflow',
+  borderWidth: 'borderWidth',
+  borderRadius: 'borderRadius',
+  borderStyle: 'borderStyle',
+  boxShadow: 'boxShadow',
+  opacity: 'opacity',
+}
+
+function extractStyleProperties(
+  styleValue: ResponsiveStyleValue,
+): StyleProperty[] {
+  const properties = new Set<StyleProperty>()
+
+  for (const device of styleValue) {
+    for (const cssProp of Object.keys(device.value)) {
+      const styleProp = CSS_TO_STYLE_PROPERTY[cssProp]
+      if (styleProp) {
+        properties.add(styleProp)
+      }
+    }
+  }
+
+  return Array.from(properties)
+}
+
+function createStyleControl(
+  styleValue: ResponsiveStyleValue,
+): StyleControlValue | null {
+  if (styleValue.length === 0) return null
+
+  const properties = extractStyleProperties(styleValue)
+  if (properties.length === 0) return null
+
+  return {
+    type: 'Style',
+    properties,
+    value: styleValue,
+  }
+}
+
+function createColorControl(
+  colorValue: ResponsiveColorValue,
+  property: 'textColor' | 'backgroundColor' | 'borderColor',
+): ColorControlValue | null {
+  if (colorValue.length === 0) return null
+
+  return {
+    type: 'Color',
+    property,
+    value: colorValue,
+  }
+}
+
+function createTypographyControl(
+  typographyValue: ResponsiveTypographyValue,
+): TypographyControlValue | null {
+  if (typographyValue.length === 0) return null
+
+  const hasValues = typographyValue.some(
+    (device) => Object.keys(device.value).length > 0,
+  )
+
+  if (!hasValues) return null
+
+  return {
+    type: 'Typography',
+    value: typographyValue,
+  }
+}
+
+function createTextInputControl(value: string): TextInputControlValue {
+  return {
+    type: 'TextInput',
+    value,
+  }
+}
+
+function createTextAreaControl(value: string): TextAreaControlValue {
+  return {
+    type: 'TextArea',
+    value,
+  }
+}
+
+function createRichTextControl(value: string): RichTextControlValue {
+  return {
+    type: 'RichText',
+    value,
+  }
+}
+
+type ImageAttributes = {
+  src?: string
+  alt?: string
+  width?: number | string
+  height?: number | string
+}
+
+function createImageControl(attributes: ImageAttributes): ImageControlValue | null {
+  const src = attributes.src
+
+  if (!src || src === '[dynamic]') {
+    return null
+  }
+
+  const result: ImageControlValue = {
+    type: 'Image',
+    value: {
+      src,
+    },
+  }
+
+  if (attributes.alt && attributes.alt !== '[dynamic]') {
+    result.value.alt = String(attributes.alt)
+  }
+
+  if (attributes.width !== undefined && attributes.width !== '[dynamic]') {
+    const width = typeof attributes.width === 'number'
+      ? attributes.width
+      : parseInt(String(attributes.width), 10)
+
+    if (!isNaN(width)) {
+      result.value.width = width
+    }
+  }
+
+  if (attributes.height !== undefined && attributes.height !== '[dynamic]') {
+    const height = typeof attributes.height === 'number'
+      ? attributes.height
+      : parseInt(String(attributes.height), 10)
+
+    if (!isNaN(height)) {
+      result.value.height = height
+    }
+  }
+
+  return result
+}
+
+type LinkAttributes = {
+  href?: string
+  target?: string
+}
+
+function createLinkControl(attributes: LinkAttributes): LinkControlValue | null {
+  const href = attributes.href
+
+  if (!href || href === '[dynamic]') {
+    return null
+  }
+
+  const result: LinkControlValue = {
+    type: 'Link',
+    value: {
+      href,
+    },
+  }
+
+  if (attributes.target && attributes.target !== '[dynamic]') {
+    result.value.target = String(attributes.target)
+  }
+
+  return result
+}
+
+function isImageElement(tagName: string): boolean {
+  return tagName.toLowerCase() === 'img'
+}
+
+function isLinkElement(tagName: string): boolean {
+  return tagName.toLowerCase() === 'a'
+}
+
+function isVideoElement(tagName: string): boolean {
+  return tagName.toLowerCase() === 'video'
+}
+
+function isButtonElement(tagName: string): boolean {
+  return tagName.toLowerCase() === 'button'
+}
+
+export function mapElementToControls(
+  element: ParsedJSXElement,
+): ControlMappingResult {
+  const controls: Record<string, ControlValue> = {}
+  const unmappedClasses: string[] = []
+
+  const parseResult = tokenizeTailwindClasses(element.className)
+  const responsiveValues = buildResponsiveValues(parseResult)
+
+  const styleControl = createStyleControl(responsiveValues.style)
+  if (styleControl) {
+    controls.style = styleControl
+  }
+
+  if (responsiveValues.colors.textColor) {
+    const textColorControl = createColorControl(
+      responsiveValues.colors.textColor,
+      'textColor',
+    )
+    if (textColorControl) {
+      controls.textColor = textColorControl
+    }
+  }
+
+  if (responsiveValues.colors.backgroundColor) {
+    const bgColorControl = createColorControl(
+      responsiveValues.colors.backgroundColor,
+      'backgroundColor',
+    )
+    if (bgColorControl) {
+      controls.backgroundColor = bgColorControl
+    }
+  }
+
+  if (responsiveValues.colors.borderColor) {
+    const borderColorControl = createColorControl(
+      responsiveValues.colors.borderColor,
+      'borderColor',
+    )
+    if (borderColorControl) {
+      controls.borderColor = borderColorControl
+    }
+  }
+
+  const typographyControl = createTypographyControl(responsiveValues.typography)
+  if (typographyControl) {
+    controls.typography = typographyControl
+  }
+
+  if (isImageElement(element.tagName)) {
+    const imageControl = createImageControl(element.attributes as ImageAttributes)
+    if (imageControl) {
+      controls.image = imageControl
+    }
+  }
+
+  if (isLinkElement(element.tagName)) {
+    const linkControl = createLinkControl(element.attributes as LinkAttributes)
+    if (linkControl) {
+      controls.link = linkControl
+    }
+
+    if (element.textContent) {
+      controls.content = createTextInputControl(element.textContent)
+    }
+  } else if (isButtonElement(element.tagName)) {
+    const linkControl = createLinkControl(element.attributes as LinkAttributes)
+    if (linkControl) {
+      controls.link = linkControl
+    }
+
+    if (element.textContent) {
+      controls.content = createTextInputControl(element.textContent)
+    }
+  } else if (isVideoElement(element.tagName)) {
+    const videoSrc = element.attributes.src as string | undefined
+    const poster = element.attributes.poster as string | undefined
+
+    if (videoSrc && videoSrc !== '[dynamic]') {
+      controls.video = {
+        type: 'TextInput',
+        value: videoSrc,
+      }
+    }
+
+    if (poster && poster !== '[dynamic]') {
+      const posterControl = createImageControl({ src: poster })
+      if (posterControl) {
+        controls.poster = posterControl
+      }
+    }
+  } else if (element.textContent) {
+    const inference = inferContentControlType(element)
+
+    switch (inference.controlType) {
+      case 'TextInput':
+        controls.content = createTextInputControl(element.textContent)
+        break
+      case 'TextArea':
+        controls.content = createTextAreaControl(element.textContent)
+        break
+      case 'RichText':
+        controls.content = createRichTextControl(element.textContent)
+        break
+    }
+  }
+
+  for (const stateVariant of Object.keys(parseResult.stateClasses)) {
+    for (const token of parseResult.stateClasses[stateVariant]) {
+      unmappedClasses.push(token.raw)
+    }
+  }
+
+  return { controls, unmappedClasses }
+}
+
+export function createSlotControl(
+  children: ParsedJSXElement[],
+  transformFn: (el: ParsedJSXElement) => import('../types').ElementSchema,
+): SlotControlValue | null {
+  if (children.length === 0) return null
+
+  return {
+    type: 'Slot',
+    elements: children.map(transformFn),
+  }
+}
+
+export function getControlsForElementType(
+  element: ParsedJSXElement,
+): string[] {
+  const inference = inferElementType(element)
+  return inference.suggestedControls
+}

--- a/packages/jsx-to-makeswift/src/controls/index.ts
+++ b/packages/jsx-to-makeswift/src/controls/index.ts
@@ -1,0 +1,3 @@
+export * from './type-inference'
+export * from './control-mapper'
+export * from './schema-builder'

--- a/packages/jsx-to-makeswift/src/controls/schema-builder.ts
+++ b/packages/jsx-to-makeswift/src/controls/schema-builder.ts
@@ -1,0 +1,182 @@
+import { z } from 'zod'
+
+import type {
+  ElementSchema,
+  ParsedJSXElement,
+  TransformOptions,
+  TransformResult,
+} from '../types'
+
+import { tokenizeTailwindClasses } from '../tailwind/tokenizer'
+
+import { createSlotControl, mapElementToControls } from './control-mapper'
+import { inferElementType } from './type-inference'
+
+const DEFAULT_OPTIONS: TransformOptions = {
+  inferContentControls: true,
+  includeStateVariants: false,
+  preserveOriginalClasses: false,
+}
+
+function transformElement(
+  element: ParsedJSXElement,
+  options: TransformOptions,
+): ElementSchema {
+  const { controls } = mapElementToControls(element)
+  const { elementType } = inferElementType(element)
+
+  const schema: ElementSchema = {
+    type: elementType,
+    tagName: element.tagName,
+    controls,
+  }
+
+  if (element.children.length > 0) {
+    const slot = createSlotControl(element.children, (child) =>
+      transformElement(child, options),
+    )
+    if (slot) {
+      schema.children = slot
+    }
+  }
+
+  if (options.preserveOriginalClasses && element.className) {
+    schema.metadata = {
+      ...schema.metadata,
+      originalClassName: element.className,
+    }
+  }
+
+  if (options.includeStateVariants && element.className) {
+    const parseResult = tokenizeTailwindClasses(element.className)
+    const stateVariants: Record<string, string[]> = {}
+
+    for (const [variant, tokens] of Object.entries(parseResult.stateClasses)) {
+      stateVariants[variant] = tokens.map((t) => t.raw)
+    }
+
+    if (Object.keys(stateVariants).length > 0) {
+      schema.metadata = {
+        ...schema.metadata,
+        stateVariants,
+      }
+    }
+  }
+
+  return schema
+}
+
+export function buildSchema(
+  elements: ParsedJSXElement[],
+  options: Partial<TransformOptions> = {},
+): TransformResult[] {
+  const mergedOptions = { ...DEFAULT_OPTIONS, ...options }
+
+  return elements.map((element) => {
+    const allUnmapped: string[] = []
+    const allWarnings: string[] = []
+
+    const collectUnmapped = (el: ParsedJSXElement): void => {
+      const parseResult = tokenizeTailwindClasses(el.className)
+
+      for (const variant of Object.keys(parseResult.stateClasses)) {
+        for (const token of parseResult.stateClasses[variant]) {
+          allUnmapped.push(token.raw)
+        }
+      }
+
+      for (const child of el.children) {
+        collectUnmapped(child)
+      }
+    }
+
+    collectUnmapped(element)
+
+    const schema = transformElement(element, mergedOptions)
+
+    return {
+      schema,
+      warnings: allWarnings,
+      unmappedClasses: [...new Set(allUnmapped)],
+    }
+  })
+}
+
+export function buildSingleSchema(
+  element: ParsedJSXElement,
+  options: Partial<TransformOptions> = {},
+): TransformResult {
+  const results = buildSchema([element], options)
+  return results[0]
+}
+
+type ElementSchemaValidatorType = z.ZodObject<{
+  type: z.ZodString
+  tagName: z.ZodString
+  controls: z.ZodRecord<z.ZodString, z.ZodAny>
+  children: z.ZodOptional<z.ZodObject<{
+    type: z.ZodLiteral<'Slot'>
+    elements: z.ZodArray<z.ZodLazy<z.ZodTypeAny>>
+  }>>
+  metadata: z.ZodOptional<z.ZodObject<{
+    originalClassName: z.ZodOptional<z.ZodString>
+    stateVariants: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodArray<z.ZodString>>>
+  }>>
+}>
+
+export const ElementSchemaValidator: ElementSchemaValidatorType = z.object({
+  type: z.string(),
+  tagName: z.string(),
+  controls: z.record(z.string(), z.any()),
+  children: z
+    .object({
+      type: z.literal('Slot'),
+      elements: z.array(z.lazy((): z.ZodTypeAny => ElementSchemaValidator)),
+    })
+    .optional(),
+  metadata: z
+    .object({
+      originalClassName: z.string().optional(),
+      stateVariants: z.record(z.string(), z.array(z.string())).optional(),
+    })
+    .optional(),
+})
+
+export function validateSchema(schema: unknown): {
+  valid: boolean
+  errors: string[]
+} {
+  const result = ElementSchemaValidator.safeParse(schema)
+
+  if (result.success) {
+    return { valid: true, errors: [] }
+  }
+
+  return {
+    valid: false,
+    errors: result.error.errors.map(
+      (e) => `${e.path.join('.')}: ${e.message}`,
+    ),
+  }
+}
+
+export function serializeSchema(schema: ElementSchema): string {
+  return JSON.stringify(schema, null, 2)
+}
+
+export function deserializeSchema(json: string): ElementSchema | null {
+  try {
+    const parsed = JSON.parse(json)
+    const validation = validateSchema(parsed)
+
+    if (validation.valid) {
+      return parsed as ElementSchema
+    }
+
+    console.error('Schema validation errors:', validation.errors)
+    return null
+  } catch (error: unknown) {
+    console.error('Failed to parse schema JSON:', error)
+    return null
+  }
+}

--- a/packages/jsx-to-makeswift/src/controls/type-inference.ts
+++ b/packages/jsx-to-makeswift/src/controls/type-inference.ts
@@ -1,0 +1,281 @@
+import type { ControlType, ParsedJSXElement } from '../types'
+
+type ContentControlType = 'TextInput' | 'TextArea' | 'RichText'
+
+type InferenceResult = {
+  controlType: ContentControlType
+  confidence: 'high' | 'medium' | 'low'
+  reason: string
+}
+
+const HEADING_TAGS = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']
+const INLINE_TAGS = ['span', 'strong', 'em', 'b', 'i', 'u', 'a', 'code', 'small', 'mark']
+const BLOCK_TEXT_TAGS = ['p', 'div', 'article', 'section', 'blockquote']
+const FORM_INPUT_TAGS = ['label', 'button']
+const LIST_TAGS = ['li', 'dt', 'dd']
+
+const SHORT_TEXT_THRESHOLD = 50
+const MEDIUM_TEXT_THRESHOLD = 200
+
+export function inferContentControlType(element: ParsedJSXElement): InferenceResult {
+  const { tagName, textContent, hasRichContent, children } = element
+
+  if (hasRichContent) {
+    return {
+      controlType: 'RichText',
+      confidence: 'high',
+      reason: 'Element contains nested HTML elements indicating rich content',
+    }
+  }
+
+  if (HEADING_TAGS.includes(tagName.toLowerCase())) {
+    const length = textContent?.length ?? 0
+
+    if (length <= SHORT_TEXT_THRESHOLD) {
+      return {
+        controlType: 'TextInput',
+        confidence: 'high',
+        reason: `Heading tag (${tagName}) with short text content`,
+      }
+    }
+
+    return {
+      controlType: 'TextArea',
+      confidence: 'medium',
+      reason: `Heading tag (${tagName}) with longer text content`,
+    }
+  }
+
+  if (FORM_INPUT_TAGS.includes(tagName.toLowerCase())) {
+    return {
+      controlType: 'TextInput',
+      confidence: 'high',
+      reason: `Form element (${tagName}) typically has short, single-line content`,
+    }
+  }
+
+  if (INLINE_TAGS.includes(tagName.toLowerCase())) {
+    return {
+      controlType: 'TextInput',
+      confidence: 'medium',
+      reason: `Inline element (${tagName}) typically contains short text`,
+    }
+  }
+
+  if (LIST_TAGS.includes(tagName.toLowerCase())) {
+    const length = textContent?.length ?? 0
+
+    if (length <= SHORT_TEXT_THRESHOLD) {
+      return {
+        controlType: 'TextInput',
+        confidence: 'medium',
+        reason: `List item (${tagName}) with short content`,
+      }
+    }
+
+    return {
+      controlType: 'TextArea',
+      confidence: 'medium',
+      reason: `List item (${tagName}) with longer content`,
+    }
+  }
+
+  if (BLOCK_TEXT_TAGS.includes(tagName.toLowerCase())) {
+    const length = textContent?.length ?? 0
+
+    if (length <= SHORT_TEXT_THRESHOLD) {
+      return {
+        controlType: 'TextInput',
+        confidence: 'medium',
+        reason: `Block element (${tagName}) with short content`,
+      }
+    }
+
+    if (length <= MEDIUM_TEXT_THRESHOLD) {
+      return {
+        controlType: 'TextArea',
+        confidence: 'medium',
+        reason: `Block element (${tagName}) with medium-length content`,
+      }
+    }
+
+    if (children.length > 0) {
+      return {
+        controlType: 'RichText',
+        confidence: 'medium',
+        reason: `Block element (${tagName}) with multiple children`,
+      }
+    }
+
+    return {
+      controlType: 'TextArea',
+      confidence: 'medium',
+      reason: `Block element (${tagName}) with long content`,
+    }
+  }
+
+  if (!textContent) {
+    return {
+      controlType: 'TextInput',
+      confidence: 'low',
+      reason: 'No text content detected, defaulting to TextInput',
+    }
+  }
+
+  const length = textContent.length
+  const hasNewlines = textContent.includes('\n')
+
+  if (hasNewlines || length > MEDIUM_TEXT_THRESHOLD) {
+    return {
+      controlType: 'TextArea',
+      confidence: 'medium',
+      reason: 'Content contains newlines or is long',
+    }
+  }
+
+  if (length <= SHORT_TEXT_THRESHOLD) {
+    return {
+      controlType: 'TextInput',
+      confidence: 'medium',
+      reason: 'Short text content',
+    }
+  }
+
+  return {
+    controlType: 'TextArea',
+    confidence: 'low',
+    reason: 'Medium-length content, defaulting to TextArea',
+  }
+}
+
+type ElementTypeResult = {
+  elementType: string
+  suggestedControls: ControlType[]
+}
+
+export function inferElementType(element: ParsedJSXElement): ElementTypeResult {
+  const { tagName, attributes } = element
+  const lowerTag = tagName.toLowerCase()
+
+  if (HEADING_TAGS.includes(lowerTag)) {
+    return {
+      elementType: 'Heading',
+      suggestedControls: ['TextInput', 'Typography', 'Style'],
+    }
+  }
+
+  if (lowerTag === 'p') {
+    return {
+      elementType: 'Paragraph',
+      suggestedControls: ['TextArea', 'Typography', 'Style'],
+    }
+  }
+
+  if (lowerTag === 'img') {
+    return {
+      elementType: 'Image',
+      suggestedControls: ['Image', 'Style'],
+    }
+  }
+
+  if (lowerTag === 'a') {
+    return {
+      elementType: 'Link',
+      suggestedControls: ['Link', 'TextInput', 'Style'],
+    }
+  }
+
+  if (lowerTag === 'button') {
+    return {
+      elementType: 'Button',
+      suggestedControls: ['TextInput', 'Link', 'Style', 'Color'],
+    }
+  }
+
+  if (lowerTag === 'input') {
+    const inputType = attributes.type as string | undefined
+
+    if (inputType === 'checkbox') {
+      return {
+        elementType: 'Checkbox',
+        suggestedControls: ['Checkbox', 'Style'],
+      }
+    }
+
+    return {
+      elementType: 'Input',
+      suggestedControls: ['TextInput', 'Style'],
+    }
+  }
+
+  if (lowerTag === 'textarea') {
+    return {
+      elementType: 'TextArea',
+      suggestedControls: ['TextArea', 'Style'],
+    }
+  }
+
+  if (lowerTag === 'ul' || lowerTag === 'ol') {
+    return {
+      elementType: 'List',
+      suggestedControls: ['List', 'Style'],
+    }
+  }
+
+  if (lowerTag === 'div' || lowerTag === 'section' || lowerTag === 'article') {
+    return {
+      elementType: 'Container',
+      suggestedControls: ['Style', 'Slot'],
+    }
+  }
+
+  if (lowerTag === 'span') {
+    return {
+      elementType: 'Text',
+      suggestedControls: ['TextInput', 'Typography', 'Style'],
+    }
+  }
+
+  if (lowerTag === 'nav' || lowerTag === 'header' || lowerTag === 'footer') {
+    return {
+      elementType: tagName.charAt(0).toUpperCase() + tagName.slice(1),
+      suggestedControls: ['Style', 'Slot'],
+    }
+  }
+
+  const isCustomComponent = tagName[0] === tagName[0].toUpperCase()
+  if (isCustomComponent) {
+    return {
+      elementType: tagName,
+      suggestedControls: ['Style', 'Slot'],
+    }
+  }
+
+  return {
+    elementType: 'Container',
+    suggestedControls: ['Style', 'Slot'],
+  }
+}
+
+export function shouldHaveTextControl(element: ParsedJSXElement): boolean {
+  const { textContent, children, hasRichContent } = element
+
+  if (hasRichContent) return true
+  if (textContent && textContent.trim().length > 0) return true
+  if (children.length === 0) return false
+
+  return false
+}
+
+export function suggestListControl(elements: ParsedJSXElement[]): boolean {
+  if (elements.length < 2) return false
+
+  const tagNames = elements.map((e) => e.tagName.toLowerCase())
+  const uniqueTags = new Set(tagNames)
+
+  if (uniqueTags.size === 1) {
+    return true
+  }
+
+  return false
+}

--- a/packages/jsx-to-makeswift/src/index.ts
+++ b/packages/jsx-to-makeswift/src/index.ts
@@ -1,0 +1,10 @@
+export * from './types'
+
+export * from './parser'
+export * from './tailwind'
+export * from './controls'
+export * from './utils'
+export * from './reverse'
+export * from './makeswift-runtime'
+
+export * from './transform'

--- a/packages/jsx-to-makeswift/src/makeswift-runtime/index.ts
+++ b/packages/jsx-to-makeswift/src/makeswift-runtime/index.ts
@@ -1,0 +1,2 @@
+export * from './runtime-to-jsx'
+export * from './types'

--- a/packages/jsx-to-makeswift/src/makeswift-runtime/runtime-to-jsx.ts
+++ b/packages/jsx-to-makeswift/src/makeswift-runtime/runtime-to-jsx.ts
@@ -1,0 +1,568 @@
+/**
+ * @fileoverview Converts Makeswift runtime schemas to JSX with Tailwind.
+ *
+ * This module handles the actual Makeswift page data format and converts it
+ * to JSX source code with Tailwind CSS classes.
+ */
+
+import type {
+  MakeswiftChildren,
+  MakeswiftDeviceValue,
+  MakeswiftElement,
+  MakeswiftMarginValue,
+  MakeswiftPaddingValue,
+  MakeswiftRichTextV2,
+  MakeswiftRuntimeSchema,
+  MakeswiftSizeValue,
+  MakeswiftTypographyStyle,
+} from './types'
+
+export type RuntimeToJSXOptions = {
+  indent?: string
+  includeKeys?: boolean
+}
+
+export type RuntimeToJSXResult = {
+  jsx: string
+  warnings: string[]
+}
+
+const DEFAULT_OPTIONS: Required<RuntimeToJSXOptions> = {
+  indent: '  ',
+  includeKeys: false,
+}
+
+const COMPONENT_TO_TAG: Record<string, string> = {
+  './components/Box/index.js': 'div',
+  './components/Text/index.js': 'p',
+  './components/Image/index.js': 'img',
+  './components/Button/index.js': 'button',
+  './components/Link/index.js': 'a',
+  './components/Video/index.js': 'video',
+  './components/Embed/index.js': 'div',
+  './components/Form/index.js': 'form',
+  './components/Input/index.js': 'input',
+  './components/Textarea/index.js': 'textarea',
+  './components/Select/index.js': 'select',
+  './components/Checkbox/index.js': 'input',
+  './components/Radio/index.js': 'input',
+  './components/Navigation/index.js': 'nav',
+  './components/Root/index.js': 'div',
+}
+
+const SPACING_PX_TO_TAILWIND: Record<number, string> = {
+  0: '0',
+  1: 'px',
+  2: '0.5',
+  4: '1',
+  6: '1.5',
+  8: '2',
+  10: '2.5',
+  12: '3',
+  14: '3.5',
+  16: '4',
+  20: '5',
+  24: '6',
+  28: '7',
+  32: '8',
+  36: '9',
+  40: '10',
+  44: '11',
+  48: '12',
+  56: '14',
+  64: '16',
+  80: '20',
+  96: '24',
+  112: '28',
+  128: '32',
+  144: '36',
+  160: '40',
+  176: '44',
+  192: '48',
+  208: '52',
+  224: '56',
+  240: '60',
+  256: '64',
+  288: '72',
+  320: '80',
+  384: '96',
+}
+
+const FONT_SIZE_PX_TO_TAILWIND: Record<number, string> = {
+  12: 'xs',
+  14: 'sm',
+  16: 'base',
+  18: 'lg',
+  20: 'xl',
+  24: '2xl',
+  30: '3xl',
+  36: '4xl',
+  48: '5xl',
+  60: '6xl',
+  72: '7xl',
+  96: '8xl',
+  128: '9xl',
+}
+
+const FONT_WEIGHT_TO_TAILWIND: Record<number, string> = {
+  100: 'thin',
+  200: 'extralight',
+  300: 'light',
+  400: 'normal',
+  500: 'medium',
+  600: 'semibold',
+  700: 'bold',
+  800: 'extrabold',
+  900: 'black',
+}
+
+const LINE_HEIGHT_TO_TAILWIND: Record<number, string> = {
+  1: 'none',
+  1.25: 'tight',
+  1.375: 'snug',
+  1.5: 'normal',
+  1.625: 'relaxed',
+  2: 'loose',
+}
+
+const DEVICE_TO_PREFIX: Record<string, string> = {
+  mobile: '',
+  tablet: 'sm:',
+  desktop: 'lg:',
+}
+
+function pxToSpacingClass(px: number, prefix: string): string {
+  const scale = SPACING_PX_TO_TAILWIND[px]
+  if (scale) {
+    return `${prefix}${scale}`
+  }
+  return `${prefix}[${px}px]`
+}
+
+function addDevicePrefix(cls: string, deviceId: string): string {
+  const prefix = DEVICE_TO_PREFIX[deviceId] || ''
+  return `${prefix}${cls}`
+}
+
+function processPadding(
+  padding: MakeswiftDeviceValue<MakeswiftPaddingValue>[],
+): string[] {
+  const classes: string[] = []
+
+  for (const { deviceId, value } of padding) {
+    const pt = value.paddingTop
+    const pr = value.paddingRight
+    const pb = value.paddingBottom
+    const pl = value.paddingLeft
+
+    const ptVal = typeof pt === 'object' ? pt?.value : pt
+    const prVal = typeof pr === 'object' ? pr?.value : pr
+    const pbVal = typeof pb === 'object' ? pb?.value : pb
+    const plVal = typeof pl === 'object' ? pl?.value : pl
+
+    if (
+      ptVal !== undefined &&
+      ptVal === prVal &&
+      ptVal === pbVal &&
+      ptVal === plVal
+    ) {
+      classes.push(addDevicePrefix(pxToSpacingClass(ptVal, 'p-'), deviceId))
+    } else {
+      if (ptVal !== undefined && ptVal === pbVal && prVal === plVal && ptVal !== prVal) {
+        classes.push(addDevicePrefix(pxToSpacingClass(ptVal, 'py-'), deviceId))
+        if (prVal !== undefined) {
+          classes.push(addDevicePrefix(pxToSpacingClass(prVal, 'px-'), deviceId))
+        }
+      } else {
+        if (ptVal !== undefined) {
+          classes.push(addDevicePrefix(pxToSpacingClass(ptVal, 'pt-'), deviceId))
+        }
+        if (prVal !== undefined) {
+          classes.push(addDevicePrefix(pxToSpacingClass(prVal, 'pr-'), deviceId))
+        }
+        if (pbVal !== undefined) {
+          classes.push(addDevicePrefix(pxToSpacingClass(pbVal, 'pb-'), deviceId))
+        }
+        if (plVal !== undefined) {
+          classes.push(addDevicePrefix(pxToSpacingClass(plVal, 'pl-'), deviceId))
+        }
+      }
+    }
+  }
+
+  return classes
+}
+
+function processMargin(
+  margin: MakeswiftDeviceValue<MakeswiftMarginValue>[],
+): string[] {
+  const classes: string[] = []
+
+  for (const { deviceId, value } of margin) {
+    const mt = value.marginTop
+    const mr = value.marginRight
+    const mb = value.marginBottom
+    const ml = value.marginLeft
+
+    if (mr === 'auto' && ml === 'auto') {
+      classes.push(addDevicePrefix('mx-auto', deviceId))
+    } else {
+      if (ml === 'auto') {
+        classes.push(addDevicePrefix('ml-auto', deviceId))
+      } else if (typeof ml === 'object' && ml?.value !== undefined) {
+        classes.push(addDevicePrefix(pxToSpacingClass(ml.value, 'ml-'), deviceId))
+      }
+
+      if (mr === 'auto') {
+        classes.push(addDevicePrefix('mr-auto', deviceId))
+      } else if (typeof mr === 'object' && mr?.value !== undefined) {
+        classes.push(addDevicePrefix(pxToSpacingClass(mr.value, 'mr-'), deviceId))
+      }
+    }
+
+    if (typeof mt === 'object' && mt?.value !== undefined) {
+      classes.push(addDevicePrefix(pxToSpacingClass(mt.value, 'mt-'), deviceId))
+    }
+
+    if (typeof mb === 'object' && mb?.value !== undefined) {
+      classes.push(addDevicePrefix(pxToSpacingClass(mb.value, 'mb-'), deviceId))
+    }
+  }
+
+  return classes
+}
+
+function processWidth(width: MakeswiftDeviceValue<MakeswiftSizeValue>[]): string[] {
+  const classes: string[] = []
+
+  for (const { deviceId, value } of width) {
+    const { value: px, unit } = value
+
+    if (unit === '%') {
+      if (px === 100) {
+        classes.push(addDevicePrefix('w-full', deviceId))
+      } else if (px === 50) {
+        classes.push(addDevicePrefix('w-1/2', deviceId))
+      } else {
+        classes.push(addDevicePrefix(`w-[${px}%]`, deviceId))
+      }
+    } else if (unit === 'px') {
+      const scale = SPACING_PX_TO_TAILWIND[px]
+      if (scale) {
+        classes.push(addDevicePrefix(`w-${scale}`, deviceId))
+      } else {
+        classes.push(addDevicePrefix(`w-[${px}px]`, deviceId))
+      }
+    } else {
+      classes.push(addDevicePrefix(`w-[${px}${unit}]`, deviceId))
+    }
+  }
+
+  return classes
+}
+
+function processGap(
+  gap: MakeswiftDeviceValue<MakeswiftSizeValue>[],
+  direction: 'gap' | 'gap-x' | 'gap-y',
+): string[] {
+  const classes: string[] = []
+
+  for (const { deviceId, value } of gap) {
+    const { value: px } = value
+    classes.push(addDevicePrefix(pxToSpacingClass(px, `${direction}-`), deviceId))
+  }
+
+  return classes
+}
+
+function processTypography(style: MakeswiftTypographyStyle, deviceId: string): string[] {
+  const classes: string[] = []
+
+  if (style.fontSize) {
+    const px = style.fontSize.value
+    const scale = FONT_SIZE_PX_TO_TAILWIND[px]
+    if (scale) {
+      classes.push(addDevicePrefix(`text-${scale}`, deviceId))
+    } else {
+      classes.push(addDevicePrefix(`text-[${px}px]`, deviceId))
+    }
+  }
+
+  if (style.fontWeight) {
+    const weight = FONT_WEIGHT_TO_TAILWIND[style.fontWeight]
+    if (weight) {
+      classes.push(addDevicePrefix(`font-${weight}`, deviceId))
+    }
+  }
+
+  if (style.lineHeight) {
+    const lh = LINE_HEIGHT_TO_TAILWIND[style.lineHeight]
+    if (lh) {
+      classes.push(addDevicePrefix(`leading-${lh}`, deviceId))
+    }
+  }
+
+  return classes
+}
+
+function extractTextContent(richText: MakeswiftRichTextV2): { text: string; classes: string[] } {
+  const classes: string[] = []
+  let text = ''
+
+  for (const descendant of richText.descendants) {
+    if (descendant.textAlign) {
+      for (const { deviceId, value } of descendant.textAlign) {
+        classes.push(addDevicePrefix(`text-${value}`, deviceId))
+      }
+    }
+
+    for (const child of descendant.children) {
+      text += child.text
+
+      if (child.typography?.style) {
+        for (const { deviceId, value } of child.typography.style) {
+          classes.push(...processTypography(value, deviceId))
+        }
+      }
+    }
+  }
+
+  return { text, classes }
+}
+
+function processColumns(columns: MakeswiftDeviceValue<{ spans: number[][]; count: number }>[]): {
+  isGrid: boolean
+  gridClasses: string[]
+  childWidths: Map<number, string[]>
+} {
+  const gridClasses: string[] = []
+  const childWidths = new Map<number, string[]>()
+  let isGrid = false
+
+  for (const { deviceId, value } of columns) {
+    const { spans, count } = value
+
+    if (spans.length > 0 && spans[0].length > 1) {
+      isGrid = true
+      gridClasses.push(addDevicePrefix('grid', deviceId))
+      gridClasses.push(addDevicePrefix(`grid-cols-${count}`, deviceId))
+
+      let childIndex = 0
+      for (const row of spans) {
+        for (const span of row) {
+          if (!childWidths.has(childIndex)) {
+            childWidths.set(childIndex, [])
+          }
+          if (span !== count) {
+            childWidths.get(childIndex)!.push(addDevicePrefix(`col-span-${span}`, deviceId))
+          }
+          childIndex++
+        }
+      }
+    }
+  }
+
+  return { isGrid, gridClasses, childWidths }
+}
+
+function elementToJSX(
+  element: MakeswiftElement,
+  options: Required<RuntimeToJSXOptions>,
+  depth: number = 0,
+  colSpanClasses: string[] = [],
+): { jsx: string; warnings: string[] } {
+  const indent = options.indent.repeat(depth)
+  const warnings: string[] = []
+
+  const tagName = COMPONENT_TO_TAG[element.type] || 'div'
+  const props = element.props
+
+  const classes: string[] = [...colSpanClasses]
+
+  if (props.padding) {
+    classes.push(...processPadding(props.padding))
+  }
+
+  if (props.margin) {
+    classes.push(...processMargin(props.margin))
+  }
+
+  if (props.width) {
+    classes.push(...processWidth(props.width))
+  }
+
+  if (props.rowGap) {
+    classes.push(...processGap(props.rowGap, 'gap-y'))
+  }
+
+  if (props.columnGap) {
+    classes.push(...processGap(props.columnGap, 'gap-x'))
+  }
+
+  if (props.textStyle) {
+    for (const { deviceId, value } of props.textStyle) {
+      classes.push(...processTypography(value, deviceId))
+    }
+  }
+
+  let textContent = ''
+  if (props.text && typeof props.text === 'object' && props.text.type === 'makeswift::controls::rich-text-v2') {
+    const { text, classes: textClasses } = extractTextContent(props.text)
+    textContent = text
+    classes.push(...textClasses)
+  }
+
+  if (typeof props.children === 'string') {
+    textContent = props.children
+  }
+
+  const attrs: string[] = []
+
+  if (classes.length > 0) {
+    const uniqueClasses = [...new Set(classes)]
+    attrs.push(`className="${uniqueClasses.join(' ')}"`)
+  }
+
+  if (props.image && tagName === 'img') {
+    attrs.push(`src="${props.image}"`)
+    if (props.alt) {
+      attrs.push(`alt="${props.alt}"`)
+    }
+  }
+
+  if (props.link && props.link.payload?.url) {
+    attrs.push(`href="${props.link.payload.url}"`)
+    if (props.link.payload.openInNewTab) {
+      attrs.push('target="_blank"')
+    }
+  }
+
+  if (options.includeKeys) {
+    attrs.push(`data-key="${element.key}"`)
+  }
+
+  const attrString = attrs.length > 0 ? ' ' + attrs.join(' ') : ''
+
+  if (tagName === 'img') {
+    return { jsx: `${indent}<${tagName}${attrString} />`, warnings }
+  }
+
+  const children = props.children as MakeswiftChildren | undefined
+  const hasChildren = children && typeof children === 'object' && children.elements && children.elements.length > 0
+
+  if (!hasChildren && textContent) {
+    return { jsx: `${indent}<${tagName}${attrString}>${textContent}</${tagName}>`, warnings }
+  }
+
+  if (!hasChildren && !textContent) {
+    return { jsx: `${indent}<${tagName}${attrString} />`, warnings }
+  }
+
+  const childrenJSX: string[] = []
+
+  if (hasChildren && children.columns) {
+    const { isGrid, gridClasses, childWidths } = processColumns(children.columns)
+
+    if (isGrid && gridClasses.length > 0) {
+      const existingClassIndex = attrs.findIndex(a => a.startsWith('className='))
+      if (existingClassIndex >= 0) {
+        const existingClasses = attrs[existingClassIndex].match(/className="(.*)"/)?.[1] || ''
+        attrs[existingClassIndex] = `className="${existingClasses} ${gridClasses.join(' ')}"`
+      } else {
+        attrs.push(`className="${gridClasses.join(' ')}"`)
+      }
+    }
+
+    for (let i = 0; i < children.elements.length; i++) {
+      const childElement = children.elements[i]
+      const childColSpan = childWidths.get(i) || []
+      const childResult = elementToJSX(childElement, options, depth + 1, childColSpan)
+      childrenJSX.push(childResult.jsx)
+      warnings.push(...childResult.warnings)
+    }
+  } else if (hasChildren) {
+    for (const childElement of children.elements) {
+      const childResult = elementToJSX(childElement, options, depth + 1)
+      childrenJSX.push(childResult.jsx)
+      warnings.push(...childResult.warnings)
+    }
+  }
+
+  const finalAttrString = attrs.length > 0 ? ' ' + attrs.join(' ') : ''
+
+  const jsx = [
+    `${indent}<${tagName}${finalAttrString}>`,
+    ...childrenJSX,
+    `${indent}</${tagName}>`,
+  ].join('\n')
+
+  return { jsx, warnings }
+}
+
+function isMakeswiftRuntimeSchema(input: unknown): input is MakeswiftRuntimeSchema {
+  if (!input || typeof input !== 'object') return false
+  const obj = input as Record<string, unknown>
+  return (
+    typeof obj.key === 'string' &&
+    typeof obj.type === 'string' &&
+    typeof obj.props === 'object' &&
+    obj.props !== null
+  )
+}
+
+/**
+ * Transforms a Makeswift runtime schema to JSX with Tailwind classes.
+ *
+ * This handles the actual Makeswift page data format (with component paths
+ * like "./components/Box/index.js" and nested props structure).
+ *
+ * @param input - Makeswift runtime schema object or JSON string
+ * @param options - Optional configuration
+ * @returns RuntimeToJSXResult containing JSX and warnings
+ *
+ * @example
+ * ```typescript
+ * import { transformRuntimeToJSX } from '@makeswift/jsx-to-makeswift'
+ *
+ * const schema = {
+ *   key: "abc123",
+ *   type: "./components/Box/index.js",
+ *   props: {
+ *     padding: [{ deviceId: "desktop", value: { paddingTop: { value: 20, unit: "px" }, ... } }],
+ *     children: { elements: [...] }
+ *   }
+ * }
+ *
+ * const result = transformRuntimeToJSX(schema)
+ * console.log(result.jsx)
+ * ```
+ */
+export function transformRuntimeToJSX(
+  input: MakeswiftRuntimeSchema | string,
+  options: Partial<RuntimeToJSXOptions> = {},
+): RuntimeToJSXResult {
+  const opts: Required<RuntimeToJSXOptions> = { ...DEFAULT_OPTIONS, ...options }
+
+  try {
+    const schema: MakeswiftRuntimeSchema = typeof input === 'string' ? JSON.parse(input) : input
+
+    if (!isMakeswiftRuntimeSchema(schema)) {
+      return {
+        jsx: '',
+        warnings: ['Invalid Makeswift runtime schema format'],
+      }
+    }
+
+    return elementToJSX(schema, opts, 0)
+  } catch (error) {
+    return {
+      jsx: '',
+      warnings: [error instanceof Error ? error.message : String(error)],
+    }
+  }
+}
+
+/**
+ * Checks if an object looks like a Makeswift runtime schema.
+ */
+export { isMakeswiftRuntimeSchema }

--- a/packages/jsx-to-makeswift/src/makeswift-runtime/runtime-to-jsx.ts
+++ b/packages/jsx-to-makeswift/src/makeswift-runtime/runtime-to-jsx.ts
@@ -5,6 +5,7 @@
  * to JSX source code with Tailwind CSS classes.
  */
 
+import { addDevicePrefix } from '../utils/device-prefixes'
 import type {
   MakeswiftChildren,
   MakeswiftDeviceValue,
@@ -125,23 +126,12 @@ const LINE_HEIGHT_TO_TAILWIND: Record<number, string> = {
   2: 'loose',
 }
 
-const DEVICE_TO_PREFIX: Record<string, string> = {
-  mobile: '',
-  tablet: 'sm:',
-  desktop: 'lg:',
-}
-
 function pxToSpacingClass(px: number, prefix: string): string {
   const scale = SPACING_PX_TO_TAILWIND[px]
   if (scale) {
     return `${prefix}${scale}`
   }
   return `${prefix}[${px}px]`
-}
-
-function addDevicePrefix(cls: string, deviceId: string): string {
-  const prefix = DEVICE_TO_PREFIX[deviceId] || ''
-  return `${prefix}${cls}`
 }
 
 function processPadding(

--- a/packages/jsx-to-makeswift/src/makeswift-runtime/types.ts
+++ b/packages/jsx-to-makeswift/src/makeswift-runtime/types.ts
@@ -1,0 +1,105 @@
+/**
+ * @fileoverview Types for Makeswift runtime schema format.
+ *
+ * This module defines the types for the actual Makeswift page data structure,
+ * which is different from the ElementSchema format used by transformJSX.
+ */
+
+export type MakeswiftDeviceValue<T> = {
+  deviceId: 'desktop' | 'mobile' | 'tablet'
+  value: T
+}
+
+export type MakeswiftSizeValue = {
+  value: number
+  unit: 'px' | '%' | 'em' | 'rem' | 'vw' | 'vh'
+}
+
+export type MakeswiftPaddingValue = {
+  paddingTop?: MakeswiftSizeValue | number
+  paddingRight?: MakeswiftSizeValue | number
+  paddingBottom?: MakeswiftSizeValue | number
+  paddingLeft?: MakeswiftSizeValue | number
+}
+
+export type MakeswiftMarginValue = {
+  marginTop?: MakeswiftSizeValue | 'auto' | number
+  marginRight?: MakeswiftSizeValue | 'auto' | number
+  marginBottom?: MakeswiftSizeValue | 'auto' | number
+  marginLeft?: MakeswiftSizeValue | 'auto' | number
+}
+
+export type MakeswiftTypographyStyle = {
+  fontFamily?: string | null
+  fontSize?: MakeswiftSizeValue
+  fontWeight?: number
+  lineHeight?: number
+  letterSpacing?: MakeswiftSizeValue | null
+  textTransform?: string[]
+  fontStyle?: string[]
+}
+
+export type MakeswiftTextNode = {
+  text: string
+  typography?: {
+    style: MakeswiftDeviceValue<MakeswiftTypographyStyle>[]
+  }
+}
+
+export type MakeswiftTextDescendant = {
+  type: 'default' | string
+  children: MakeswiftTextNode[]
+  textAlign?: MakeswiftDeviceValue<string>[]
+}
+
+export type MakeswiftRichTextV2 = {
+  type: 'makeswift::controls::rich-text-v2'
+  version: 2
+  descendants: MakeswiftTextDescendant[]
+  key: string
+}
+
+export type MakeswiftLink = {
+  type: 'OPEN_URL' | 'OPEN_PAGE' | string
+  payload: {
+    url?: string
+    openInNewTab?: boolean
+    pageId?: string
+  }
+}
+
+export type MakeswiftColumns = {
+  spans: number[][]
+  count: number
+}
+
+export type MakeswiftChildren = {
+  elements: MakeswiftElement[]
+  columns?: MakeswiftDeviceValue<MakeswiftColumns>[]
+}
+
+export type MakeswiftElementProps = {
+  padding?: MakeswiftDeviceValue<MakeswiftPaddingValue>[]
+  margin?: MakeswiftDeviceValue<MakeswiftMarginValue>[]
+  width?: MakeswiftDeviceValue<MakeswiftSizeValue>[]
+  height?: MakeswiftDeviceValue<MakeswiftSizeValue>[]
+  rowGap?: MakeswiftDeviceValue<MakeswiftSizeValue>[]
+  columnGap?: MakeswiftDeviceValue<MakeswiftSizeValue>[]
+  children?: MakeswiftChildren | string
+  text?: MakeswiftRichTextV2
+  image?: string
+  alt?: string
+  link?: MakeswiftLink
+  variant?: MakeswiftDeviceValue<string>[]
+  shape?: MakeswiftDeviceValue<string>[]
+  textStyle?: MakeswiftDeviceValue<MakeswiftTypographyStyle>[]
+  [key: string]: unknown
+}
+
+export type MakeswiftElement = {
+  key: string
+  type: string
+  props: MakeswiftElementProps
+}
+
+export type MakeswiftRuntimeSchema = MakeswiftElement

--- a/packages/jsx-to-makeswift/src/parser/index.ts
+++ b/packages/jsx-to-makeswift/src/parser/index.ts
@@ -1,0 +1,2 @@
+export * from './jsx-parser'
+export * from './types'

--- a/packages/jsx-to-makeswift/src/parser/jsx-parser.ts
+++ b/packages/jsx-to-makeswift/src/parser/jsx-parser.ts
@@ -1,0 +1,232 @@
+import { parse } from '@babel/parser'
+import traverse from '@babel/traverse'
+import * as t from '@babel/types'
+
+import type { ParsedJSXElement } from '../types'
+
+import type { ParseResult, ParserOptions } from './types'
+
+const DEFAULT_OPTIONS: ParserOptions = {
+  sourceType: 'module',
+  plugins: ['jsx', 'typescript'],
+}
+
+type ExtractClassNameResult = {
+  className: string | null
+  isDynamic: boolean
+}
+
+function extractClassName(
+  node: t.JSXAttribute | undefined,
+): ExtractClassNameResult {
+  if (!node || !node.value) {
+    return { className: null, isDynamic: false }
+  }
+
+  if (t.isStringLiteral(node.value)) {
+    return { className: node.value.value, isDynamic: false }
+  }
+
+  if (t.isJSXExpressionContainer(node.value)) {
+    const expression = node.value.expression
+
+    if (t.isStringLiteral(expression)) {
+      return { className: expression.value, isDynamic: false }
+    }
+
+    if (t.isTemplateLiteral(expression) && expression.quasis.length === 1) {
+      return {
+        className: expression.quasis[0].value.raw,
+        isDynamic: false,
+      }
+    }
+
+    return { className: null, isDynamic: true }
+  }
+
+  return { className: null, isDynamic: false }
+}
+
+type ExtractAttributesResult = {
+  attributes: Record<string, unknown>
+  className: string | null
+}
+
+function extractAttributes(
+  attributes: (t.JSXAttribute | t.JSXSpreadAttribute)[],
+): ExtractAttributesResult {
+  const result: Record<string, unknown> = {}
+  let className: string | null = null
+
+  for (const attr of attributes) {
+    if (t.isJSXSpreadAttribute(attr)) {
+      continue
+    }
+
+    const name = t.isJSXIdentifier(attr.name)
+      ? attr.name.name
+      : t.isJSXNamespacedName(attr.name)
+        ? `${attr.name.namespace.name}:${attr.name.name.name}`
+        : null
+
+    if (!name) continue
+
+    if (name === 'className' || name === 'class') {
+      const extracted = extractClassName(attr)
+      className = extracted.className
+      continue
+    }
+
+    if (!attr.value) {
+      result[name] = true
+      continue
+    }
+
+    if (t.isStringLiteral(attr.value)) {
+      result[name] = attr.value.value
+    } else if (t.isJSXExpressionContainer(attr.value)) {
+      const expr = attr.value.expression
+
+      if (t.isStringLiteral(expr)) {
+        result[name] = expr.value
+      } else if (t.isNumericLiteral(expr)) {
+        result[name] = expr.value
+      } else if (t.isBooleanLiteral(expr)) {
+        result[name] = expr.value
+      } else if (t.isNullLiteral(expr)) {
+        result[name] = null
+      } else {
+        result[name] = '[dynamic]'
+      }
+    }
+  }
+
+  return { attributes: result, className }
+}
+
+type TextExtractionResult = {
+  textContent: string | null
+  hasRichContent: boolean
+}
+
+function extractTextContent(
+  children: t.Node[],
+): TextExtractionResult {
+  const textParts: string[] = []
+  let hasRichContent = false
+
+  for (const child of children) {
+    if (t.isJSXText(child)) {
+      const trimmed = child.value.trim()
+      if (trimmed) {
+        textParts.push(trimmed)
+      }
+    } else if (t.isJSXExpressionContainer(child)) {
+      if (t.isStringLiteral(child.expression)) {
+        textParts.push(child.expression.value)
+      } else if (!t.isJSXEmptyExpression(child.expression)) {
+        textParts.push('[dynamic]')
+      }
+    } else if (t.isJSXElement(child)) {
+      hasRichContent = true
+      const nested = extractTextContent(child.children)
+      if (nested.textContent) {
+        textParts.push(nested.textContent)
+      }
+    }
+  }
+
+  return {
+    textContent: textParts.length > 0 ? textParts.join(' ') : null,
+    hasRichContent,
+  }
+}
+
+function processJSXElement(node: t.JSXElement): ParsedJSXElement {
+  const opening = node.openingElement
+  const tagName = t.isJSXIdentifier(opening.name)
+    ? opening.name.name
+    : t.isJSXMemberExpression(opening.name)
+      ? `${getMemberExpressionName(opening.name)}`
+      : 'unknown'
+
+  const { attributes, className } = extractAttributes(opening.attributes)
+  const { textContent, hasRichContent } = extractTextContent(node.children)
+
+  const children: ParsedJSXElement[] = []
+  for (const child of node.children) {
+    if (t.isJSXElement(child)) {
+      children.push(processJSXElement(child))
+    }
+  }
+
+  return {
+    tagName,
+    className,
+    attributes,
+    textContent,
+    children,
+    hasRichContent,
+  }
+}
+
+function getMemberExpressionName(node: t.JSXMemberExpression): string {
+  const parts: string[] = []
+
+  let current: t.JSXMemberExpression | t.JSXIdentifier = node
+
+  while (t.isJSXMemberExpression(current)) {
+    parts.unshift(current.property.name)
+    current = current.object
+  }
+
+  if (t.isJSXIdentifier(current)) {
+    parts.unshift(current.name)
+  }
+
+  return parts.join('.')
+}
+
+export function parseJSX(
+  source: string,
+  options: ParserOptions = {},
+): ParseResult {
+  const mergedOptions = { ...DEFAULT_OPTIONS, ...options }
+  const elements: ParsedJSXElement[] = []
+  const errors: string[] = []
+
+  try {
+    const ast = parse(source, {
+      sourceType: mergedOptions.sourceType,
+      plugins: mergedOptions.plugins,
+    })
+
+    traverse(ast, {
+      JSXElement(path) {
+        if (!path.parentPath.isJSXElement()) {
+          elements.push(processJSXElement(path.node))
+        }
+      },
+    })
+  } catch (error) {
+    errors.push(
+      error instanceof Error ? error.message : 'Unknown parsing error',
+    )
+  }
+
+  return { elements, errors }
+}
+
+export function parseJSXFragment(source: string): ParseResult {
+  const wrapped = `<>${source}</>`
+  const result = parseJSX(wrapped)
+
+  if (result.elements.length === 1 && result.elements[0].tagName === '') {
+    return {
+      elements: result.elements[0].children,
+      errors: result.errors,
+    }
+  }
+
+  return result
+}

--- a/packages/jsx-to-makeswift/src/parser/jsx-parser.ts
+++ b/packages/jsx-to-makeswift/src/parser/jsx-parser.ts
@@ -219,14 +219,5 @@ export function parseJSX(
 
 export function parseJSXFragment(source: string): ParseResult {
   const wrapped = `<>${source}</>`
-  const result = parseJSX(wrapped)
-
-  if (result.elements.length === 1 && result.elements[0].tagName === '') {
-    return {
-      elements: result.elements[0].children,
-      errors: result.errors,
-    }
-  }
-
-  return result
+  return parseJSX(wrapped)
 }

--- a/packages/jsx-to-makeswift/src/parser/types.ts
+++ b/packages/jsx-to-makeswift/src/parser/types.ts
@@ -1,0 +1,11 @@
+import type { ParsedJSXElement } from '../types'
+
+export type ParserOptions = {
+  sourceType?: 'module' | 'script'
+  plugins?: ('jsx' | 'typescript')[]
+}
+
+export type ParseResult = {
+  elements: ParsedJSXElement[]
+  errors: string[]
+}

--- a/packages/jsx-to-makeswift/src/reverse/index.ts
+++ b/packages/jsx-to-makeswift/src/reverse/index.ts
@@ -1,0 +1,3 @@
+export * from './schema-to-jsx'
+export * from './reverse-mapper'
+export * from './types'

--- a/packages/jsx-to-makeswift/src/reverse/reverse-mapper.ts
+++ b/packages/jsx-to-makeswift/src/reverse/reverse-mapper.ts
@@ -6,18 +6,13 @@
  */
 
 import type { DeviceId } from '../types'
+import { addDevicePrefix } from '../utils/device-prefixes'
 
 type TailwindClass = string
 
 type ReverseMapResult = {
   classes: TailwindClass[]
   unmapped: string[]
-}
-
-const DEVICE_TO_PREFIX: Record<DeviceId, string> = {
-  mobile: '',
-  tablet: 'sm:',
-  desktop: 'lg:',
 }
 
 const SPACING_SCALE: Record<string, string> = {
@@ -560,13 +555,10 @@ export function addResponsivePrefix(
   cls: TailwindClass,
   deviceId: DeviceId,
 ): TailwindClass {
-  const prefix = DEVICE_TO_PREFIX[deviceId]
-  return `${prefix}${cls}`
+  return addDevicePrefix(cls, deviceId)
 }
 
 /**
  * Gets the responsive prefix for a device ID.
  */
-export function getResponsivePrefix(deviceId: DeviceId): string {
-  return DEVICE_TO_PREFIX[deviceId]
-}
+export { DEVICE_TO_PREFIX, getDevicePrefix as getResponsivePrefix } from '../utils/device-prefixes'

--- a/packages/jsx-to-makeswift/src/reverse/reverse-mapper.ts
+++ b/packages/jsx-to-makeswift/src/reverse/reverse-mapper.ts
@@ -1,0 +1,572 @@
+/**
+ * @fileoverview Reverse mapping from CSS values to Tailwind classes.
+ *
+ * This module provides functions to convert CSS property values back to
+ * their corresponding Tailwind utility classes.
+ */
+
+import type { DeviceId } from '../types'
+
+type TailwindClass = string
+
+type ReverseMapResult = {
+  classes: TailwindClass[]
+  unmapped: string[]
+}
+
+const DEVICE_TO_PREFIX: Record<DeviceId, string> = {
+  mobile: '',
+  tablet: 'sm:',
+  desktop: 'lg:',
+}
+
+const SPACING_SCALE: Record<string, string> = {
+  '0': '0',
+  '0.25rem': '1',
+  '0.5rem': '2',
+  '0.75rem': '3',
+  '1rem': '4',
+  '1.25rem': '5',
+  '1.5rem': '6',
+  '1.75rem': '7',
+  '2rem': '8',
+  '2.25rem': '9',
+  '2.5rem': '10',
+  '2.75rem': '11',
+  '3rem': '12',
+  '3.5rem': '14',
+  '4rem': '16',
+  '5rem': '20',
+  '6rem': '24',
+  '7rem': '28',
+  '8rem': '32',
+  '9rem': '36',
+  '10rem': '40',
+  '11rem': '44',
+  '12rem': '48',
+  '13rem': '52',
+  '14rem': '56',
+  '15rem': '60',
+  '16rem': '64',
+  '18rem': '72',
+  '20rem': '80',
+  '24rem': '96',
+  'auto': 'auto',
+}
+
+const FONT_SIZE_SCALE: Record<string, string> = {
+  '0.75rem': 'xs',
+  '0.875rem': 'sm',
+  '1rem': 'base',
+  '1.125rem': 'lg',
+  '1.25rem': 'xl',
+  '1.5rem': '2xl',
+  '1.875rem': '3xl',
+  '2.25rem': '4xl',
+  '3rem': '5xl',
+  '3.75rem': '6xl',
+  '4.5rem': '7xl',
+  '6rem': '8xl',
+  '8rem': '9xl',
+}
+
+const FONT_WEIGHT_SCALE: Record<number, string> = {
+  100: 'thin',
+  200: 'extralight',
+  300: 'light',
+  400: 'normal',
+  500: 'medium',
+  600: 'semibold',
+  700: 'bold',
+  800: 'extrabold',
+  900: 'black',
+}
+
+const LINE_HEIGHT_SCALE: Record<string, string> = {
+  '1': 'none',
+  '1.25': 'tight',
+  '1.375': 'snug',
+  '1.5': 'normal',
+  '1.625': 'relaxed',
+  '2': 'loose',
+}
+
+const BORDER_RADIUS_SCALE: Record<string, string> = {
+  '0': 'none',
+  '0.125rem': 'sm',
+  '0.25rem': 'DEFAULT',
+  '0.375rem': 'md',
+  '0.5rem': 'lg',
+  '0.75rem': 'xl',
+  '1rem': '2xl',
+  '1.5rem': '3xl',
+  '9999px': 'full',
+}
+
+const WIDTH_SCALE: Record<string, string> = {
+  '0': '0',
+  'auto': 'auto',
+  '100%': 'full',
+  '100vw': 'screen',
+  '50%': '1/2',
+  '33.333333%': '1/3',
+  '66.666667%': '2/3',
+  '25%': '1/4',
+  '75%': '3/4',
+  '20%': '1/5',
+  '40%': '2/5',
+  '60%': '3/5',
+  '80%': '4/5',
+  ...Object.fromEntries(
+    Object.entries(SPACING_SCALE).filter(([k]) => k !== 'auto'),
+  ),
+}
+
+const HEIGHT_SCALE: Record<string, string> = {
+  '0': '0',
+  'auto': 'auto',
+  '100%': 'full',
+  '100vh': 'screen',
+  ...Object.fromEntries(
+    Object.entries(SPACING_SCALE).filter(([k]) => k !== 'auto'),
+  ),
+}
+
+const COLOR_HEX_TO_NAME: Record<string, string> = {
+  '#000000': 'black',
+  '#ffffff': 'white',
+  '#f9fafb': 'gray-50',
+  '#f3f4f6': 'gray-100',
+  '#e5e7eb': 'gray-200',
+  '#d1d5db': 'gray-300',
+  '#9ca3af': 'gray-400',
+  '#6b7280': 'gray-500',
+  '#4b5563': 'gray-600',
+  '#374151': 'gray-700',
+  '#1f2937': 'gray-800',
+  '#111827': 'gray-900',
+  '#fef2f2': 'red-50',
+  '#fee2e2': 'red-100',
+  '#fecaca': 'red-200',
+  '#fca5a5': 'red-300',
+  '#f87171': 'red-400',
+  '#ef4444': 'red-500',
+  '#dc2626': 'red-600',
+  '#b91c1c': 'red-700',
+  '#991b1b': 'red-800',
+  '#7f1d1d': 'red-900',
+  '#eff6ff': 'blue-50',
+  '#dbeafe': 'blue-100',
+  '#bfdbfe': 'blue-200',
+  '#93c5fd': 'blue-300',
+  '#60a5fa': 'blue-400',
+  '#3b82f6': 'blue-500',
+  '#2563eb': 'blue-600',
+  '#1d4ed8': 'blue-700',
+  '#1e40af': 'blue-800',
+  '#1e3a8a': 'blue-900',
+  '#f0fdf4': 'green-50',
+  '#dcfce7': 'green-100',
+  '#bbf7d0': 'green-200',
+  '#86efac': 'green-300',
+  '#4ade80': 'green-400',
+  '#22c55e': 'green-500',
+  '#16a34a': 'green-600',
+  '#15803d': 'green-700',
+  '#166534': 'green-800',
+  '#14532d': 'green-900',
+  '#fefce8': 'yellow-50',
+  '#fef9c3': 'yellow-100',
+  '#fef08a': 'yellow-200',
+  '#fde047': 'yellow-300',
+  '#facc15': 'yellow-400',
+  '#eab308': 'yellow-500',
+  '#ca8a04': 'yellow-600',
+  '#a16207': 'yellow-700',
+  '#854d0e': 'yellow-800',
+  '#713f12': 'yellow-900',
+  '#fdf4ff': 'purple-50',
+  '#fae8ff': 'purple-100',
+  '#f5d0fe': 'purple-200',
+  '#f0abfc': 'purple-300',
+  '#e879f9': 'purple-400',
+  '#d946ef': 'purple-500',
+  '#c026d3': 'purple-600',
+  '#a21caf': 'purple-700',
+  '#86198f': 'purple-800',
+  '#701a75': 'purple-900',
+  '#fff7ed': 'orange-50',
+  '#ffedd5': 'orange-100',
+  '#fed7aa': 'orange-200',
+  '#fdba74': 'orange-300',
+  '#fb923c': 'orange-400',
+  '#f97316': 'orange-500',
+  '#ea580c': 'orange-600',
+  '#c2410c': 'orange-700',
+  '#9a3412': 'orange-800',
+  '#7c2d12': 'orange-900',
+}
+
+const DISPLAY_VALUES: Record<string, string> = {
+  block: 'block',
+  'inline-block': 'inline-block',
+  inline: 'inline',
+  flex: 'flex',
+  'inline-flex': 'inline-flex',
+  grid: 'grid',
+  'inline-grid': 'inline-grid',
+  none: 'hidden',
+}
+
+const FLEX_DIRECTION_VALUES: Record<string, string> = {
+  row: 'flex-row',
+  'row-reverse': 'flex-row-reverse',
+  column: 'flex-col',
+  'column-reverse': 'flex-col-reverse',
+}
+
+const JUSTIFY_CONTENT_VALUES: Record<string, string> = {
+  'flex-start': 'justify-start',
+  'flex-end': 'justify-end',
+  center: 'justify-center',
+  'space-between': 'justify-between',
+  'space-around': 'justify-around',
+  'space-evenly': 'justify-evenly',
+}
+
+const ALIGN_ITEMS_VALUES: Record<string, string> = {
+  'flex-start': 'items-start',
+  'flex-end': 'items-end',
+  center: 'items-center',
+  baseline: 'items-baseline',
+  stretch: 'items-stretch',
+}
+
+const POSITION_VALUES: Record<string, string> = {
+  static: 'static',
+  fixed: 'fixed',
+  absolute: 'absolute',
+  relative: 'relative',
+  sticky: 'sticky',
+}
+
+const TEXT_ALIGN_VALUES: Record<string, string> = {
+  left: 'text-left',
+  center: 'text-center',
+  right: 'text-right',
+  justify: 'text-justify',
+}
+
+function createArbitraryClass(prefix: string, value: string): string {
+  const cleanPrefix = prefix.endsWith('-') ? prefix.slice(0, -1) : prefix
+  return `${cleanPrefix}-[${value}]`
+}
+
+function mapSpacingValue(
+  value: string,
+  prefix: string,
+): TailwindClass | null {
+  const scale = SPACING_SCALE[value]
+  if (scale) {
+    return `${prefix}${scale}`
+  }
+  return createArbitraryClass(prefix, value)
+}
+
+function mapMargin(
+  styles: Record<string, string | number>,
+): ReverseMapResult {
+  const classes: TailwindClass[] = []
+  const unmapped: string[] = []
+
+  const margin = styles.margin?.toString()
+  const mt = styles.marginTop?.toString()
+  const mr = styles.marginRight?.toString()
+  const mb = styles.marginBottom?.toString()
+  const ml = styles.marginLeft?.toString()
+
+  if (margin) {
+    const cls = mapSpacingValue(margin, 'm-')
+    if (cls) classes.push(cls)
+  } else {
+    if (mt) {
+      const cls = mapSpacingValue(mt, 'mt-')
+      if (cls) classes.push(cls)
+    }
+    if (mr) {
+      const cls = mapSpacingValue(mr, 'mr-')
+      if (cls) classes.push(cls)
+    }
+    if (mb) {
+      const cls = mapSpacingValue(mb, 'mb-')
+      if (cls) classes.push(cls)
+    }
+    if (ml) {
+      const cls = mapSpacingValue(ml, 'ml-')
+      if (cls) classes.push(cls)
+    }
+  }
+
+  return { classes, unmapped }
+}
+
+function mapPadding(
+  styles: Record<string, string | number>,
+): ReverseMapResult {
+  const classes: TailwindClass[] = []
+  const unmapped: string[] = []
+
+  const padding = styles.padding?.toString()
+  const pt = styles.paddingTop?.toString()
+  const pr = styles.paddingRight?.toString()
+  const pb = styles.paddingBottom?.toString()
+  const pl = styles.paddingLeft?.toString()
+
+  if (padding) {
+    const cls = mapSpacingValue(padding, 'p-')
+    if (cls) classes.push(cls)
+  } else {
+    if (pt) {
+      const cls = mapSpacingValue(pt, 'pt-')
+      if (cls) classes.push(cls)
+    }
+    if (pr) {
+      const cls = mapSpacingValue(pr, 'pr-')
+      if (cls) classes.push(cls)
+    }
+    if (pb) {
+      const cls = mapSpacingValue(pb, 'pb-')
+      if (cls) classes.push(cls)
+    }
+    if (pl) {
+      const cls = mapSpacingValue(pl, 'pl-')
+      if (cls) classes.push(cls)
+    }
+  }
+
+  return { classes, unmapped }
+}
+
+function mapWidth(value: string): TailwindClass | null {
+  const scale = WIDTH_SCALE[value]
+  if (scale) {
+    return scale === '0' ? 'w-0' : `w-${scale}`
+  }
+  return createArbitraryClass('w', value)
+}
+
+function mapHeight(value: string): TailwindClass | null {
+  const scale = HEIGHT_SCALE[value]
+  if (scale) {
+    return scale === '0' ? 'h-0' : `h-${scale}`
+  }
+  return createArbitraryClass('h', value)
+}
+
+function mapGap(value: string): TailwindClass | null {
+  const scale = SPACING_SCALE[value]
+  if (scale) {
+    return `gap-${scale}`
+  }
+  return createArbitraryClass('gap', value)
+}
+
+function mapBorderRadius(value: string): TailwindClass | null {
+  const scale = BORDER_RADIUS_SCALE[value]
+  if (scale) {
+    return scale === 'DEFAULT' ? 'rounded' : `rounded-${scale}`
+  }
+  return createArbitraryClass('rounded', value)
+}
+
+function mapColor(
+  hex: string,
+  property: 'textColor' | 'backgroundColor' | 'borderColor',
+): TailwindClass | null {
+  const colorName = COLOR_HEX_TO_NAME[hex.toLowerCase()]
+  const prefix =
+    property === 'textColor'
+      ? 'text'
+      : property === 'backgroundColor'
+        ? 'bg'
+        : 'border'
+
+  if (colorName) {
+    return `${prefix}-${colorName}`
+  }
+  return createArbitraryClass(prefix, hex)
+}
+
+function mapFontSize(value: string): TailwindClass | null {
+  const scale = FONT_SIZE_SCALE[value]
+  if (scale) {
+    return `text-${scale}`
+  }
+  return createArbitraryClass('text', value)
+}
+
+function mapFontWeight(value: number): TailwindClass | null {
+  const scale = FONT_WEIGHT_SCALE[value]
+  if (scale) {
+    return `font-${scale}`
+  }
+  return createArbitraryClass('font', value.toString())
+}
+
+function mapLineHeight(value: string): TailwindClass | null {
+  const scale = LINE_HEIGHT_SCALE[value]
+  if (scale) {
+    return `leading-${scale}`
+  }
+  return createArbitraryClass('leading', value)
+}
+
+/**
+ * Maps a Style control value to Tailwind classes.
+ */
+export function mapStyleToClasses(
+  styles: Record<string, string | number>,
+): ReverseMapResult {
+  const classes: TailwindClass[] = []
+  const unmapped: string[] = []
+
+  const marginResult = mapMargin(styles)
+  classes.push(...marginResult.classes)
+  unmapped.push(...marginResult.unmapped)
+
+  const paddingResult = mapPadding(styles)
+  classes.push(...paddingResult.classes)
+  unmapped.push(...paddingResult.unmapped)
+
+  if (styles.width) {
+    const cls = mapWidth(styles.width.toString())
+    if (cls) classes.push(cls)
+  }
+
+  if (styles.height) {
+    const cls = mapHeight(styles.height.toString())
+    if (cls) classes.push(cls)
+  }
+
+  if (styles.gap) {
+    const cls = mapGap(styles.gap.toString())
+    if (cls) classes.push(cls)
+  }
+
+  if (styles.borderRadius) {
+    const cls = mapBorderRadius(styles.borderRadius.toString())
+    if (cls) classes.push(cls)
+  }
+
+  if (styles.display) {
+    const cls = DISPLAY_VALUES[styles.display.toString()]
+    if (cls) classes.push(cls)
+  }
+
+  if (styles.flexDirection) {
+    const cls = FLEX_DIRECTION_VALUES[styles.flexDirection.toString()]
+    if (cls) classes.push(cls)
+  }
+
+  if (styles.justifyContent) {
+    const cls = JUSTIFY_CONTENT_VALUES[styles.justifyContent.toString()]
+    if (cls) classes.push(cls)
+  }
+
+  if (styles.alignItems) {
+    const cls = ALIGN_ITEMS_VALUES[styles.alignItems.toString()]
+    if (cls) classes.push(cls)
+  }
+
+  if (styles.position) {
+    const cls = POSITION_VALUES[styles.position.toString()]
+    if (cls) classes.push(cls)
+  }
+
+  return { classes, unmapped }
+}
+
+/**
+ * Maps a Color control value to a Tailwind class.
+ */
+export function mapColorToClass(
+  color: string,
+  property: 'textColor' | 'backgroundColor' | 'borderColor',
+): TailwindClass | null {
+  return mapColor(color, property)
+}
+
+/**
+ * Maps a Typography control value to Tailwind classes.
+ */
+export function mapTypographyToClasses(typography: {
+  fontSize?: string
+  fontWeight?: number
+  lineHeight?: string
+  textAlign?: string
+  fontStyle?: string
+  textDecoration?: string
+  textTransform?: string
+  letterSpacing?: string
+}): ReverseMapResult {
+  const classes: TailwindClass[] = []
+  const unmapped: string[] = []
+
+  if (typography.fontSize) {
+    const cls = mapFontSize(typography.fontSize)
+    if (cls) classes.push(cls)
+  }
+
+  if (typography.fontWeight) {
+    const cls = mapFontWeight(typography.fontWeight)
+    if (cls) classes.push(cls)
+  }
+
+  if (typography.lineHeight) {
+    const cls = mapLineHeight(typography.lineHeight)
+    if (cls) classes.push(cls)
+  }
+
+  if (typography.textAlign) {
+    const cls = TEXT_ALIGN_VALUES[typography.textAlign]
+    if (cls) classes.push(cls)
+  }
+
+  if (typography.fontStyle === 'italic') {
+    classes.push('italic')
+  }
+
+  if (typography.textDecoration === 'underline') {
+    classes.push('underline')
+  } else if (typography.textDecoration === 'line-through') {
+    classes.push('line-through')
+  }
+
+  if (typography.textTransform === 'uppercase') {
+    classes.push('uppercase')
+  } else if (typography.textTransform === 'lowercase') {
+    classes.push('lowercase')
+  } else if (typography.textTransform === 'capitalize') {
+    classes.push('capitalize')
+  }
+
+  return { classes, unmapped }
+}
+
+/**
+ * Adds a responsive prefix to a class based on device ID.
+ */
+export function addResponsivePrefix(
+  cls: TailwindClass,
+  deviceId: DeviceId,
+): TailwindClass {
+  const prefix = DEVICE_TO_PREFIX[deviceId]
+  return `${prefix}${cls}`
+}
+
+/**
+ * Gets the responsive prefix for a device ID.
+ */
+export function getResponsivePrefix(deviceId: DeviceId): string {
+  return DEVICE_TO_PREFIX[deviceId]
+}

--- a/packages/jsx-to-makeswift/src/reverse/schema-to-jsx.ts
+++ b/packages/jsx-to-makeswift/src/reverse/schema-to-jsx.ts
@@ -1,0 +1,447 @@
+/**
+ * @fileoverview Transforms Makeswift control schemas back to JSX with Tailwind.
+ *
+ * This module provides functions to convert ElementSchema objects back into
+ * JSX source code with Tailwind CSS classes.
+ */
+
+import type {
+  ColorControlValue,
+  ControlValue,
+  ElementSchema,
+  SlotControlValue,
+  StyleControlValue,
+  TypographyControlValue,
+} from '../types'
+import {
+  addResponsivePrefix,
+  mapColorToClass,
+  mapStyleToClasses,
+  mapTypographyToClasses,
+} from './reverse-mapper'
+import type {
+  ReverseTransformInput,
+  ReverseTransformOptions,
+  ReverseTransformResult,
+} from './types'
+
+const DEFAULT_OPTIONS: Required<ReverseTransformOptions> = {
+  preferShorthand: true,
+  alwaysIncludeBreakpoints: false,
+  indent: '  ',
+  selfClosingTags: true,
+}
+
+const ELEMENT_TYPE_TO_TAG: Record<string, string> = {
+  Container: 'div',
+  Heading: 'h1',
+  Paragraph: 'p',
+  Text: 'span',
+  Button: 'button',
+  Link: 'a',
+  Image: 'img',
+  Nav: 'nav',
+  Header: 'header',
+  Footer: 'footer',
+  Section: 'section',
+  Article: 'article',
+}
+
+const SELF_CLOSING_TAGS = new Set(['img', 'input', 'br', 'hr', 'meta', 'link'])
+
+type ClassCollector = {
+  classes: string[]
+  unmapped: string[]
+}
+
+function parseInput(input: ReverseTransformInput): ElementSchema[] {
+  if (typeof input === 'string') {
+    const parsed = JSON.parse(input)
+    return Array.isArray(parsed) ? parsed : [parsed]
+  }
+  return Array.isArray(input) ? input : [input]
+}
+
+function collectClassesFromStyle(
+  control: StyleControlValue,
+  collector: ClassCollector,
+): void {
+  for (const deviceValue of control.value) {
+    const { deviceId, value } = deviceValue
+    const result = mapStyleToClasses(value)
+
+    for (const cls of result.classes) {
+      const prefixedClass = addResponsivePrefix(cls, deviceId)
+      collector.classes.push(prefixedClass)
+    }
+    collector.unmapped.push(...result.unmapped)
+  }
+}
+
+function collectClassesFromColor(
+  control: ColorControlValue,
+  collector: ClassCollector,
+): void {
+  for (const deviceValue of control.value) {
+    const { deviceId, value } = deviceValue
+    const cls = mapColorToClass(value.color, control.property)
+
+    if (cls) {
+      const prefixedClass = addResponsivePrefix(cls, deviceId)
+      collector.classes.push(prefixedClass)
+    }
+  }
+}
+
+function collectClassesFromTypography(
+  control: TypographyControlValue,
+  collector: ClassCollector,
+): void {
+  for (const deviceValue of control.value) {
+    const { deviceId, value } = deviceValue
+    const result = mapTypographyToClasses(value)
+
+    for (const cls of result.classes) {
+      const prefixedClass = addResponsivePrefix(cls, deviceId)
+      collector.classes.push(prefixedClass)
+    }
+    collector.unmapped.push(...result.unmapped)
+  }
+}
+
+function collectClasses(
+  controls: Record<string, ControlValue>,
+): ClassCollector {
+  const collector: ClassCollector = { classes: [], unmapped: [] }
+
+  for (const [, control] of Object.entries(controls)) {
+    switch (control.type) {
+      case 'Style':
+        collectClassesFromStyle(control, collector)
+        break
+      case 'Color':
+        collectClassesFromColor(control, collector)
+        break
+      case 'Typography':
+        collectClassesFromTypography(control, collector)
+        break
+    }
+  }
+
+  return collector
+}
+
+function deduplicateClasses(classes: string[]): string[] {
+  const seen = new Map<string, string>()
+
+  for (const cls of classes) {
+    const hasPrefix = cls.includes(':')
+    const baseClass = hasPrefix ? cls.split(':').slice(1).join(':') : cls
+    const prefix = hasPrefix ? cls.split(':')[0] + ':' : ''
+    const property = baseClass.split('-')[0]
+    const key = `${prefix}${property}`
+    seen.set(key, cls)
+  }
+
+  return Array.from(seen.values())
+}
+
+function orderClasses(classes: string[]): string[] {
+  const prefixOrder: Record<string, number> = {
+    '': 0,
+    'sm:': 1,
+    'md:': 2,
+    'lg:': 3,
+    'xl:': 4,
+    '2xl:': 5,
+  }
+
+  const categoryOrder: Record<string, number> = {
+    block: 0,
+    inline: 0,
+    flex: 0,
+    grid: 0,
+    hidden: 0,
+    static: 1,
+    fixed: 1,
+    absolute: 1,
+    relative: 1,
+    sticky: 1,
+    m: 2,
+    mt: 2,
+    mr: 2,
+    mb: 2,
+    ml: 2,
+    mx: 2,
+    my: 2,
+    p: 3,
+    pt: 3,
+    pr: 3,
+    pb: 3,
+    pl: 3,
+    px: 3,
+    py: 3,
+    w: 4,
+    h: 4,
+    min: 4,
+    max: 4,
+    gap: 5,
+    bg: 6,
+    text: 7,
+    font: 8,
+    leading: 9,
+    tracking: 9,
+    rounded: 10,
+    border: 11,
+    shadow: 12,
+  }
+
+  return [...classes].sort((a, b) => {
+    const aHasPrefix = a.includes(':')
+    const bHasPrefix = b.includes(':')
+
+    const aPrefix = aHasPrefix ? a.split(':')[0] + ':' : ''
+    const bPrefix = bHasPrefix ? b.split(':')[0] + ':' : ''
+
+    const prefixDiff =
+      (prefixOrder[aPrefix] ?? 99) - (prefixOrder[bPrefix] ?? 99)
+    if (prefixDiff !== 0) return prefixDiff
+
+    const aBase = aHasPrefix ? a.split(':').slice(1).join(':') : a
+    const bBase = bHasPrefix ? b.split(':').slice(1).join(':') : b
+
+    const aCategory = aBase.split('-')[0]
+    const bCategory = bBase.split('-')[0]
+
+    const categoryDiff =
+      (categoryOrder[aCategory] ?? 50) - (categoryOrder[bCategory] ?? 50)
+    if (categoryDiff !== 0) return categoryDiff
+
+    return a.localeCompare(b)
+  })
+}
+
+function getTextContent(controls: Record<string, ControlValue>): string | null {
+  for (const [, control] of Object.entries(controls)) {
+    if (
+      control.type === 'TextInput' ||
+      control.type === 'TextArea' ||
+      control.type === 'RichText'
+    ) {
+      return control.value
+    }
+  }
+  return null
+}
+
+function getImageAttributes(
+  controls: Record<string, ControlValue>,
+): Record<string, string> | null {
+  for (const [, control] of Object.entries(controls)) {
+    if (control.type === 'Image') {
+      const attrs: Record<string, string> = {
+        src: control.value.src,
+      }
+      if (control.value.alt) attrs.alt = control.value.alt
+      if (control.value.width) attrs.width = control.value.width.toString()
+      if (control.value.height) attrs.height = control.value.height.toString()
+      return attrs
+    }
+  }
+  return null
+}
+
+function getLinkAttributes(
+  controls: Record<string, ControlValue>,
+): Record<string, string> | null {
+  for (const [, control] of Object.entries(controls)) {
+    if (control.type === 'Link') {
+      const attrs: Record<string, string> = {
+        href: control.value.href,
+      }
+      if (control.value.target) attrs.target = control.value.target
+      return attrs
+    }
+  }
+  return null
+}
+
+function formatAttributes(attrs: Record<string, string>): string {
+  return Object.entries(attrs)
+    .map(([key, value]) => `${key}="${value}"`)
+    .join(' ')
+}
+
+function schemaToJSX(
+  schema: ElementSchema,
+  options: Required<ReverseTransformOptions>,
+  depth: number = 0,
+): { jsx: string; unmapped: string[] } {
+  const indent = options.indent.repeat(depth)
+  const childIndent = options.indent.repeat(depth + 1)
+
+  const tagName = schema.tagName || ELEMENT_TYPE_TO_TAG[schema.type] || 'div'
+
+  const { classes, unmapped } = collectClasses(schema.controls)
+  const orderedClasses = orderClasses(deduplicateClasses(classes))
+  const className = orderedClasses.join(' ')
+
+  const textContent = getTextContent(schema.controls)
+  const imageAttrs = getImageAttributes(schema.controls)
+  const linkAttrs = getLinkAttributes(schema.controls)
+
+  const attrs: string[] = []
+
+  if (className) {
+    attrs.push(`className="${className}"`)
+  }
+
+  if (imageAttrs) {
+    attrs.push(formatAttributes(imageAttrs))
+  }
+
+  if (linkAttrs) {
+    attrs.push(formatAttributes(linkAttrs))
+  }
+
+  const attrString = attrs.length > 0 ? ' ' + attrs.join(' ') : ''
+
+  const isSelfClosing =
+    options.selfClosingTags && SELF_CLOSING_TAGS.has(tagName)
+
+  if (isSelfClosing) {
+    return {
+      jsx: `${indent}<${tagName}${attrString} />`,
+      unmapped,
+    }
+  }
+
+  const children = schema.children as SlotControlValue | undefined
+  const hasChildren = children && children.elements && children.elements.length > 0
+
+  if (!hasChildren && textContent) {
+    return {
+      jsx: `${indent}<${tagName}${attrString}>${textContent}</${tagName}>`,
+      unmapped,
+    }
+  }
+
+  if (!hasChildren && !textContent) {
+    if (options.selfClosingTags) {
+      return {
+        jsx: `${indent}<${tagName}${attrString} />`,
+        unmapped,
+      }
+    }
+    return {
+      jsx: `${indent}<${tagName}${attrString}></${tagName}>`,
+      unmapped,
+    }
+  }
+
+  const childrenJSX: string[] = []
+  const allUnmapped = [...unmapped]
+
+  if (textContent) {
+    childrenJSX.push(`${childIndent}${textContent}`)
+  }
+
+  if (hasChildren) {
+    for (const child of children.elements) {
+      const childResult = schemaToJSX(child, options, depth + 1)
+      childrenJSX.push(childResult.jsx)
+      allUnmapped.push(...childResult.unmapped)
+    }
+  }
+
+  const jsx = [
+    `${indent}<${tagName}${attrString}>`,
+    ...childrenJSX,
+    `${indent}</${tagName}>`,
+  ].join('\n')
+
+  return { jsx, unmapped: allUnmapped }
+}
+
+/**
+ * Transforms a Makeswift control schema back to JSX with Tailwind classes.
+ *
+ * This is the reverse operation of transformJSX. It takes an ElementSchema
+ * and generates JSX source code with corresponding Tailwind utility classes.
+ *
+ * @param input - Schema object, array of schemas, or JSON string
+ * @param options - Optional configuration for the transformation
+ * @returns ReverseTransformResult containing JSX string, warnings, and unmapped values
+ *
+ * @example
+ * ```typescript
+ * import { transformSchemaToJSX } from '@makeswift/jsx-to-makeswift'
+ *
+ * const schema = {
+ *   type: 'Container',
+ *   tagName: 'div',
+ *   controls: {
+ *     style: {
+ *       type: 'Style',
+ *       properties: ['padding'],
+ *       value: [{ deviceId: 'mobile', value: { padding: '1rem' } }]
+ *     },
+ *     content: { type: 'TextInput', value: 'Hello' }
+ *   }
+ * }
+ *
+ * const result = transformSchemaToJSX(schema)
+ * console.log(result.jsx)
+ * // <div className="p-4">Hello</div>
+ * ```
+ */
+export function transformSchemaToJSX(
+  input: ReverseTransformInput,
+  options: Partial<ReverseTransformOptions> = {},
+): ReverseTransformResult {
+  const opts: Required<ReverseTransformOptions> = {
+    ...DEFAULT_OPTIONS,
+    ...options,
+  }
+
+  try {
+    const schemas = parseInput(input)
+    const results: { jsx: string; unmapped: string[] }[] = []
+
+    for (const schema of schemas) {
+      results.push(schemaToJSX(schema, opts, 0))
+    }
+
+    const jsx = results.map((r) => r.jsx).join('\n\n')
+    const unmappedValues = [...new Set(results.flatMap((r) => r.unmapped))]
+
+    return {
+      jsx,
+      warnings: [],
+      unmappedValues,
+    }
+  } catch (error) {
+    return {
+      jsx: '',
+      warnings: [error instanceof Error ? error.message : String(error)],
+      unmappedValues: [],
+    }
+  }
+}
+
+/**
+ * Transforms a schema to JSX and returns just the JSX string.
+ *
+ * This is a convenience function for simple use cases where you
+ * don't need warnings or unmapped value information.
+ *
+ * @param input - Schema object, array of schemas, or JSON string
+ * @param options - Optional configuration for the transformation
+ * @returns JSX string
+ */
+export function schemaToJSXString(
+  input: ReverseTransformInput,
+  options: Partial<ReverseTransformOptions> = {},
+): string {
+  return transformSchemaToJSX(input, options).jsx
+}

--- a/packages/jsx-to-makeswift/src/reverse/types.ts
+++ b/packages/jsx-to-makeswift/src/reverse/types.ts
@@ -1,0 +1,32 @@
+import type { ElementSchema } from '../types'
+
+/**
+ * Options for reverse transformation (Schema → JSX).
+ */
+export type ReverseTransformOptions = {
+  /** Use shorthand classes when possible (e.g., p-4 instead of pt-4 pr-4 pb-4 pl-4) */
+  preferShorthand?: boolean
+  /** Include responsive prefixes even when value matches mobile */
+  alwaysIncludeBreakpoints?: boolean
+  /** Indentation string (default: 2 spaces) */
+  indent?: string
+  /** Use self-closing tags for empty elements */
+  selfClosingTags?: boolean
+}
+
+/**
+ * Result of reverse transformation.
+ */
+export type ReverseTransformResult = {
+  /** Generated JSX string */
+  jsx: string
+  /** Warnings during transformation */
+  warnings: string[]
+  /** CSS values that couldn't be mapped to Tailwind classes */
+  unmappedValues: string[]
+}
+
+/**
+ * Input for reverse transformation - can be schema object or JSON string.
+ */
+export type ReverseTransformInput = ElementSchema | ElementSchema[] | string

--- a/packages/jsx-to-makeswift/src/tailwind/index.ts
+++ b/packages/jsx-to-makeswift/src/tailwind/index.ts
@@ -1,0 +1,2 @@
+export * from './tokenizer'
+export * from './mapping'

--- a/packages/jsx-to-makeswift/src/tailwind/mapping/borders.ts
+++ b/packages/jsx-to-makeswift/src/tailwind/mapping/borders.ts
@@ -1,0 +1,262 @@
+import type { TailwindClassToken } from '../../types'
+
+type BorderResult = {
+  property: string
+  value: string
+} | null
+
+const BORDER_WIDTH_SCALE: Record<string, string> = {
+  '': '1px',
+  '0': '0px',
+  '2': '2px',
+  '4': '4px',
+  '8': '8px',
+}
+
+const BORDER_RADIUS_SCALE: Record<string, string> = {
+  none: '0px',
+  sm: '0.125rem',
+  '': '0.25rem',
+  md: '0.375rem',
+  lg: '0.5rem',
+  xl: '0.75rem',
+  '2xl': '1rem',
+  '3xl': '1.5rem',
+  full: '9999px',
+}
+
+const BORDER_STYLE_VALUES: Record<string, string> = {
+  'border-solid': 'solid',
+  'border-dashed': 'dashed',
+  'border-dotted': 'dotted',
+  'border-double': 'double',
+  'border-hidden': 'hidden',
+  'border-none': 'none',
+}
+
+const SHADOW_SCALE: Record<string, string> = {
+  sm: '0 1px 2px 0 rgb(0 0 0 / 0.05)',
+  '': '0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1)',
+  md: '0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)',
+  lg: '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)',
+  xl: '0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)',
+  '2xl': '0 25px 50px -12px rgb(0 0 0 / 0.25)',
+  inner: 'inset 0 2px 4px 0 rgb(0 0 0 / 0.05)',
+  none: 'none',
+}
+
+const OPACITY_SCALE: Record<string, string> = {
+  '0': '0',
+  '5': '0.05',
+  '10': '0.1',
+  '15': '0.15',
+  '20': '0.2',
+  '25': '0.25',
+  '30': '0.3',
+  '35': '0.35',
+  '40': '0.4',
+  '45': '0.45',
+  '50': '0.5',
+  '55': '0.55',
+  '60': '0.6',
+  '65': '0.65',
+  '70': '0.7',
+  '75': '0.75',
+  '80': '0.8',
+  '85': '0.85',
+  '90': '0.9',
+  '95': '0.95',
+  '100': '1',
+}
+
+export function resolveBorderWidth(token: TailwindClassToken): BorderResult {
+  if (!token.utility.startsWith('border')) return null
+
+  if (token.isArbitrary && token.value) {
+    return { property: 'borderWidth', value: token.value }
+  }
+
+  const sides: Record<string, string> = {
+    'border-t': 'borderTopWidth',
+    'border-r': 'borderRightWidth',
+    'border-b': 'borderBottomWidth',
+    'border-l': 'borderLeftWidth',
+    'border-x': 'borderInlineWidth',
+    'border-y': 'borderBlockWidth',
+  }
+
+  if (token.utility === 'border') {
+    const width = BORDER_WIDTH_SCALE[token.value ?? '']
+    if (width) {
+      return { property: 'borderWidth', value: width }
+    }
+  }
+
+  const sideProperty = sides[token.utility]
+  if (sideProperty) {
+    const width = BORDER_WIDTH_SCALE[token.value ?? '']
+    if (width) {
+      return { property: sideProperty, value: width }
+    }
+  }
+
+  return null
+}
+
+export function resolveBorderRadius(token: TailwindClassToken): BorderResult {
+  if (!token.utility.startsWith('rounded')) return null
+
+  if (token.isArbitrary && token.value) {
+    return { property: 'borderRadius', value: token.value }
+  }
+
+  const corners: Record<string, string> = {
+    'rounded-t': 'borderTopRadius',
+    'rounded-r': 'borderRightRadius',
+    'rounded-b': 'borderBottomRadius',
+    'rounded-l': 'borderLeftRadius',
+    'rounded-tl': 'borderTopLeftRadius',
+    'rounded-tr': 'borderTopRightRadius',
+    'rounded-br': 'borderBottomRightRadius',
+    'rounded-bl': 'borderBottomLeftRadius',
+    'rounded-s': 'borderStartRadius',
+    'rounded-e': 'borderEndRadius',
+    'rounded-ss': 'borderStartStartRadius',
+    'rounded-se': 'borderStartEndRadius',
+    'rounded-ee': 'borderEndEndRadius',
+    'rounded-es': 'borderEndStartRadius',
+  }
+
+  if (token.utility === 'rounded') {
+    const radius = BORDER_RADIUS_SCALE[token.value ?? '']
+    if (radius) {
+      return { property: 'borderRadius', value: radius }
+    }
+  }
+
+  const cornerProperty = corners[token.utility]
+  if (cornerProperty) {
+    const radius = BORDER_RADIUS_SCALE[token.value ?? '']
+    if (radius) {
+      return { property: cornerProperty, value: radius }
+    }
+  }
+
+  return null
+}
+
+export function resolveBorderStyle(token: TailwindClassToken): BorderResult {
+  const value = BORDER_STYLE_VALUES[token.utility]
+  if (value) {
+    return { property: 'borderStyle', value }
+  }
+  return null
+}
+
+export function resolveShadow(token: TailwindClassToken): BorderResult {
+  if (token.utility !== 'shadow') return null
+
+  if (token.isArbitrary && token.value) {
+    return { property: 'boxShadow', value: token.value }
+  }
+
+  const shadow = SHADOW_SCALE[token.value ?? '']
+  if (shadow) {
+    return { property: 'boxShadow', value: shadow }
+  }
+
+  return null
+}
+
+export function resolveOpacity(token: TailwindClassToken): BorderResult {
+  if (token.utility !== 'opacity') return null
+
+  if (token.isArbitrary && token.value) {
+    return { property: 'opacity', value: token.value }
+  }
+
+  if (!token.value) return null
+
+  const opacity = OPACITY_SCALE[token.value]
+  if (opacity) {
+    return { property: 'opacity', value: opacity }
+  }
+
+  return null
+}
+
+export function resolveRing(token: TailwindClassToken): BorderResult {
+  if (token.utility !== 'ring') return null
+
+  const ringWidths: Record<string, string> = {
+    '': '3px',
+    '0': '0px',
+    '1': '1px',
+    '2': '2px',
+    '4': '4px',
+    '8': '8px',
+    inset: 'inset',
+  }
+
+  if (token.isArbitrary && token.value) {
+    return { property: '--tw-ring-width', value: token.value }
+  }
+
+  const width = ringWidths[token.value ?? '']
+  if (width) {
+    return { property: '--tw-ring-width', value: width }
+  }
+
+  return null
+}
+
+const BORDER_UTILITIES = [
+  'border',
+  'border-t',
+  'border-r',
+  'border-b',
+  'border-l',
+  'border-x',
+  'border-y',
+  'rounded',
+  'rounded-t',
+  'rounded-r',
+  'rounded-b',
+  'rounded-l',
+  'rounded-tl',
+  'rounded-tr',
+  'rounded-br',
+  'rounded-bl',
+  'rounded-s',
+  'rounded-e',
+  'rounded-ss',
+  'rounded-se',
+  'rounded-ee',
+  'rounded-es',
+  'border-solid',
+  'border-dashed',
+  'border-dotted',
+  'border-double',
+  'border-hidden',
+  'border-none',
+  'shadow',
+  'opacity',
+  'ring',
+]
+
+export function isBorderUtility(utility: string): boolean {
+  return BORDER_UTILITIES.includes(utility)
+}
+
+export function resolveBorder(token: TailwindClassToken): BorderResult {
+  return (
+    resolveBorderWidth(token) ??
+    resolveBorderRadius(token) ??
+    resolveBorderStyle(token) ??
+    resolveShadow(token) ??
+    resolveOpacity(token) ??
+    resolveRing(token)
+  )
+}
+
+export { BORDER_RADIUS_SCALE, SHADOW_SCALE }

--- a/packages/jsx-to-makeswift/src/tailwind/mapping/colors.ts
+++ b/packages/jsx-to-makeswift/src/tailwind/mapping/colors.ts
@@ -1,0 +1,449 @@
+import type { TailwindClassToken } from '../../types'
+
+const COLOR_PALETTE: Record<string, Record<string, string>> = {
+  slate: {
+    '50': '#f8fafc',
+    '100': '#f1f5f9',
+    '200': '#e2e8f0',
+    '300': '#cbd5e1',
+    '400': '#94a3b8',
+    '500': '#64748b',
+    '600': '#475569',
+    '700': '#334155',
+    '800': '#1e293b',
+    '900': '#0f172a',
+    '950': '#020617',
+  },
+  gray: {
+    '50': '#f9fafb',
+    '100': '#f3f4f6',
+    '200': '#e5e7eb',
+    '300': '#d1d5db',
+    '400': '#9ca3af',
+    '500': '#6b7280',
+    '600': '#4b5563',
+    '700': '#374151',
+    '800': '#1f2937',
+    '900': '#111827',
+    '950': '#030712',
+  },
+  zinc: {
+    '50': '#fafafa',
+    '100': '#f4f4f5',
+    '200': '#e4e4e7',
+    '300': '#d4d4d8',
+    '400': '#a1a1aa',
+    '500': '#71717a',
+    '600': '#52525b',
+    '700': '#3f3f46',
+    '800': '#27272a',
+    '900': '#18181b',
+    '950': '#09090b',
+  },
+  neutral: {
+    '50': '#fafafa',
+    '100': '#f5f5f5',
+    '200': '#e5e5e5',
+    '300': '#d4d4d4',
+    '400': '#a3a3a3',
+    '500': '#737373',
+    '600': '#525252',
+    '700': '#404040',
+    '800': '#262626',
+    '900': '#171717',
+    '950': '#0a0a0a',
+  },
+  stone: {
+    '50': '#fafaf9',
+    '100': '#f5f5f4',
+    '200': '#e7e5e4',
+    '300': '#d6d3d1',
+    '400': '#a8a29e',
+    '500': '#78716c',
+    '600': '#57534e',
+    '700': '#44403c',
+    '800': '#292524',
+    '900': '#1c1917',
+    '950': '#0c0a09',
+  },
+  red: {
+    '50': '#fef2f2',
+    '100': '#fee2e2',
+    '200': '#fecaca',
+    '300': '#fca5a5',
+    '400': '#f87171',
+    '500': '#ef4444',
+    '600': '#dc2626',
+    '700': '#b91c1c',
+    '800': '#991b1b',
+    '900': '#7f1d1d',
+    '950': '#450a0a',
+  },
+  orange: {
+    '50': '#fff7ed',
+    '100': '#ffedd5',
+    '200': '#fed7aa',
+    '300': '#fdba74',
+    '400': '#fb923c',
+    '500': '#f97316',
+    '600': '#ea580c',
+    '700': '#c2410c',
+    '800': '#9a3412',
+    '900': '#7c2d12',
+    '950': '#431407',
+  },
+  amber: {
+    '50': '#fffbeb',
+    '100': '#fef3c7',
+    '200': '#fde68a',
+    '300': '#fcd34d',
+    '400': '#fbbf24',
+    '500': '#f59e0b',
+    '600': '#d97706',
+    '700': '#b45309',
+    '800': '#92400e',
+    '900': '#78350f',
+    '950': '#451a03',
+  },
+  yellow: {
+    '50': '#fefce8',
+    '100': '#fef9c3',
+    '200': '#fef08a',
+    '300': '#fde047',
+    '400': '#facc15',
+    '500': '#eab308',
+    '600': '#ca8a04',
+    '700': '#a16207',
+    '800': '#854d0e',
+    '900': '#713f12',
+    '950': '#422006',
+  },
+  lime: {
+    '50': '#f7fee7',
+    '100': '#ecfccb',
+    '200': '#d9f99d',
+    '300': '#bef264',
+    '400': '#a3e635',
+    '500': '#84cc16',
+    '600': '#65a30d',
+    '700': '#4d7c0f',
+    '800': '#3f6212',
+    '900': '#365314',
+    '950': '#1a2e05',
+  },
+  green: {
+    '50': '#f0fdf4',
+    '100': '#dcfce7',
+    '200': '#bbf7d0',
+    '300': '#86efac',
+    '400': '#4ade80',
+    '500': '#22c55e',
+    '600': '#16a34a',
+    '700': '#15803d',
+    '800': '#166534',
+    '900': '#14532d',
+    '950': '#052e16',
+  },
+  emerald: {
+    '50': '#ecfdf5',
+    '100': '#d1fae5',
+    '200': '#a7f3d0',
+    '300': '#6ee7b7',
+    '400': '#34d399',
+    '500': '#10b981',
+    '600': '#059669',
+    '700': '#047857',
+    '800': '#065f46',
+    '900': '#064e3b',
+    '950': '#022c22',
+  },
+  teal: {
+    '50': '#f0fdfa',
+    '100': '#ccfbf1',
+    '200': '#99f6e4',
+    '300': '#5eead4',
+    '400': '#2dd4bf',
+    '500': '#14b8a6',
+    '600': '#0d9488',
+    '700': '#0f766e',
+    '800': '#115e59',
+    '900': '#134e4a',
+    '950': '#042f2e',
+  },
+  cyan: {
+    '50': '#ecfeff',
+    '100': '#cffafe',
+    '200': '#a5f3fc',
+    '300': '#67e8f9',
+    '400': '#22d3ee',
+    '500': '#06b6d4',
+    '600': '#0891b2',
+    '700': '#0e7490',
+    '800': '#155e75',
+    '900': '#164e63',
+    '950': '#083344',
+  },
+  sky: {
+    '50': '#f0f9ff',
+    '100': '#e0f2fe',
+    '200': '#bae6fd',
+    '300': '#7dd3fc',
+    '400': '#38bdf8',
+    '500': '#0ea5e9',
+    '600': '#0284c7',
+    '700': '#0369a1',
+    '800': '#075985',
+    '900': '#0c4a6e',
+    '950': '#082f49',
+  },
+  blue: {
+    '50': '#eff6ff',
+    '100': '#dbeafe',
+    '200': '#bfdbfe',
+    '300': '#93c5fd',
+    '400': '#60a5fa',
+    '500': '#3b82f6',
+    '600': '#2563eb',
+    '700': '#1d4ed8',
+    '800': '#1e40af',
+    '900': '#1e3a8a',
+    '950': '#172554',
+  },
+  indigo: {
+    '50': '#eef2ff',
+    '100': '#e0e7ff',
+    '200': '#c7d2fe',
+    '300': '#a5b4fc',
+    '400': '#818cf8',
+    '500': '#6366f1',
+    '600': '#4f46e5',
+    '700': '#4338ca',
+    '800': '#3730a3',
+    '900': '#312e81',
+    '950': '#1e1b4b',
+  },
+  violet: {
+    '50': '#f5f3ff',
+    '100': '#ede9fe',
+    '200': '#ddd6fe',
+    '300': '#c4b5fd',
+    '400': '#a78bfa',
+    '500': '#8b5cf6',
+    '600': '#7c3aed',
+    '700': '#6d28d9',
+    '800': '#5b21b6',
+    '900': '#4c1d95',
+    '950': '#2e1065',
+  },
+  purple: {
+    '50': '#faf5ff',
+    '100': '#f3e8ff',
+    '200': '#e9d5ff',
+    '300': '#d8b4fe',
+    '400': '#c084fc',
+    '500': '#a855f7',
+    '600': '#9333ea',
+    '700': '#7e22ce',
+    '800': '#6b21a8',
+    '900': '#581c87',
+    '950': '#3b0764',
+  },
+  fuchsia: {
+    '50': '#fdf4ff',
+    '100': '#fae8ff',
+    '200': '#f5d0fe',
+    '300': '#f0abfc',
+    '400': '#e879f9',
+    '500': '#d946ef',
+    '600': '#c026d3',
+    '700': '#a21caf',
+    '800': '#86198f',
+    '900': '#701a75',
+    '950': '#4a044e',
+  },
+  pink: {
+    '50': '#fdf2f8',
+    '100': '#fce7f3',
+    '200': '#fbcfe8',
+    '300': '#f9a8d4',
+    '400': '#f472b6',
+    '500': '#ec4899',
+    '600': '#db2777',
+    '700': '#be185d',
+    '800': '#9d174d',
+    '900': '#831843',
+    '950': '#500724',
+  },
+  rose: {
+    '50': '#fff1f2',
+    '100': '#ffe4e6',
+    '200': '#fecdd3',
+    '300': '#fda4af',
+    '400': '#fb7185',
+    '500': '#f43f5e',
+    '600': '#e11d48',
+    '700': '#be123c',
+    '800': '#9f1239',
+    '900': '#881337',
+    '950': '#4c0519',
+  },
+}
+
+const SPECIAL_COLORS: Record<string, string> = {
+  inherit: 'inherit',
+  current: 'currentColor',
+  transparent: 'transparent',
+  black: '#000000',
+  white: '#ffffff',
+}
+
+type ColorResult = {
+  property: string
+  value: string
+  colorName: string
+  shade: string | null
+} | null
+
+function parseColorValue(value: string | null): { colorName: string; shade: string | null } | null {
+  if (!value) return null
+
+  if (SPECIAL_COLORS[value]) {
+    return { colorName: value, shade: null }
+  }
+
+  const parts = value.split('-')
+  if (parts.length === 2) {
+    const [colorName, shade] = parts
+    if (COLOR_PALETTE[colorName]?.[shade]) {
+      return { colorName, shade }
+    }
+  }
+
+  if (COLOR_PALETTE[value]) {
+    return { colorName: value, shade: '500' }
+  }
+
+  return null
+}
+
+function getColorHex(colorName: string, shade: string | null): string | null {
+  if (SPECIAL_COLORS[colorName]) {
+    return SPECIAL_COLORS[colorName]
+  }
+
+  if (!shade) return null
+
+  return COLOR_PALETTE[colorName]?.[shade] ?? null
+}
+
+export function resolveTextColor(token: TailwindClassToken): ColorResult {
+  if (token.utility !== 'text') return null
+
+  if (token.isArbitrary && token.value) {
+    return {
+      property: 'color',
+      value: token.value,
+      colorName: 'arbitrary',
+      shade: null,
+    }
+  }
+
+  const parsed = parseColorValue(token.value)
+  if (!parsed) return null
+
+  const hex = getColorHex(parsed.colorName, parsed.shade)
+  if (!hex) return null
+
+  return {
+    property: 'color',
+    value: hex,
+    colorName: parsed.colorName,
+    shade: parsed.shade,
+  }
+}
+
+export function resolveBackgroundColor(token: TailwindClassToken): ColorResult {
+  if (token.utility !== 'bg') return null
+
+  if (token.isArbitrary && token.value) {
+    return {
+      property: 'backgroundColor',
+      value: token.value,
+      colorName: 'arbitrary',
+      shade: null,
+    }
+  }
+
+  const parsed = parseColorValue(token.value)
+  if (!parsed) return null
+
+  const hex = getColorHex(parsed.colorName, parsed.shade)
+  if (!hex) return null
+
+  return {
+    property: 'backgroundColor',
+    value: hex,
+    colorName: parsed.colorName,
+    shade: parsed.shade,
+  }
+}
+
+export function resolveBorderColor(token: TailwindClassToken): ColorResult {
+  if (token.utility !== 'border') return null
+
+  if (token.isArbitrary && token.value) {
+    return {
+      property: 'borderColor',
+      value: token.value,
+      colorName: 'arbitrary',
+      shade: null,
+    }
+  }
+
+  const parsed = parseColorValue(token.value)
+  if (!parsed) return null
+
+  const hex = getColorHex(parsed.colorName, parsed.shade)
+  if (!hex) return null
+
+  return {
+    property: 'borderColor',
+    value: hex,
+    colorName: parsed.colorName,
+    shade: parsed.shade,
+  }
+}
+
+export function isColorUtility(token: TailwindClassToken): boolean {
+  const colorPrefixes = ['text', 'bg', 'border', 'ring', 'divide', 'placeholder', 'caret', 'accent', 'fill', 'stroke']
+
+  if (!colorPrefixes.includes(token.utility)) {
+    return false
+  }
+
+  if (token.isArbitrary) {
+    return true
+  }
+
+  if (!token.value) {
+    return false
+  }
+
+  const parsed = parseColorValue(token.value)
+  return parsed !== null
+}
+
+export function resolveColor(token: TailwindClassToken): ColorResult {
+  switch (token.utility) {
+    case 'text':
+      return resolveTextColor(token)
+    case 'bg':
+      return resolveBackgroundColor(token)
+    case 'border':
+      return resolveBorderColor(token)
+    default:
+      return null
+  }
+}
+
+export { COLOR_PALETTE, SPECIAL_COLORS }

--- a/packages/jsx-to-makeswift/src/tailwind/mapping/index.ts
+++ b/packages/jsx-to-makeswift/src/tailwind/mapping/index.ts
@@ -1,0 +1,115 @@
+import type { TailwindClassToken } from '../../types'
+
+import { isBorderUtility, resolveBorder } from './borders'
+import { isColorUtility, resolveColor } from './colors'
+import { isLayoutUtility, resolveLayout } from './layout'
+import { isSizingUtility, resolveSizing } from './sizing'
+import { isSpacingUtility, resolveSpacing } from './spacing'
+import { isTypographyUtility, resolveTypography } from './typography'
+
+export * from './spacing'
+export * from './sizing'
+export * from './colors'
+export * from './typography'
+export * from './layout'
+export * from './borders'
+
+export type ResolvedCSSProperty = {
+  property: string
+  value: string | number
+  category: 'spacing' | 'sizing' | 'color' | 'typography' | 'layout' | 'border'
+  colorName?: string
+  colorShade?: string | null
+}
+
+export type ResolutionResult = {
+  resolved: ResolvedCSSProperty[]
+  unresolved: TailwindClassToken[]
+}
+
+export function resolveToken(token: TailwindClassToken): ResolvedCSSProperty | null {
+  if (isSpacingUtility(token.utility)) {
+    const result = resolveSpacing(token)
+    if (result) {
+      return { ...result, category: 'spacing' }
+    }
+  }
+
+  if (isSizingUtility(token.utility)) {
+    const result = resolveSizing(token)
+    if (result) {
+      return { ...result, category: 'sizing' }
+    }
+  }
+
+  if (isColorUtility(token)) {
+    const result = resolveColor(token)
+    if (result) {
+      return {
+        property: result.property,
+        value: result.value,
+        category: 'color',
+        colorName: result.colorName,
+        colorShade: result.shade,
+      }
+    }
+  }
+
+  if (isTypographyUtility(token.utility)) {
+    const result = resolveTypography(token)
+    if (result) {
+      return { ...result, category: 'typography' }
+    }
+  }
+
+  if (isLayoutUtility(token.utility)) {
+    const result = resolveLayout(token)
+    if (result) {
+      return { ...result, category: 'layout' }
+    }
+  }
+
+  if (isBorderUtility(token.utility)) {
+    const result = resolveBorder(token)
+    if (result) {
+      return { ...result, category: 'border' }
+    }
+  }
+
+  return null
+}
+
+export function resolveTokens(tokens: TailwindClassToken[]): ResolutionResult {
+  const resolved: ResolvedCSSProperty[] = []
+  const unresolved: TailwindClassToken[] = []
+
+  for (const token of tokens) {
+    const result = resolveToken(token)
+    if (result) {
+      resolved.push(result)
+    } else {
+      unresolved.push(token)
+    }
+  }
+
+  return { resolved, unresolved }
+}
+
+export function groupByCategory(
+  properties: ResolvedCSSProperty[],
+): Record<ResolvedCSSProperty['category'], ResolvedCSSProperty[]> {
+  const groups: Record<ResolvedCSSProperty['category'], ResolvedCSSProperty[]> = {
+    spacing: [],
+    sizing: [],
+    color: [],
+    typography: [],
+    layout: [],
+    border: [],
+  }
+
+  for (const prop of properties) {
+    groups[prop.category].push(prop)
+  }
+
+  return groups
+}

--- a/packages/jsx-to-makeswift/src/tailwind/mapping/layout.ts
+++ b/packages/jsx-to-makeswift/src/tailwind/mapping/layout.ts
@@ -1,0 +1,292 @@
+import type { TailwindClassToken } from '../../types'
+
+type LayoutResult = {
+  property: string
+  value: string
+} | null
+
+const DISPLAY_VALUES: Record<string, string> = {
+  block: 'block',
+  'inline-block': 'inline-block',
+  inline: 'inline',
+  flex: 'flex',
+  'inline-flex': 'inline-flex',
+  table: 'table',
+  'inline-table': 'inline-table',
+  'table-caption': 'table-caption',
+  'table-cell': 'table-cell',
+  'table-column': 'table-column',
+  'table-column-group': 'table-column-group',
+  'table-footer-group': 'table-footer-group',
+  'table-header-group': 'table-header-group',
+  'table-row-group': 'table-row-group',
+  'table-row': 'table-row',
+  'flow-root': 'flow-root',
+  grid: 'grid',
+  'inline-grid': 'inline-grid',
+  contents: 'contents',
+  'list-item': 'list-item',
+  hidden: 'none',
+}
+
+const POSITION_VALUES: Record<string, string> = {
+  static: 'static',
+  fixed: 'fixed',
+  absolute: 'absolute',
+  relative: 'relative',
+  sticky: 'sticky',
+}
+
+const FLEX_DIRECTION_VALUES: Record<string, string> = {
+  'flex-row': 'row',
+  'flex-row-reverse': 'row-reverse',
+  'flex-col': 'column',
+  'flex-col-reverse': 'column-reverse',
+}
+
+const FLEX_WRAP_VALUES: Record<string, string> = {
+  'flex-wrap': 'wrap',
+  'flex-wrap-reverse': 'wrap-reverse',
+  'flex-nowrap': 'nowrap',
+}
+
+const JUSTIFY_CONTENT_VALUES: Record<string, string> = {
+  'justify-normal': 'normal',
+  'justify-start': 'flex-start',
+  'justify-end': 'flex-end',
+  'justify-center': 'center',
+  'justify-between': 'space-between',
+  'justify-around': 'space-around',
+  'justify-evenly': 'space-evenly',
+  'justify-stretch': 'stretch',
+}
+
+const ALIGN_ITEMS_VALUES: Record<string, string> = {
+  'items-start': 'flex-start',
+  'items-end': 'flex-end',
+  'items-center': 'center',
+  'items-baseline': 'baseline',
+  'items-stretch': 'stretch',
+}
+
+const ALIGN_SELF_VALUES: Record<string, string> = {
+  'self-auto': 'auto',
+  'self-start': 'flex-start',
+  'self-end': 'flex-end',
+  'self-center': 'center',
+  'self-stretch': 'stretch',
+  'self-baseline': 'baseline',
+}
+
+const ALIGN_CONTENT_VALUES: Record<string, string> = {
+  'content-normal': 'normal',
+  'content-center': 'center',
+  'content-start': 'flex-start',
+  'content-end': 'flex-end',
+  'content-between': 'space-between',
+  'content-around': 'space-around',
+  'content-evenly': 'space-evenly',
+  'content-baseline': 'baseline',
+  'content-stretch': 'stretch',
+}
+
+const OVERFLOW_VALUES: Record<string, string> = {
+  'overflow-auto': 'auto',
+  'overflow-hidden': 'hidden',
+  'overflow-clip': 'clip',
+  'overflow-visible': 'visible',
+  'overflow-scroll': 'scroll',
+  'overflow-x-auto': 'auto',
+  'overflow-y-auto': 'auto',
+  'overflow-x-hidden': 'hidden',
+  'overflow-y-hidden': 'hidden',
+  'overflow-x-clip': 'clip',
+  'overflow-y-clip': 'clip',
+  'overflow-x-visible': 'visible',
+  'overflow-y-visible': 'visible',
+  'overflow-x-scroll': 'scroll',
+  'overflow-y-scroll': 'scroll',
+}
+
+const Z_INDEX_SCALE: Record<string, string> = {
+  '0': '0',
+  '10': '10',
+  '20': '20',
+  '30': '30',
+  '40': '40',
+  '50': '50',
+  auto: 'auto',
+}
+
+export function resolveDisplay(token: TailwindClassToken): LayoutResult {
+  const value = DISPLAY_VALUES[token.utility]
+  if (value) {
+    return { property: 'display', value }
+  }
+  return null
+}
+
+export function resolvePosition(token: TailwindClassToken): LayoutResult {
+  const value = POSITION_VALUES[token.utility]
+  if (value) {
+    return { property: 'position', value }
+  }
+  return null
+}
+
+export function resolveFlexDirection(token: TailwindClassToken): LayoutResult {
+  const value = FLEX_DIRECTION_VALUES[token.utility]
+  if (value) {
+    return { property: 'flexDirection', value }
+  }
+  return null
+}
+
+export function resolveFlexWrap(token: TailwindClassToken): LayoutResult {
+  const value = FLEX_WRAP_VALUES[token.utility]
+  if (value) {
+    return { property: 'flexWrap', value }
+  }
+  return null
+}
+
+export function resolveJustifyContent(token: TailwindClassToken): LayoutResult {
+  const value = JUSTIFY_CONTENT_VALUES[token.utility]
+  if (value) {
+    return { property: 'justifyContent', value }
+  }
+  return null
+}
+
+export function resolveAlignItems(token: TailwindClassToken): LayoutResult {
+  const value = ALIGN_ITEMS_VALUES[token.utility]
+  if (value) {
+    return { property: 'alignItems', value }
+  }
+  return null
+}
+
+export function resolveAlignSelf(token: TailwindClassToken): LayoutResult {
+  const value = ALIGN_SELF_VALUES[token.utility]
+  if (value) {
+    return { property: 'alignSelf', value }
+  }
+  return null
+}
+
+export function resolveAlignContent(token: TailwindClassToken): LayoutResult {
+  const value = ALIGN_CONTENT_VALUES[token.utility]
+  if (value) {
+    return { property: 'alignContent', value }
+  }
+  return null
+}
+
+export function resolveOverflow(token: TailwindClassToken): LayoutResult {
+  const value = OVERFLOW_VALUES[token.utility]
+  if (value) {
+    const property = token.utility.includes('-x')
+      ? 'overflowX'
+      : token.utility.includes('-y')
+        ? 'overflowY'
+        : 'overflow'
+    return { property, value }
+  }
+  return null
+}
+
+export function resolveZIndex(token: TailwindClassToken): LayoutResult {
+  if (token.utility !== 'z') return null
+
+  if (token.isArbitrary && token.value) {
+    return { property: 'zIndex', value: token.value }
+  }
+
+  if (!token.value) return null
+
+  const value = Z_INDEX_SCALE[token.value]
+  if (value) {
+    return { property: 'zIndex', value }
+  }
+
+  return null
+}
+
+export function resolveFlexGrow(token: TailwindClassToken): LayoutResult {
+  if (token.utility === 'grow') {
+    return { property: 'flexGrow', value: token.value ?? '1' }
+  }
+  if (token.utility === 'grow-0') {
+    return { property: 'flexGrow', value: '0' }
+  }
+  return null
+}
+
+export function resolveFlexShrink(token: TailwindClassToken): LayoutResult {
+  if (token.utility === 'shrink') {
+    return { property: 'flexShrink', value: token.value ?? '1' }
+  }
+  if (token.utility === 'shrink-0') {
+    return { property: 'flexShrink', value: '0' }
+  }
+  return null
+}
+
+export function resolveOrder(token: TailwindClassToken): LayoutResult {
+  if (token.utility !== 'order') return null
+
+  const orderValues: Record<string, string> = {
+    first: '-9999',
+    last: '9999',
+    none: '0',
+  }
+
+  if (token.isArbitrary && token.value) {
+    return { property: 'order', value: token.value }
+  }
+
+  if (!token.value) return null
+
+  const value = orderValues[token.value] ?? token.value
+  return { property: 'order', value }
+}
+
+const LAYOUT_UTILITIES = [
+  ...Object.keys(DISPLAY_VALUES),
+  ...Object.keys(POSITION_VALUES),
+  ...Object.keys(FLEX_DIRECTION_VALUES),
+  ...Object.keys(FLEX_WRAP_VALUES),
+  ...Object.keys(JUSTIFY_CONTENT_VALUES),
+  ...Object.keys(ALIGN_ITEMS_VALUES),
+  ...Object.keys(ALIGN_SELF_VALUES),
+  ...Object.keys(ALIGN_CONTENT_VALUES),
+  ...Object.keys(OVERFLOW_VALUES),
+  'z',
+  'grow',
+  'grow-0',
+  'shrink',
+  'shrink-0',
+  'order',
+]
+
+export function isLayoutUtility(utility: string): boolean {
+  return LAYOUT_UTILITIES.includes(utility)
+}
+
+export function resolveLayout(token: TailwindClassToken): LayoutResult {
+  return (
+    resolveDisplay(token) ??
+    resolvePosition(token) ??
+    resolveFlexDirection(token) ??
+    resolveFlexWrap(token) ??
+    resolveJustifyContent(token) ??
+    resolveAlignItems(token) ??
+    resolveAlignSelf(token) ??
+    resolveAlignContent(token) ??
+    resolveOverflow(token) ??
+    resolveZIndex(token) ??
+    resolveFlexGrow(token) ??
+    resolveFlexShrink(token) ??
+    resolveOrder(token)
+  )
+}

--- a/packages/jsx-to-makeswift/src/tailwind/mapping/sizing.ts
+++ b/packages/jsx-to-makeswift/src/tailwind/mapping/sizing.ts
@@ -1,0 +1,223 @@
+import type { TailwindClassToken } from '../../types'
+
+const SIZE_SCALE: Record<string, string> = {
+  '0': '0px',
+  px: '1px',
+  '0.5': '0.125rem',
+  '1': '0.25rem',
+  '1.5': '0.375rem',
+  '2': '0.5rem',
+  '2.5': '0.625rem',
+  '3': '0.75rem',
+  '3.5': '0.875rem',
+  '4': '1rem',
+  '5': '1.25rem',
+  '6': '1.5rem',
+  '7': '1.75rem',
+  '8': '2rem',
+  '9': '2.25rem',
+  '10': '2.5rem',
+  '11': '2.75rem',
+  '12': '3rem',
+  '14': '3.5rem',
+  '16': '4rem',
+  '20': '5rem',
+  '24': '6rem',
+  '28': '7rem',
+  '32': '8rem',
+  '36': '9rem',
+  '40': '10rem',
+  '44': '11rem',
+  '48': '12rem',
+  '52': '13rem',
+  '56': '14rem',
+  '60': '15rem',
+  '64': '16rem',
+  '72': '18rem',
+  '80': '20rem',
+  '96': '24rem',
+  auto: 'auto',
+  full: '100%',
+  screen: '100vw',
+  svw: '100svw',
+  lvw: '100lvw',
+  dvw: '100dvw',
+  min: 'min-content',
+  max: 'max-content',
+  fit: 'fit-content',
+}
+
+const WIDTH_FRACTIONS: Record<string, string> = {
+  '1/2': '50%',
+  '1/3': '33.333333%',
+  '2/3': '66.666667%',
+  '1/4': '25%',
+  '2/4': '50%',
+  '3/4': '75%',
+  '1/5': '20%',
+  '2/5': '40%',
+  '3/5': '60%',
+  '4/5': '80%',
+  '1/6': '16.666667%',
+  '2/6': '33.333333%',
+  '3/6': '50%',
+  '4/6': '66.666667%',
+  '5/6': '83.333333%',
+  '1/12': '8.333333%',
+  '2/12': '16.666667%',
+  '3/12': '25%',
+  '4/12': '33.333333%',
+  '5/12': '41.666667%',
+  '6/12': '50%',
+  '7/12': '58.333333%',
+  '8/12': '66.666667%',
+  '9/12': '75%',
+  '10/12': '83.333333%',
+  '11/12': '91.666667%',
+}
+
+const HEIGHT_SCREEN_VALUES: Record<string, string> = {
+  screen: '100vh',
+  svh: '100svh',
+  lvh: '100lvh',
+  dvh: '100dvh',
+}
+
+type SizingResult = {
+  property: string
+  value: string
+} | null
+
+function resolveSizeValue(
+  value: string | null,
+  isArbitrary: boolean,
+  includeFractions = true,
+): string | null {
+  if (!value) return null
+
+  if (isArbitrary) {
+    return value
+  }
+
+  if (SIZE_SCALE[value]) {
+    return SIZE_SCALE[value]
+  }
+
+  if (includeFractions && WIDTH_FRACTIONS[value]) {
+    return WIDTH_FRACTIONS[value]
+  }
+
+  if (HEIGHT_SCREEN_VALUES[value]) {
+    return HEIGHT_SCREEN_VALUES[value]
+  }
+
+  return null
+}
+
+export function resolveWidth(token: TailwindClassToken): SizingResult {
+  const value = resolveSizeValue(token.value, token.isArbitrary)
+  if (!value) return null
+
+  switch (token.utility) {
+    case 'w':
+      return { property: 'width', value }
+    case 'min-w':
+      return { property: 'minWidth', value }
+    case 'max-w':
+      return resolveMaxWidth(token)
+    default:
+      return null
+  }
+}
+
+function resolveMaxWidth(token: TailwindClassToken): SizingResult {
+  const maxWidthScale: Record<string, string> = {
+    '0': '0rem',
+    none: 'none',
+    xs: '20rem',
+    sm: '24rem',
+    md: '28rem',
+    lg: '32rem',
+    xl: '36rem',
+    '2xl': '42rem',
+    '3xl': '48rem',
+    '4xl': '56rem',
+    '5xl': '64rem',
+    '6xl': '72rem',
+    '7xl': '80rem',
+    full: '100%',
+    min: 'min-content',
+    max: 'max-content',
+    fit: 'fit-content',
+    prose: '65ch',
+    'screen-sm': '640px',
+    'screen-md': '768px',
+    'screen-lg': '1024px',
+    'screen-xl': '1280px',
+    'screen-2xl': '1536px',
+  }
+
+  if (token.isArbitrary && token.value) {
+    return { property: 'maxWidth', value: token.value }
+  }
+
+  const value = token.value ? maxWidthScale[token.value] : null
+  if (!value) return null
+
+  return { property: 'maxWidth', value }
+}
+
+export function resolveHeight(token: TailwindClassToken): SizingResult {
+  const value = resolveSizeValue(token.value, token.isArbitrary, false)
+  if (!value) return null
+
+  switch (token.utility) {
+    case 'h':
+      return { property: 'height', value }
+    case 'min-h':
+      return { property: 'minHeight', value }
+    case 'max-h':
+      return { property: 'maxHeight', value }
+    default:
+      return null
+  }
+}
+
+export function resolveSize(token: TailwindClassToken): SizingResult {
+  const value = resolveSizeValue(token.value, token.isArbitrary)
+  if (!value) return null
+
+  if (token.utility === 'size') {
+    return { property: 'size', value }
+  }
+
+  return null
+}
+
+const WIDTH_UTILITIES = ['w', 'min-w', 'max-w']
+const HEIGHT_UTILITIES = ['h', 'min-h', 'max-h']
+const SIZE_UTILITIES = ['size']
+
+export function isSizingUtility(utility: string): boolean {
+  return (
+    WIDTH_UTILITIES.includes(utility) ||
+    HEIGHT_UTILITIES.includes(utility) ||
+    SIZE_UTILITIES.includes(utility)
+  )
+}
+
+export function resolveSizing(token: TailwindClassToken): SizingResult {
+  if (WIDTH_UTILITIES.includes(token.utility)) {
+    return resolveWidth(token)
+  }
+
+  if (HEIGHT_UTILITIES.includes(token.utility)) {
+    return resolveHeight(token)
+  }
+
+  if (SIZE_UTILITIES.includes(token.utility)) {
+    return resolveSize(token)
+  }
+
+  return null
+}

--- a/packages/jsx-to-makeswift/src/tailwind/mapping/spacing.ts
+++ b/packages/jsx-to-makeswift/src/tailwind/mapping/spacing.ts
@@ -1,0 +1,183 @@
+import type { TailwindClassToken } from '../../types'
+
+const SPACING_SCALE: Record<string, string> = {
+  '0': '0px',
+  px: '1px',
+  '0.5': '0.125rem',
+  '1': '0.25rem',
+  '1.5': '0.375rem',
+  '2': '0.5rem',
+  '2.5': '0.625rem',
+  '3': '0.75rem',
+  '3.5': '0.875rem',
+  '4': '1rem',
+  '5': '1.25rem',
+  '6': '1.5rem',
+  '7': '1.75rem',
+  '8': '2rem',
+  '9': '2.25rem',
+  '10': '2.5rem',
+  '11': '2.75rem',
+  '12': '3rem',
+  '14': '3.5rem',
+  '16': '4rem',
+  '20': '5rem',
+  '24': '6rem',
+  '28': '7rem',
+  '32': '8rem',
+  '36': '9rem',
+  '40': '10rem',
+  '44': '11rem',
+  '48': '12rem',
+  '52': '13rem',
+  '56': '14rem',
+  '60': '15rem',
+  '64': '16rem',
+  '72': '18rem',
+  '80': '20rem',
+  '96': '24rem',
+  auto: 'auto',
+}
+
+type SpacingResult = {
+  property: string
+  value: string
+} | null
+
+export function resolveSpacingValue(value: string | null, isArbitrary: boolean): string | null {
+  if (!value) return null
+
+  if (isArbitrary) {
+    return value
+  }
+
+  return SPACING_SCALE[value] ?? null
+}
+
+export function resolveMargin(token: TailwindClassToken): SpacingResult {
+  const value = resolveSpacingValue(token.value, token.isArbitrary)
+  if (!value) return null
+
+  const sign = token.isNegative ? '-' : ''
+  const finalValue = `${sign}${value}`
+
+  switch (token.utility) {
+    case 'm':
+      return { property: 'margin', value: finalValue }
+    case 'mx':
+      return { property: 'marginInline', value: finalValue }
+    case 'my':
+      return { property: 'marginBlock', value: finalValue }
+    case 'mt':
+      return { property: 'marginTop', value: finalValue }
+    case 'mr':
+      return { property: 'marginRight', value: finalValue }
+    case 'mb':
+      return { property: 'marginBottom', value: finalValue }
+    case 'ml':
+      return { property: 'marginLeft', value: finalValue }
+    case 'ms':
+      return { property: 'marginInlineStart', value: finalValue }
+    case 'me':
+      return { property: 'marginInlineEnd', value: finalValue }
+    default:
+      return null
+  }
+}
+
+export function resolvePadding(token: TailwindClassToken): SpacingResult {
+  const value = resolveSpacingValue(token.value, token.isArbitrary)
+  if (!value) return null
+
+  switch (token.utility) {
+    case 'p':
+      return { property: 'padding', value }
+    case 'px':
+      return { property: 'paddingInline', value }
+    case 'py':
+      return { property: 'paddingBlock', value }
+    case 'pt':
+      return { property: 'paddingTop', value }
+    case 'pr':
+      return { property: 'paddingRight', value }
+    case 'pb':
+      return { property: 'paddingBottom', value }
+    case 'pl':
+      return { property: 'paddingLeft', value }
+    case 'ps':
+      return { property: 'paddingInlineStart', value }
+    case 'pe':
+      return { property: 'paddingInlineEnd', value }
+    default:
+      return null
+  }
+}
+
+export function resolveGap(token: TailwindClassToken): SpacingResult {
+  const value = resolveSpacingValue(token.value, token.isArbitrary)
+  if (!value) return null
+
+  switch (token.utility) {
+    case 'gap':
+      return { property: 'gap', value }
+    case 'gap-x':
+      return { property: 'columnGap', value }
+    case 'gap-y':
+      return { property: 'rowGap', value }
+    default:
+      return null
+  }
+}
+
+export function resolveSpaceUtility(token: TailwindClassToken): SpacingResult {
+  const value = resolveSpacingValue(token.value, token.isArbitrary)
+  if (!value) return null
+
+  const sign = token.isNegative ? '-' : ''
+  const finalValue = `${sign}${value}`
+
+  switch (token.utility) {
+    case 'space-x':
+      return { property: '--tw-space-x', value: finalValue }
+    case 'space-y':
+      return { property: '--tw-space-y', value: finalValue }
+    default:
+      return null
+  }
+}
+
+const MARGIN_UTILITIES = ['m', 'mx', 'my', 'mt', 'mr', 'mb', 'ml', 'ms', 'me']
+const PADDING_UTILITIES = ['p', 'px', 'py', 'pt', 'pr', 'pb', 'pl', 'ps', 'pe']
+const GAP_UTILITIES = ['gap', 'gap-x', 'gap-y']
+const SPACE_UTILITIES = ['space-x', 'space-y']
+
+export function isSpacingUtility(utility: string): boolean {
+  return (
+    MARGIN_UTILITIES.includes(utility) ||
+    PADDING_UTILITIES.includes(utility) ||
+    GAP_UTILITIES.includes(utility) ||
+    SPACE_UTILITIES.includes(utility)
+  )
+}
+
+export function resolveSpacing(
+  token: TailwindClassToken,
+): SpacingResult {
+  if (MARGIN_UTILITIES.includes(token.utility)) {
+    return resolveMargin(token)
+  }
+
+  if (PADDING_UTILITIES.includes(token.utility)) {
+    return resolvePadding(token)
+  }
+
+  if (GAP_UTILITIES.includes(token.utility)) {
+    return resolveGap(token)
+  }
+
+  if (SPACE_UTILITIES.includes(token.utility)) {
+    return resolveSpaceUtility(token)
+  }
+
+  return null
+}

--- a/packages/jsx-to-makeswift/src/tailwind/mapping/typography.ts
+++ b/packages/jsx-to-makeswift/src/tailwind/mapping/typography.ts
@@ -1,0 +1,265 @@
+import type { TailwindClassToken } from '../../types'
+
+const FONT_SIZE_SCALE: Record<string, { fontSize: string; lineHeight: string }> = {
+  xs: { fontSize: '0.75rem', lineHeight: '1rem' },
+  sm: { fontSize: '0.875rem', lineHeight: '1.25rem' },
+  base: { fontSize: '1rem', lineHeight: '1.5rem' },
+  lg: { fontSize: '1.125rem', lineHeight: '1.75rem' },
+  xl: { fontSize: '1.25rem', lineHeight: '1.75rem' },
+  '2xl': { fontSize: '1.5rem', lineHeight: '2rem' },
+  '3xl': { fontSize: '1.875rem', lineHeight: '2.25rem' },
+  '4xl': { fontSize: '2.25rem', lineHeight: '2.5rem' },
+  '5xl': { fontSize: '3rem', lineHeight: '1' },
+  '6xl': { fontSize: '3.75rem', lineHeight: '1' },
+  '7xl': { fontSize: '4.5rem', lineHeight: '1' },
+  '8xl': { fontSize: '6rem', lineHeight: '1' },
+  '9xl': { fontSize: '8rem', lineHeight: '1' },
+}
+
+const FONT_WEIGHT_SCALE: Record<string, number> = {
+  thin: 100,
+  extralight: 200,
+  light: 300,
+  normal: 400,
+  medium: 500,
+  semibold: 600,
+  bold: 700,
+  extrabold: 800,
+  black: 900,
+}
+
+const LINE_HEIGHT_SCALE: Record<string, string> = {
+  '3': '0.75rem',
+  '4': '1rem',
+  '5': '1.25rem',
+  '6': '1.5rem',
+  '7': '1.75rem',
+  '8': '2rem',
+  '9': '2.25rem',
+  '10': '2.5rem',
+  none: '1',
+  tight: '1.25',
+  snug: '1.375',
+  normal: '1.5',
+  relaxed: '1.625',
+  loose: '2',
+}
+
+const LETTER_SPACING_SCALE: Record<string, string> = {
+  tighter: '-0.05em',
+  tight: '-0.025em',
+  normal: '0em',
+  wide: '0.025em',
+  wider: '0.05em',
+  widest: '0.1em',
+}
+
+const FONT_FAMILY_SCALE: Record<string, string> = {
+  sans: 'ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
+  serif: 'ui-serif, Georgia, Cambria, "Times New Roman", Times, serif',
+  mono: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+}
+
+type TypographyResult = {
+  property: string
+  value: string | number
+} | null
+
+export function resolveFontSize(token: TailwindClassToken): TypographyResult {
+  if (token.utility !== 'text') return null
+
+  if (token.isArbitrary && token.value) {
+    return { property: 'fontSize', value: token.value }
+  }
+
+  if (!token.value) return null
+
+  const sizeData = FONT_SIZE_SCALE[token.value]
+  if (sizeData) {
+    return { property: 'fontSize', value: sizeData.fontSize }
+  }
+
+  return null
+}
+
+export function resolveFontWeight(token: TailwindClassToken): TypographyResult {
+  if (token.utility !== 'font') return null
+
+  if (token.isArbitrary && token.value) {
+    const numValue = parseInt(token.value, 10)
+    if (!isNaN(numValue)) {
+      return { property: 'fontWeight', value: numValue }
+    }
+  }
+
+  if (!token.value) return null
+
+  const weight = FONT_WEIGHT_SCALE[token.value]
+  if (weight !== undefined) {
+    return { property: 'fontWeight', value: weight }
+  }
+
+  return null
+}
+
+export function resolveFontFamily(token: TailwindClassToken): TypographyResult {
+  if (token.utility !== 'font') return null
+
+  if (token.isArbitrary && token.value) {
+    return { property: 'fontFamily', value: token.value }
+  }
+
+  if (!token.value) return null
+
+  const family = FONT_FAMILY_SCALE[token.value]
+  if (family) {
+    return { property: 'fontFamily', value: family }
+  }
+
+  return null
+}
+
+export function resolveLineHeight(token: TailwindClassToken): TypographyResult {
+  if (token.utility !== 'leading') return null
+
+  if (token.isArbitrary && token.value) {
+    return { property: 'lineHeight', value: token.value }
+  }
+
+  if (!token.value) return null
+
+  const lineHeight = LINE_HEIGHT_SCALE[token.value]
+  if (lineHeight) {
+    return { property: 'lineHeight', value: lineHeight }
+  }
+
+  return null
+}
+
+export function resolveLetterSpacing(token: TailwindClassToken): TypographyResult {
+  if (token.utility !== 'tracking') return null
+
+  if (token.isArbitrary && token.value) {
+    return { property: 'letterSpacing', value: token.value }
+  }
+
+  if (!token.value) return null
+
+  const spacing = LETTER_SPACING_SCALE[token.value]
+  if (spacing) {
+    return { property: 'letterSpacing', value: spacing }
+  }
+
+  return null
+}
+
+export function resolveTextAlign(token: TailwindClassToken): TypographyResult {
+  if (token.utility !== 'text') return null
+
+  const alignments = ['left', 'center', 'right', 'justify', 'start', 'end']
+  if (token.value && alignments.includes(token.value)) {
+    return { property: 'textAlign', value: token.value }
+  }
+
+  return null
+}
+
+export function resolveTextTransform(token: TailwindClassToken): TypographyResult {
+  const transforms: Record<string, string> = {
+    uppercase: 'uppercase',
+    lowercase: 'lowercase',
+    capitalize: 'capitalize',
+    'normal-case': 'none',
+  }
+
+  const value = transforms[token.utility]
+  if (value) {
+    return { property: 'textTransform', value }
+  }
+
+  return null
+}
+
+export function resolveTextDecoration(token: TailwindClassToken): TypographyResult {
+  const decorations: Record<string, string> = {
+    underline: 'underline',
+    overline: 'overline',
+    'line-through': 'line-through',
+    'no-underline': 'none',
+  }
+
+  const value = decorations[token.utility]
+  if (value) {
+    return { property: 'textDecoration', value }
+  }
+
+  return null
+}
+
+export function resolveFontStyle(token: TailwindClassToken): TypographyResult {
+  if (token.utility === 'italic') {
+    return { property: 'fontStyle', value: 'italic' }
+  }
+
+  if (token.utility === 'not-italic') {
+    return { property: 'fontStyle', value: 'normal' }
+  }
+
+  return null
+}
+
+const TYPOGRAPHY_UTILITIES = [
+  'text',
+  'font',
+  'leading',
+  'tracking',
+  'uppercase',
+  'lowercase',
+  'capitalize',
+  'normal-case',
+  'underline',
+  'overline',
+  'line-through',
+  'no-underline',
+  'italic',
+  'not-italic',
+]
+
+export function isTypographyUtility(utility: string): boolean {
+  return TYPOGRAPHY_UTILITIES.includes(utility)
+}
+
+export function resolveTypography(
+  token: TailwindClassToken,
+): TypographyResult {
+  const fontSize = resolveFontSize(token)
+  if (fontSize) return fontSize
+
+  const fontWeight = resolveFontWeight(token)
+  if (fontWeight) return fontWeight
+
+  const fontFamily = resolveFontFamily(token)
+  if (fontFamily) return fontFamily
+
+  const lineHeight = resolveLineHeight(token)
+  if (lineHeight) return lineHeight
+
+  const letterSpacing = resolveLetterSpacing(token)
+  if (letterSpacing) return letterSpacing
+
+  const textAlign = resolveTextAlign(token)
+  if (textAlign) return textAlign
+
+  const textTransform = resolveTextTransform(token)
+  if (textTransform) return textTransform
+
+  const textDecoration = resolveTextDecoration(token)
+  if (textDecoration) return textDecoration
+
+  const fontStyle = resolveFontStyle(token)
+  if (fontStyle) return fontStyle
+
+  return null
+}
+
+export { FONT_SIZE_SCALE, FONT_WEIGHT_SCALE, LINE_HEIGHT_SCALE, LETTER_SPACING_SCALE }

--- a/packages/jsx-to-makeswift/src/tailwind/tokenizer.ts
+++ b/packages/jsx-to-makeswift/src/tailwind/tokenizer.ts
@@ -1,0 +1,316 @@
+import type {
+  DeviceId,
+  TailwindClassToken,
+  TailwindParseResult,
+} from '../types'
+
+const RESPONSIVE_PREFIXES: Record<string, DeviceId> = {
+  sm: 'tablet',
+  md: 'desktop',
+  lg: 'desktop',
+  xl: 'desktop',
+  '2xl': 'desktop',
+}
+
+const STATE_VARIANTS = [
+  'hover',
+  'focus',
+  'active',
+  'disabled',
+  'visited',
+  'focus-within',
+  'focus-visible',
+  'first',
+  'last',
+  'odd',
+  'even',
+  'group-hover',
+  'group-focus',
+  'peer-hover',
+  'peer-focus',
+]
+
+const ARBITRARY_VALUE_PATTERN = /^(.+)-\[(.+)\]$/
+const NEGATIVE_PREFIX_PATTERN = /^-(.+)$/
+
+const SINGLE_PART_UTILITIES = [
+  'bg',
+  'text',
+  'border',
+  'ring',
+  'divide',
+  'placeholder',
+  'caret',
+  'accent',
+  'fill',
+  'stroke',
+  'from',
+  'via',
+  'to',
+  'shadow',
+  'opacity',
+  'font',
+  'leading',
+  'tracking',
+  'rounded',
+  'outline',
+  'm',
+  'mx',
+  'my',
+  'mt',
+  'mr',
+  'mb',
+  'ml',
+  'ms',
+  'me',
+  'p',
+  'px',
+  'py',
+  'pt',
+  'pr',
+  'pb',
+  'pl',
+  'ps',
+  'pe',
+  'w',
+  'h',
+  'min-w',
+  'max-w',
+  'min-h',
+  'max-h',
+  'size',
+  'gap',
+  'gap-x',
+  'gap-y',
+  'space-x',
+  'space-y',
+  'inset',
+  'inset-x',
+  'inset-y',
+  'top',
+  'right',
+  'bottom',
+  'left',
+  'start',
+  'end',
+  'z',
+  'order',
+  'basis',
+  'grow',
+  'shrink',
+  'columns',
+  'aspect',
+  'scale',
+  'rotate',
+  'translate-x',
+  'translate-y',
+  'skew-x',
+  'skew-y',
+  'origin',
+  'delay',
+  'duration',
+  'ease',
+  'blur',
+  'brightness',
+  'contrast',
+  'grayscale',
+  'hue-rotate',
+  'invert',
+  'saturate',
+  'sepia',
+  'backdrop-blur',
+  'backdrop-brightness',
+  'backdrop-contrast',
+  'backdrop-grayscale',
+  'backdrop-hue-rotate',
+  'backdrop-invert',
+  'backdrop-opacity',
+  'backdrop-saturate',
+  'backdrop-sepia',
+  'border-t',
+  'border-r',
+  'border-b',
+  'border-l',
+  'border-x',
+  'border-y',
+  'rounded-t',
+  'rounded-r',
+  'rounded-b',
+  'rounded-l',
+  'rounded-tl',
+  'rounded-tr',
+  'rounded-br',
+  'rounded-bl',
+  'rounded-s',
+  'rounded-e',
+  'rounded-ss',
+  'rounded-se',
+  'rounded-ee',
+  'rounded-es',
+].sort((a, b) => b.length - a.length)
+
+type ParsedClass = {
+  prefix: string | null
+  variant: string | null
+  utility: string
+  value: string | null
+  isArbitrary: boolean
+  isNegative: boolean
+}
+
+function parseUtilityAndValue(
+  utilityPart: string,
+): Pick<ParsedClass, 'utility' | 'value' | 'isArbitrary' | 'isNegative'> {
+  let isNegative = false
+  let workingPart = utilityPart
+
+  const negativeMatch = workingPart.match(NEGATIVE_PREFIX_PATTERN)
+  if (negativeMatch) {
+    isNegative = true
+    workingPart = negativeMatch[1]
+  }
+
+  const arbitraryMatch = workingPart.match(ARBITRARY_VALUE_PATTERN)
+  if (arbitraryMatch) {
+    return {
+      utility: arbitraryMatch[1],
+      value: arbitraryMatch[2],
+      isArbitrary: true,
+      isNegative,
+    }
+  }
+
+  for (const utility of SINGLE_PART_UTILITIES) {
+    if (workingPart === utility) {
+      return {
+        utility: workingPart,
+        value: null,
+        isArbitrary: false,
+        isNegative,
+      }
+    }
+
+    if (workingPart.startsWith(`${utility}-`)) {
+      return {
+        utility,
+        value: workingPart.substring(utility.length + 1),
+        isArbitrary: false,
+        isNegative,
+      }
+    }
+  }
+
+  return {
+    utility: workingPart,
+    value: null,
+    isArbitrary: false,
+    isNegative,
+  }
+}
+
+function tokenizeClass(className: string): TailwindClassToken {
+  const parts = className.split(':')
+
+  let prefix: string | null = null
+  let variant: string | null = null
+  let utilityPart: string
+
+  if (parts.length === 1) {
+    utilityPart = parts[0]
+  } else if (parts.length === 2) {
+    const firstPart = parts[0]
+
+    if (RESPONSIVE_PREFIXES[firstPart]) {
+      prefix = firstPart
+    } else if (STATE_VARIANTS.includes(firstPart)) {
+      variant = firstPart
+    } else {
+      prefix = firstPart
+    }
+
+    utilityPart = parts[1]
+  } else {
+    prefix = parts[0]
+    variant = parts.slice(1, -1).join(':')
+    utilityPart = parts[parts.length - 1]
+  }
+
+  const { utility, value, isArbitrary, isNegative } =
+    parseUtilityAndValue(utilityPart)
+
+  return {
+    raw: className,
+    prefix,
+    variant,
+    utility,
+    value,
+    isArbitrary,
+    isNegative,
+  }
+}
+
+export function tokenizeTailwindClasses(
+  classString: string | null,
+): TailwindParseResult {
+  const result: TailwindParseResult = {
+    baseClasses: [],
+    responsiveClasses: {
+      mobile: [],
+      tablet: [],
+      desktop: [],
+    },
+    stateClasses: {},
+  }
+
+  if (!classString) {
+    return result
+  }
+
+  const classes = classString.split(/\s+/).filter(Boolean)
+
+  for (const cls of classes) {
+    const token = tokenizeClass(cls)
+
+    if (token.variant) {
+      if (!result.stateClasses[token.variant]) {
+        result.stateClasses[token.variant] = []
+      }
+      result.stateClasses[token.variant].push(token)
+    } else if (token.prefix && RESPONSIVE_PREFIXES[token.prefix]) {
+      const deviceId = RESPONSIVE_PREFIXES[token.prefix]
+      result.responsiveClasses[deviceId].push(token)
+    } else {
+      result.baseClasses.push(token)
+    }
+  }
+
+  return result
+}
+
+export function getTokensByUtility(
+  tokens: TailwindClassToken[],
+  utilityPrefix: string,
+): TailwindClassToken[] {
+  return tokens.filter(
+    (token) =>
+      token.utility === utilityPrefix ||
+      token.utility.startsWith(`${utilityPrefix}-`),
+  )
+}
+
+export function findToken(
+  tokens: TailwindClassToken[],
+  utility: string,
+): TailwindClassToken | undefined {
+  return tokens.find((token) => token.utility === utility)
+}
+
+export function hasUtility(
+  tokens: TailwindClassToken[],
+  utility: string,
+): boolean {
+  return tokens.some(
+    (token) =>
+      token.utility === utility || token.utility.startsWith(`${utility}-`),
+  )
+}

--- a/packages/jsx-to-makeswift/src/transform.ts
+++ b/packages/jsx-to-makeswift/src/transform.ts
@@ -1,0 +1,168 @@
+import { buildSchema, buildSingleSchema } from './controls/schema-builder'
+import { parseJSX, parseJSXFragment } from './parser/jsx-parser'
+import type { ElementSchema, TransformOptions, TransformResult } from './types'
+
+/**
+ * Options for the transformJSX function.
+ *
+ * @property fragment - If true, wraps the input in a fragment before parsing.
+ *                      Use this when the input contains multiple root elements.
+ * @property inferContentControls - If true, infers content control types (TextInput, TextArea, RichText).
+ * @property includeStateVariants - If true, includes hover:, focus:, etc. in metadata.
+ * @property preserveOriginalClasses - If true, stores original Tailwind classes in metadata.
+ */
+export type TransformJSXOptions = TransformOptions & {
+  fragment?: boolean
+}
+
+/**
+ * Result of transforming JSX to Makeswift control schemas.
+ *
+ * @property schemas - Array of generated ElementSchema objects.
+ * @property results - Detailed transform results including warnings and unmapped classes per element.
+ * @property errors - Parse errors that prevented transformation.
+ * @property warnings - Non-fatal warnings during transformation.
+ * @property unmappedClasses - Tailwind classes that could not be mapped to controls.
+ */
+export type TransformJSXResult = {
+  schemas: ElementSchema[]
+  results: TransformResult[]
+  errors: string[]
+  warnings: string[]
+  unmappedClasses: string[]
+}
+
+/**
+ * Transforms JSX source code with Tailwind CSS classes into Makeswift control schemas.
+ *
+ * This is the primary entry point for converting JSX to Makeswift controls.
+ * It parses the JSX, resolves Tailwind classes to CSS properties, and maps
+ * those properties to appropriate Makeswift control types.
+ *
+ * @param source - JSX source code as a string
+ * @param options - Optional configuration for the transformation
+ * @returns TransformJSXResult containing schemas, errors, warnings, and unmapped classes
+ *
+ * @example
+ * ```typescript
+ * import { transformJSX } from '@makeswift/jsx-to-makeswift'
+ *
+ * const jsx = `<div className="m-4 p-6 bg-blue-500">Hello</div>`
+ * const result = transformJSX(jsx)
+ *
+ * console.log(result.schemas[0])
+ * // {
+ * //   type: 'Container',
+ * //   tagName: 'div',
+ * //   controls: {
+ * //     style: { type: 'Style', properties: ['margin', 'padding'], ... },
+ * //     backgroundColor: { type: 'Color', ... },
+ * //     content: { type: 'TextInput', value: 'Hello' }
+ * //   }
+ * // }
+ * ```
+ */
+export function transformJSX(
+  source: string,
+  options: Partial<TransformJSXOptions> = {},
+): TransformJSXResult {
+  const { fragment = false, ...transformOptions } = options
+
+  const parseResult = fragment ? parseJSXFragment(source) : parseJSX(source)
+
+  if (parseResult.errors.length > 0) {
+    return {
+      schemas: [],
+      results: [],
+      errors: parseResult.errors,
+      warnings: [],
+      unmappedClasses: [],
+    }
+  }
+
+  const results = buildSchema(parseResult.elements, transformOptions)
+
+  const schemas = results.map((r) => r.schema)
+  const allWarnings = results.flatMap((r) => r.warnings)
+  const allUnmapped = [...new Set(results.flatMap((r) => r.unmappedClasses))]
+
+  return {
+    schemas,
+    results,
+    errors: [],
+    warnings: allWarnings,
+    unmappedClasses: allUnmapped,
+  }
+}
+
+/**
+ * Transforms a single JSX element to a Makeswift control schema.
+ *
+ * Use this when you have exactly one root element and want a simpler result type.
+ * Returns null if parsing fails or no elements are found.
+ *
+ * @param source - JSX source code containing a single element
+ * @param options - Optional configuration for the transformation
+ * @returns TransformResult or null if transformation failed
+ *
+ * @example
+ * ```typescript
+ * const result = transformJSXElement(`<h1 className="text-2xl">Title</h1>`)
+ * if (result) {
+ *   console.log(result.schema.type) // 'Heading'
+ * }
+ * ```
+ */
+export function transformJSXElement(
+  source: string,
+  options: Partial<TransformOptions> = {},
+): TransformResult | null {
+  const parseResult = parseJSX(source)
+
+  if (parseResult.errors.length > 0 || parseResult.elements.length === 0) {
+    return null
+  }
+
+  return buildSingleSchema(parseResult.elements[0], options)
+}
+
+/**
+ * Transforms JSX to a JSON string representation of Makeswift control schemas.
+ *
+ * This is a convenience function that combines transformJSX with JSON.stringify.
+ * Useful for CLI tools, debugging, or when JSON output is needed directly.
+ *
+ * @param source - JSX source code as a string
+ * @param options - Optional configuration for the transformation
+ * @returns Pretty-printed JSON string of the schema(s) or error object
+ *
+ * @example
+ * ```typescript
+ * const json = transformJSXToJSON(`<div className="p-4">Hello</div>`)
+ * console.log(json)
+ * // {
+ * //   "type": "Container",
+ * //   "tagName": "div",
+ * //   "controls": { ... }
+ * // }
+ * ```
+ */
+export function transformJSXToJSON(
+  source: string,
+  options: Partial<TransformJSXOptions> = {},
+): string {
+  const result = transformJSX(source, options)
+
+  if (result.errors.length > 0) {
+    return JSON.stringify({ errors: result.errors }, null, 2)
+  }
+
+  if (result.schemas.length === 1) {
+    return JSON.stringify(result.schemas[0], null, 2)
+  }
+
+  return JSON.stringify(result.schemas, null, 2)
+}
+
+export { buildSchema, buildSingleSchema } from './controls/schema-builder'
+export { parseJSX, parseJSXFragment } from './parser/jsx-parser'

--- a/packages/jsx-to-makeswift/src/types.ts
+++ b/packages/jsx-to-makeswift/src/types.ts
@@ -1,0 +1,459 @@
+/**
+ * @fileoverview Type definitions and Zod schemas for JSX to Makeswift Controls transformation.
+ *
+ * This module exports all the types and schemas needed to understand and validate
+ * the output of the transformJSX function. AI agents can use these types for
+ * type-safe integration and the Zod schemas for runtime validation.
+ *
+ * @module @makeswift/jsx-to-makeswift/types
+ */
+
+import { z } from 'zod'
+
+/**
+ * Zod schema for valid Makeswift control types.
+ *
+ * Use this to validate that a control type string is valid.
+ */
+export const ControlTypeSchema = z.enum([
+  'Style',
+  'Color',
+  'Typography',
+  'TextInput',
+  'TextArea',
+  'RichText',
+  'Number',
+  'Checkbox',
+  'Select',
+  'Image',
+  'Link',
+  'List',
+  'Shape',
+  'Group',
+  'Slot',
+])
+
+/**
+ * All valid Makeswift control types.
+ *
+ * - Style: CSS styling properties (margin, padding, layout, etc.)
+ * - Color: Color values with alpha channel
+ * - Typography: Font properties (size, weight, family, etc.)
+ * - TextInput: Single-line text content
+ * - TextArea: Multi-line text content
+ * - RichText: Formatted text with inline elements
+ * - Image: Image with src, alt, dimensions
+ * - Link: URL/navigation with href and target
+ * - Slot: Container for nested elements
+ */
+export type ControlType = z.infer<typeof ControlTypeSchema>
+
+/**
+ * Zod schema for Makeswift device IDs.
+ *
+ * Makeswift uses a 3-device responsive model:
+ * - mobile: Base styles (no Tailwind prefix)
+ * - tablet: Tailwind sm: prefix (640px+)
+ * - desktop: Tailwind md:/lg:/xl:/2xl: prefixes (768px+)
+ */
+export const DeviceIdSchema = z.enum([
+  'mobile',
+  'tablet',
+  'desktop',
+])
+
+/**
+ * Valid device identifiers for responsive values.
+ *
+ * - mobile: Base styles, applies to all screen sizes
+ * - tablet: Applies at 640px and above
+ * - desktop: Applies at 768px and above
+ */
+export type DeviceId = z.infer<typeof DeviceIdSchema>
+
+/**
+ * A value override for a specific device.
+ *
+ * @template T - The type of the value being overridden
+ */
+export type DeviceOverride<T> = {
+  deviceId: DeviceId
+  value: T
+}
+
+/**
+ * An array of device-specific value overrides.
+ *
+ * Values cascade from mobile → tablet → desktop.
+ * Each entry specifies a value for a specific device.
+ *
+ * @template T - The type of the responsive value
+ *
+ * @example
+ * ```typescript
+ * const padding: ResponsiveValue<string> = [
+ *   { deviceId: 'mobile', value: '1rem' },
+ *   { deviceId: 'tablet', value: '1.5rem' },
+ *   { deviceId: 'desktop', value: '2rem' }
+ * ]
+ * ```
+ */
+export type ResponsiveValue<T> = DeviceOverride<T>[]
+
+/**
+ * CSS properties that can be controlled by the Style control.
+ */
+export type StyleProperty =
+  | 'margin'
+  | 'marginTop'
+  | 'marginRight'
+  | 'marginBottom'
+  | 'marginLeft'
+  | 'padding'
+  | 'paddingTop'
+  | 'paddingRight'
+  | 'paddingBottom'
+  | 'paddingLeft'
+  | 'width'
+  | 'height'
+  | 'minWidth'
+  | 'minHeight'
+  | 'maxWidth'
+  | 'maxHeight'
+  | 'gap'
+  | 'rowGap'
+  | 'columnGap'
+  | 'display'
+  | 'flexDirection'
+  | 'justifyContent'
+  | 'alignItems'
+  | 'flexWrap'
+  | 'position'
+  | 'top'
+  | 'right'
+  | 'bottom'
+  | 'left'
+  | 'zIndex'
+  | 'overflow'
+  | 'borderWidth'
+  | 'borderRadius'
+  | 'borderStyle'
+  | 'boxShadow'
+  | 'opacity'
+
+/**
+ * Style control value containing CSS properties.
+ *
+ * Maps Tailwind classes like m-4, p-6, flex, rounded-lg to CSS properties.
+ */
+export type StyleControlValue = {
+  type: 'Style'
+  /** List of CSS properties this control manages */
+  properties: StyleProperty[]
+  /** Responsive CSS values */
+  value: ResponsiveValue<Record<string, string | number>>
+}
+
+/**
+ * Color control value for text, background, or border colors.
+ *
+ * Maps Tailwind color classes like text-blue-500, bg-gray-100.
+ */
+export type ColorControlValue = {
+  type: 'Color'
+  /** Which color property this control manages */
+  property: 'textColor' | 'backgroundColor' | 'borderColor'
+  /** Responsive color values with hex color and alpha */
+  value: ResponsiveValue<{ color: string; alpha: number }>
+}
+
+/**
+ * Typography control value for font properties.
+ *
+ * Maps Tailwind classes like text-xl, font-bold, leading-relaxed.
+ */
+export type TypographyControlValue = {
+  type: 'Typography'
+  /** Responsive typography values */
+  value: ResponsiveValue<{
+    fontFamily?: string
+    fontSize?: string
+    fontWeight?: number
+    lineHeight?: string
+    letterSpacing?: string
+    textAlign?: string
+    textTransform?: string
+    textDecoration?: string
+    fontStyle?: string
+  }>
+}
+
+/**
+ * Single-line text input control.
+ *
+ * Used for short text content like headings, labels, button text.
+ */
+export type TextInputControlValue = {
+  type: 'TextInput'
+  /** The text content */
+  value: string
+}
+
+/**
+ * Multi-line text area control.
+ *
+ * Used for longer text content like paragraphs, descriptions.
+ */
+export type TextAreaControlValue = {
+  type: 'TextArea'
+  /** The text content */
+  value: string
+}
+
+/**
+ * Rich text control for formatted content.
+ *
+ * Used when content contains inline formatting (bold, italic, links).
+ */
+export type RichTextControlValue = {
+  type: 'RichText'
+  /** The text content (may contain inline HTML) */
+  value: string
+}
+
+/**
+ * Number control for numeric values.
+ */
+export type NumberControlValue = {
+  type: 'Number'
+  value: number
+}
+
+/**
+ * Checkbox control for boolean values.
+ */
+export type CheckboxControlValue = {
+  type: 'Checkbox'
+  value: boolean
+}
+
+/**
+ * Image control for image elements.
+ *
+ * Extracted from <img> elements with src, alt, width, height attributes.
+ */
+export type ImageControlValue = {
+  type: 'Image'
+  value: {
+    /** Image source URL */
+    src: string
+    /** Alt text for accessibility */
+    alt?: string
+    /** Image width in pixels */
+    width?: number
+    /** Image height in pixels */
+    height?: number
+  }
+}
+
+/**
+ * Link control for anchor elements.
+ *
+ * Extracted from <a> elements with href and target attributes.
+ */
+export type LinkControlValue = {
+  type: 'Link'
+  value: {
+    /** Link destination URL */
+    href: string
+    /** Link target (_blank, _self, etc.) */
+    target?: string
+  }
+}
+
+/**
+ * List control for repeating elements.
+ */
+export type ListControlValue = {
+  type: 'List'
+  /** Template for list items */
+  itemType: ControlValue
+  /** Array of list item values */
+  items: ControlValue[]
+}
+
+/**
+ * Slot control for nested child elements.
+ *
+ * Contains an array of child ElementSchema objects.
+ */
+export type SlotControlValue = {
+  type: 'Slot'
+  /** Nested element schemas */
+  elements: ElementSchema[]
+}
+
+/**
+ * Union type of all possible control values.
+ *
+ * Each control value has a `type` field that discriminates the union.
+ */
+export type ControlValue =
+  | StyleControlValue
+  | ColorControlValue
+  | TypographyControlValue
+  | TextInputControlValue
+  | TextAreaControlValue
+  | RichTextControlValue
+  | NumberControlValue
+  | CheckboxControlValue
+  | ImageControlValue
+  | LinkControlValue
+  | ListControlValue
+  | SlotControlValue
+
+/**
+ * The main output schema for a transformed JSX element.
+ *
+ * This represents a single element in the Makeswift page structure.
+ *
+ * @example
+ * ```typescript
+ * const schema: ElementSchema = {
+ *   type: 'Container',
+ *   tagName: 'div',
+ *   controls: {
+ *     style: { type: 'Style', properties: ['margin'], value: [...] },
+ *     content: { type: 'TextInput', value: 'Hello World' }
+ *   },
+ *   children: { type: 'Slot', elements: [...] }
+ * }
+ * ```
+ */
+export type ElementSchema = {
+  /** Inferred element type (Container, Heading, Paragraph, Button, Image, Link, etc.) */
+  type: string
+  /** Original HTML tag name (div, h1, p, button, img, a, etc.) */
+  tagName: string
+  /** Map of control names to control values */
+  controls: Record<string, ControlValue>
+  /** Child elements wrapped in a Slot control */
+  children?: SlotControlValue
+  /** Optional metadata about the transformation */
+  metadata?: {
+    /** Original Tailwind className string */
+    originalClassName?: string
+    /** State variant classes grouped by variant (hover, focus, etc.) */
+    stateVariants?: Record<string, string[]>
+  }
+}
+
+/**
+ * Internal representation of a parsed JSX element.
+ */
+export type ParsedJSXElement = {
+  tagName: string
+  className: string | null
+  attributes: Record<string, unknown>
+  textContent: string | null
+  children: ParsedJSXElement[]
+  hasRichContent: boolean
+}
+
+/**
+ * Token representing a parsed Tailwind class.
+ */
+export type TailwindClassToken = {
+  /** Original class string */
+  raw: string
+  /** Responsive prefix (sm, md, lg, xl, 2xl) or null */
+  prefix: string | null
+  /** State variant (hover, focus, etc.) or null */
+  variant: string | null
+  /** Utility name (m, p, bg, text, flex, etc.) */
+  utility: string
+  /** Utility value (4, blue-500, center, etc.) or null */
+  value: string | null
+  /** Whether value is arbitrary (e.g., w-[300px]) */
+  isArbitrary: boolean
+  /** Whether value is negative (e.g., -mt-4) */
+  isNegative: boolean
+}
+
+/**
+ * Result of parsing Tailwind classes from a className string.
+ */
+export type TailwindParseResult = {
+  /** Base classes without responsive or state prefixes */
+  baseClasses: TailwindClassToken[]
+  /** Classes grouped by device ID */
+  responsiveClasses: Record<DeviceId, TailwindClassToken[]>
+  /** Classes grouped by state variant */
+  stateClasses: Record<string, TailwindClassToken[]>
+}
+
+/**
+ * Options for controlling the transformation process.
+ */
+export type TransformOptions = {
+  /** Infer content control types (TextInput, TextArea, RichText) */
+  inferContentControls?: boolean
+  /** Include hover:, focus:, etc. in metadata */
+  includeStateVariants?: boolean
+  /** Preserve original className in metadata */
+  preserveOriginalClasses?: boolean
+}
+
+/**
+ * Result of transforming a single element.
+ */
+export type TransformResult = {
+  /** The generated schema for this element */
+  schema: ElementSchema
+  /** Non-fatal warnings during transformation */
+  warnings: string[]
+  /** Tailwind classes that could not be mapped */
+  unmappedClasses: string[]
+}
+
+/**
+ * Zod schema for validating StyleProperty strings.
+ */
+export const StylePropertySchema = z.enum([
+  'margin',
+  'marginTop',
+  'marginRight',
+  'marginBottom',
+  'marginLeft',
+  'padding',
+  'paddingTop',
+  'paddingRight',
+  'paddingBottom',
+  'paddingLeft',
+  'width',
+  'height',
+  'minWidth',
+  'minHeight',
+  'maxWidth',
+  'maxHeight',
+  'gap',
+  'rowGap',
+  'columnGap',
+  'display',
+  'flexDirection',
+  'justifyContent',
+  'alignItems',
+  'flexWrap',
+  'position',
+  'top',
+  'right',
+  'bottom',
+  'left',
+  'zIndex',
+  'overflow',
+  'borderWidth',
+  'borderRadius',
+  'borderStyle',
+  'boxShadow',
+  'opacity',
+])

--- a/packages/jsx-to-makeswift/src/utils/device-prefixes.ts
+++ b/packages/jsx-to-makeswift/src/utils/device-prefixes.ts
@@ -1,0 +1,29 @@
+import type { DeviceId } from '../types'
+
+/**
+ * Maps Makeswift device IDs to Tailwind responsive prefixes.
+ *
+ * - mobile: no prefix (base styles)
+ * - tablet: sm: prefix (640px+)
+ * - desktop: lg: prefix (1024px+)
+ */
+export const DEVICE_TO_PREFIX: Record<DeviceId, string> = {
+  mobile: '',
+  tablet: 'sm:',
+  desktop: 'lg:',
+}
+
+/**
+ * Adds a responsive prefix to a Tailwind class based on device ID.
+ */
+export function addDevicePrefix(cls: string, deviceId: DeviceId | string): string {
+  const prefix = DEVICE_TO_PREFIX[deviceId as DeviceId] || ''
+  return `${prefix}${cls}`
+}
+
+/**
+ * Gets the responsive prefix for a device ID.
+ */
+export function getDevicePrefix(deviceId: DeviceId | string): string {
+  return DEVICE_TO_PREFIX[deviceId as DeviceId] || ''
+}

--- a/packages/jsx-to-makeswift/src/utils/index.ts
+++ b/packages/jsx-to-makeswift/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './responsive-value'

--- a/packages/jsx-to-makeswift/src/utils/index.ts
+++ b/packages/jsx-to-makeswift/src/utils/index.ts
@@ -1,1 +1,2 @@
+export * from './device-prefixes'
 export * from './responsive-value'

--- a/packages/jsx-to-makeswift/src/utils/responsive-value.ts
+++ b/packages/jsx-to-makeswift/src/utils/responsive-value.ts
@@ -1,0 +1,288 @@
+import type {
+  DeviceId,
+  DeviceOverride,
+  ResponsiveValue,
+  TailwindClassToken,
+  TailwindParseResult,
+} from '../types'
+
+import {
+  groupByCategory,
+  resolveTokens,
+  type ResolvedCSSProperty,
+} from '../tailwind/mapping'
+
+const DEVICE_ORDER: DeviceId[] = [
+  'mobile',
+  'tablet',
+  'desktop',
+]
+
+const BREAKPOINT_PRIORITY: Record<string, number> = {
+  sm: 1,
+  md: 2,
+  lg: 3,
+  xl: 4,
+  '2xl': 5,
+}
+
+function sortTokensByBreakpointPriority(
+  tokens: TailwindClassToken[],
+): TailwindClassToken[] {
+  return [...tokens].sort((a, b) => {
+    const priorityA = a.prefix ? (BREAKPOINT_PRIORITY[a.prefix] ?? 0) : 0
+    const priorityB = b.prefix ? (BREAKPOINT_PRIORITY[b.prefix] ?? 0) : 0
+    return priorityA - priorityB
+  })
+}
+
+export type ResponsiveStyleValue = ResponsiveValue<Record<string, string | number>>
+
+export type ResponsiveColorValue = ResponsiveValue<{
+  color: string
+  alpha: number
+  colorName?: string
+  colorShade?: string | null
+}>
+
+export type ResponsiveTypographyValue = ResponsiveValue<{
+  fontFamily?: string
+  fontSize?: string
+  fontWeight?: number
+  lineHeight?: string
+  letterSpacing?: string
+  textAlign?: string
+  textTransform?: string
+  textDecoration?: string
+  fontStyle?: string
+}>
+
+type CategorizedResponsiveValues = {
+  style: ResponsiveStyleValue
+  colors: {
+    textColor?: ResponsiveColorValue
+    backgroundColor?: ResponsiveColorValue
+    borderColor?: ResponsiveColorValue
+  }
+  typography: ResponsiveTypographyValue
+}
+
+function propertiesToRecord(
+  properties: ResolvedCSSProperty[],
+): Record<string, string | number> {
+  const result: Record<string, string | number> = {}
+
+  for (const prop of properties) {
+    result[prop.property] = prop.value
+  }
+
+  return result
+}
+
+function propertiesToTypography(
+  properties: ResolvedCSSProperty[],
+): ResponsiveTypographyValue[number]['value'] {
+  const result: ResponsiveTypographyValue[number]['value'] = {}
+
+  for (const prop of properties) {
+    switch (prop.property) {
+      case 'fontFamily':
+        result.fontFamily = String(prop.value)
+        break
+      case 'fontSize':
+        result.fontSize = String(prop.value)
+        break
+      case 'fontWeight':
+        result.fontWeight = Number(prop.value)
+        break
+      case 'lineHeight':
+        result.lineHeight = String(prop.value)
+        break
+      case 'letterSpacing':
+        result.letterSpacing = String(prop.value)
+        break
+      case 'textAlign':
+        result.textAlign = String(prop.value)
+        break
+      case 'textTransform':
+        result.textTransform = String(prop.value)
+        break
+      case 'textDecoration':
+        result.textDecoration = String(prop.value)
+        break
+      case 'fontStyle':
+        result.fontStyle = String(prop.value)
+        break
+    }
+  }
+
+  return result
+}
+
+export function buildResponsiveValues(
+  parseResult: TailwindParseResult,
+): CategorizedResponsiveValues {
+  const style: ResponsiveStyleValue = []
+  const colors: CategorizedResponsiveValues['colors'] = {}
+  const typography: ResponsiveTypographyValue = []
+
+  const baseResolution = resolveTokens(parseResult.baseClasses)
+  const baseGrouped = groupByCategory(baseResolution.resolved)
+
+  const baseStyleProps = [
+    ...baseGrouped.spacing,
+    ...baseGrouped.sizing,
+    ...baseGrouped.layout,
+    ...baseGrouped.border,
+  ]
+
+  if (baseStyleProps.length > 0) {
+    style.push({
+      deviceId: 'mobile',
+      value: propertiesToRecord(baseStyleProps),
+    })
+  }
+
+  for (const colorProp of baseGrouped.color) {
+    const colorValue = {
+      color: String(colorProp.value),
+      alpha: 1,
+      colorName: colorProp.colorName,
+      colorShade: colorProp.colorShade,
+    }
+
+    switch (colorProp.property) {
+      case 'color':
+        if (!colors.textColor) colors.textColor = []
+        colors.textColor.push({ deviceId: 'mobile', value: colorValue })
+        break
+      case 'backgroundColor':
+        if (!colors.backgroundColor) colors.backgroundColor = []
+        colors.backgroundColor.push({ deviceId: 'mobile', value: colorValue })
+        break
+      case 'borderColor':
+        if (!colors.borderColor) colors.borderColor = []
+        colors.borderColor.push({ deviceId: 'mobile', value: colorValue })
+        break
+    }
+  }
+
+  if (baseGrouped.typography.length > 0) {
+    typography.push({
+      deviceId: 'mobile',
+      value: propertiesToTypography(baseGrouped.typography),
+    })
+  }
+
+  for (const deviceId of DEVICE_ORDER) {
+    if (deviceId === 'mobile') continue
+
+    const deviceTokens = parseResult.responsiveClasses[deviceId]
+    if (deviceTokens.length === 0) continue
+
+    const sortedTokens = sortTokensByBreakpointPriority(deviceTokens)
+
+    const deviceResolution = resolveTokens(sortedTokens)
+    const deviceGrouped = groupByCategory(deviceResolution.resolved)
+
+    const deviceStyleProps = [
+      ...deviceGrouped.spacing,
+      ...deviceGrouped.sizing,
+      ...deviceGrouped.layout,
+      ...deviceGrouped.border,
+    ]
+
+    if (deviceStyleProps.length > 0) {
+      style.push({
+        deviceId,
+        value: propertiesToRecord(deviceStyleProps),
+      })
+    }
+
+    const deviceColors: Record<string, { color: string; alpha: number; colorName?: string; colorShade?: string | null }> = {}
+
+    for (const colorProp of deviceGrouped.color) {
+      deviceColors[colorProp.property] = {
+        color: String(colorProp.value),
+        alpha: 1,
+        colorName: colorProp.colorName,
+        colorShade: colorProp.colorShade,
+      }
+    }
+
+    if (deviceColors['color']) {
+      if (!colors.textColor) colors.textColor = []
+      colors.textColor.push({ deviceId, value: deviceColors['color'] })
+    }
+    if (deviceColors['backgroundColor']) {
+      if (!colors.backgroundColor) colors.backgroundColor = []
+      colors.backgroundColor.push({ deviceId, value: deviceColors['backgroundColor'] })
+    }
+    if (deviceColors['borderColor']) {
+      if (!colors.borderColor) colors.borderColor = []
+      colors.borderColor.push({ deviceId, value: deviceColors['borderColor'] })
+    }
+
+    if (deviceGrouped.typography.length > 0) {
+      typography.push({
+        deviceId,
+        value: propertiesToTypography(deviceGrouped.typography),
+      })
+    }
+  }
+
+  return { style, colors, typography }
+}
+
+export function mergeResponsiveValues<T>(
+  base: ResponsiveValue<T>,
+  override: ResponsiveValue<T>,
+  merger: (a: T, b: T) => T,
+): ResponsiveValue<T> {
+  const result: ResponsiveValue<T> = [...base]
+
+  for (const overrideItem of override) {
+    const existingIndex = result.findIndex(
+      (item) => item.deviceId === overrideItem.deviceId,
+    )
+
+    if (existingIndex >= 0) {
+      result[existingIndex] = {
+        deviceId: overrideItem.deviceId,
+        value: merger(result[existingIndex].value, overrideItem.value),
+      }
+    } else {
+      result.push(overrideItem)
+    }
+  }
+
+  return result.sort(
+    (a, b) => DEVICE_ORDER.indexOf(a.deviceId) - DEVICE_ORDER.indexOf(b.deviceId),
+  )
+}
+
+export function getValueForDevice<T>(
+  responsiveValue: ResponsiveValue<T>,
+  deviceId: DeviceId,
+): T | undefined {
+  const deviceIndex = DEVICE_ORDER.indexOf(deviceId)
+
+  for (let i = deviceIndex; i >= 0; i--) {
+    const device = DEVICE_ORDER[i]
+    const value = responsiveValue.find((v) => v.deviceId === device)
+    if (value) return value.value
+  }
+
+  return undefined
+}
+
+export function hasResponsiveValues<T>(value: ResponsiveValue<T>): boolean {
+  return value.length > 1
+}
+
+export function createDeviceOverride<T>(
+  deviceId: DeviceId,
+  value: T,
+): DeviceOverride<T> {
+  return { deviceId, value }
+}

--- a/packages/jsx-to-makeswift/tsconfig.json
+++ b/packages/jsx-to-makeswift/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "isolatedModules": true,
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ESNext", "DOM"],
+    "moduleResolution": "Node",
+    "strict": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "rootDir": "src",
+    "declarationDir": "dist/types",
+    "emitDeclarationOnly": true
+  },
+  "include": ["src"]
+}

--- a/packages/jsx-to-makeswift/tsup.config.ts
+++ b/packages/jsx-to-makeswift/tsup.config.ts
@@ -1,0 +1,50 @@
+import { defineConfig, Options } from 'tsup'
+
+export default defineConfig(() => {
+  const commonOptions = {
+    entry: [
+      'src/**/*.ts',
+      '!src/**/*.test.ts',
+      '!src/**/__tests__/**',
+      '!src/cli.ts',
+    ],
+    bundle: false,
+    minify: false,
+    sourcemap: true,
+    legacyOutput: true,
+    esbuildOptions(options, { format }) {
+      if (format === 'cjs')
+        options.supported = { ...options.supported, 'dynamic-import': false }
+    },
+  } satisfies Options
+
+  const esmOptions: Options = {
+    ...commonOptions,
+    entry: [...commonOptions.entry],
+    format: 'esm',
+  }
+
+  const cjsOptions: Options = {
+    ...commonOptions,
+    format: 'cjs',
+    outDir: 'dist/cjs',
+  }
+
+  const cliOptions: Options = {
+    entry: ['src/cli.ts'],
+    outDir: 'dist',
+    format: 'cjs',
+    bundle: true,
+    minify: false,
+    sourcemap: false,
+    platform: 'node',
+    target: 'node18',
+    banner: {
+      js: '#!/usr/bin/env node',
+    },
+    noExternal: [/.*/],
+    external: ['fs', 'path'],
+  }
+
+  return [esmOptions, cjsOptions, cliOptions]
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,6 +263,49 @@ importers:
         specifier: ^5.9.2
         version: 5.9.2
 
+  packages/jsx-to-makeswift:
+    dependencies:
+      '@babel/parser':
+        specifier: ^7.24.0
+        version: 7.28.0
+      '@babel/traverse':
+        specifier: ^7.24.0
+        version: 7.28.0
+      '@babel/types':
+        specifier: ^7.24.0
+        version: 7.28.2
+      '@makeswift/controls':
+        specifier: workspace:*
+        version: link:../controls
+      zod:
+        specifier: ^3.21.4
+        version: 3.21.4
+    devDependencies:
+      '@ianvs/prettier-plugin-sort-imports':
+        specifier: ^4.3.1
+        version: 4.3.1(prettier@3.6.2)
+      '@swc/jest':
+        specifier: ^0.2.36
+        version: 0.2.36(@swc/core@1.7.0(@swc/helpers@0.5.15))
+      '@types/babel__traverse':
+        specifier: ^7.20.5
+        version: 7.28.0
+      '@types/jest':
+        specifier: ^29.5.12
+        version: 29.5.12
+      concurrently:
+        specifier: ^8.2.2
+        version: 8.2.2
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.7.0(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.9.2))
+      tsup:
+        specifier: ^8.0.2
+        version: 8.0.2(@swc/core@1.7.0(@swc/helpers@0.5.15))(postcss@8.5.3)(ts-node@10.9.2(@swc/core@1.7.0(@swc/helpers@0.5.15))(@types/node@20.14.11)(typescript@5.9.2))(typescript@5.9.2)
+      typescript:
+        specifier: ^5.1.6
+        version: 5.9.2
+
   packages/makeswift:
     dependencies:
       '@babel/core':
@@ -719,10 +762,6 @@ packages:
     resolution: {integrity: sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/code-frame@7.24.2':
-    resolution: {integrity: sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/code-frame@7.24.7':
     resolution: {integrity: sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==}
     engines: {node: '>=6.9.0'}
@@ -865,24 +904,12 @@ packages:
     resolution: {integrity: sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.24.8':
-    resolution: {integrity: sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-identifier@7.18.6':
-    resolution: {integrity: sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-validator-identifier@7.22.20':
     resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.24.7':
-    resolution: {integrity: sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.27.1':
@@ -916,11 +943,6 @@ packages:
   '@babel/highlight@7.24.7':
     resolution: {integrity: sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.21.9':
-    resolution: {integrity: sha512-q5PNg/Bi1OpGgx5jYlvWZwAorZepEudDMCLtj967aeS7WMont7dUZI46M2XwcIQqvUlMxWfdLFu4S/qSxeUu5g==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   '@babel/parser@7.24.8':
     resolution: {integrity: sha512-WzfbgXOkGzZiXXCqk43kKwZjzwx4oulxZi3nq2TYL9mOjQv6kYwul9mz6ID36njuL7Xkp6nJEfok848Zj10j/w==}
@@ -2812,6 +2834,9 @@ packages:
 
   '@types/babel__traverse@7.18.1':
     resolution: {integrity: sha512-FSdLaZh2UxaMuLp9lixWaHq/golWTRWOnRsAXzDTDSDOQLuZb1nsdCt6pJSPWSEQt2eFZ2YVk3oYhn+1kLMeMA==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
@@ -6712,9 +6737,6 @@ packages:
   picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
 
-  picocolors@1.0.1:
-    resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
-
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -8444,11 +8466,11 @@ snapshots:
   '@ardatan/relay-compiler@12.0.0(graphql@16.3.0)':
     dependencies:
       '@babel/core': 7.24.9
-      '@babel/generator': 7.24.10
-      '@babel/parser': 7.24.8
+      '@babel/generator': 7.28.0
+      '@babel/parser': 7.28.0
       '@babel/runtime': 7.28.2
-      '@babel/traverse': 7.24.8
-      '@babel/types': 7.24.9
+      '@babel/traverse': 7.28.0
+      '@babel/types': 7.28.2
       babel-preset-fbjs: 3.4.0(@babel/core@7.24.9)
       chalk: 4.1.2
       fb-watchman: 2.0.1
@@ -8482,15 +8504,10 @@ snapshots:
       '@babel/highlight': 7.23.4
       chalk: 2.4.2
 
-  '@babel/code-frame@7.24.2':
-    dependencies:
-      '@babel/highlight': 7.24.7
-      picocolors: 1.1.1
-
   '@babel/code-frame@7.24.7':
     dependencies:
       '@babel/highlight': 7.24.7
-      picocolors: 1.0.1
+      picocolors: 1.1.1
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -8510,10 +8527,10 @@ snapshots:
       '@babel/helper-compilation-targets': 7.18.9(@babel/core@7.18.13)
       '@babel/helper-module-transforms': 7.18.9
       '@babel/helpers': 7.18.9
-      '@babel/parser': 7.21.9
+      '@babel/parser': 7.28.0
       '@babel/template': 7.18.10
-      '@babel/traverse': 7.18.13
-      '@babel/types': 7.23.0
+      '@babel/traverse': 7.28.0
+      '@babel/types': 7.28.2
       convert-source-map: 1.8.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
@@ -8530,10 +8547,10 @@ snapshots:
       '@babel/helper-compilation-targets': 7.24.8
       '@babel/helper-module-transforms': 7.24.9(@babel/core@7.24.9)
       '@babel/helpers': 7.24.8
-      '@babel/parser': 7.24.8
+      '@babel/parser': 7.28.0
       '@babel/template': 7.24.7
-      '@babel/traverse': 7.24.8
-      '@babel/types': 7.24.9
+      '@babel/traverse': 7.28.0
+      '@babel/types': 7.28.2
       convert-source-map: 2.0.0
       debug: 4.4.1
       gensync: 1.0.0-beta.2
@@ -8544,13 +8561,13 @@ snapshots:
 
   '@babel/generator@7.18.13':
     dependencies:
-      '@babel/types': 7.23.0
+      '@babel/types': 7.28.2
       '@jridgewell/gen-mapping': 0.3.2
       jsesc: 2.5.2
 
   '@babel/generator@7.24.10':
     dependencies:
-      '@babel/types': 7.24.9
+      '@babel/types': 7.28.2
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 2.5.2
@@ -8565,7 +8582,7 @@ snapshots:
 
   '@babel/helper-annotate-as-pure@7.16.7':
     dependencies:
-      '@babel/types': 7.24.9
+      '@babel/types': 7.28.2
 
   '@babel/helper-compilation-targets@7.18.9(@babel/core@7.18.13)':
     dependencies:
@@ -8600,35 +8617,35 @@ snapshots:
 
   '@babel/helper-environment-visitor@7.24.7':
     dependencies:
-      '@babel/types': 7.24.9
+      '@babel/types': 7.28.2
 
   '@babel/helper-function-name@7.18.9':
     dependencies:
       '@babel/template': 7.18.10
-      '@babel/types': 7.23.0
+      '@babel/types': 7.28.2
 
   '@babel/helper-function-name@7.24.7':
     dependencies:
-      '@babel/template': 7.24.7
-      '@babel/types': 7.24.9
+      '@babel/template': 7.27.2
+      '@babel/types': 7.28.2
 
   '@babel/helper-globals@7.28.0': {}
 
   '@babel/helper-hoist-variables@7.18.6':
     dependencies:
-      '@babel/types': 7.23.0
+      '@babel/types': 7.28.2
 
   '@babel/helper-hoist-variables@7.24.7':
     dependencies:
-      '@babel/types': 7.24.9
+      '@babel/types': 7.28.2
 
   '@babel/helper-member-expression-to-functions@7.17.7':
     dependencies:
-      '@babel/types': 7.24.9
+      '@babel/types': 7.28.2
 
   '@babel/helper-module-imports@7.18.6':
     dependencies:
-      '@babel/types': 7.24.9
+      '@babel/types': 7.28.2
 
   '@babel/helper-module-imports@7.27.1':
     dependencies:
@@ -8643,10 +8660,10 @@ snapshots:
       '@babel/helper-module-imports': 7.18.6
       '@babel/helper-simple-access': 7.18.6
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/helper-validator-identifier': 7.18.6
+      '@babel/helper-validator-identifier': 7.27.1
       '@babel/template': 7.18.10
-      '@babel/traverse': 7.18.13
-      '@babel/types': 7.23.0
+      '@babel/traverse': 7.28.0
+      '@babel/types': 7.28.2
     transitivePeerDependencies:
       - supports-color
 
@@ -8657,13 +8674,13 @@ snapshots:
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-simple-access': 7.24.7
       '@babel/helper-split-export-declaration': 7.24.7
-      '@babel/helper-validator-identifier': 7.24.7
+      '@babel/helper-validator-identifier': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-optimise-call-expression@7.16.7':
     dependencies:
-      '@babel/types': 7.24.9
+      '@babel/types': 7.28.2
 
   '@babel/helper-plugin-utils@7.18.9': {}
 
@@ -8672,45 +8689,39 @@ snapshots:
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-member-expression-to-functions': 7.17.7
       '@babel/helper-optimise-call-expression': 7.16.7
-      '@babel/traverse': 7.24.8
-      '@babel/types': 7.24.9
+      '@babel/traverse': 7.28.0
+      '@babel/types': 7.28.2
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-simple-access@7.18.6':
     dependencies:
-      '@babel/types': 7.24.9
+      '@babel/types': 7.28.2
 
   '@babel/helper-simple-access@7.24.7':
     dependencies:
-      '@babel/traverse': 7.24.8
-      '@babel/types': 7.24.9
+      '@babel/traverse': 7.28.0
+      '@babel/types': 7.28.2
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.16.0':
     dependencies:
-      '@babel/types': 7.24.9
+      '@babel/types': 7.28.2
 
   '@babel/helper-split-export-declaration@7.18.6':
     dependencies:
-      '@babel/types': 7.23.0
+      '@babel/types': 7.28.2
 
   '@babel/helper-split-export-declaration@7.24.7':
     dependencies:
-      '@babel/types': 7.24.9
+      '@babel/types': 7.28.2
 
   '@babel/helper-string-parser@7.22.5': {}
 
-  '@babel/helper-string-parser@7.24.8': {}
-
   '@babel/helper-string-parser@7.27.1': {}
 
-  '@babel/helper-validator-identifier@7.18.6': {}
-
   '@babel/helper-validator-identifier@7.22.20': {}
-
-  '@babel/helper-validator-identifier@7.24.7': {}
 
   '@babel/helper-validator-identifier@7.27.1': {}
 
@@ -8721,42 +8732,38 @@ snapshots:
   '@babel/helpers@7.18.9':
     dependencies:
       '@babel/template': 7.18.10
-      '@babel/traverse': 7.18.13
-      '@babel/types': 7.23.0
+      '@babel/traverse': 7.28.0
+      '@babel/types': 7.28.2
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helpers@7.24.8':
     dependencies:
-      '@babel/template': 7.24.7
-      '@babel/types': 7.24.9
+      '@babel/template': 7.27.2
+      '@babel/types': 7.28.2
 
   '@babel/highlight@7.18.6':
     dependencies:
-      '@babel/helper-validator-identifier': 7.24.7
+      '@babel/helper-validator-identifier': 7.27.1
       chalk: 2.4.2
       js-tokens: 4.0.0
 
   '@babel/highlight@7.23.4':
     dependencies:
-      '@babel/helper-validator-identifier': 7.24.7
+      '@babel/helper-validator-identifier': 7.27.1
       chalk: 2.4.2
       js-tokens: 4.0.0
 
   '@babel/highlight@7.24.7':
     dependencies:
-      '@babel/helper-validator-identifier': 7.24.7
+      '@babel/helper-validator-identifier': 7.27.1
       chalk: 2.4.2
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/parser@7.21.9':
-    dependencies:
-      '@babel/types': 7.23.0
-
   '@babel/parser@7.24.8':
     dependencies:
-      '@babel/types': 7.24.9
+      '@babel/types': 7.28.2
 
   '@babel/parser@7.28.0':
     dependencies:
@@ -9033,7 +9040,7 @@ snapshots:
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-plugin-utils': 7.18.9
       '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.24.9)
-      '@babel/types': 7.24.9
+      '@babel/types': 7.28.2
     transitivePeerDependencies:
       - supports-color
 
@@ -9064,14 +9071,14 @@ snapshots:
   '@babel/template@7.18.10':
     dependencies:
       '@babel/code-frame': 7.18.6
-      '@babel/parser': 7.21.9
-      '@babel/types': 7.23.0
+      '@babel/parser': 7.28.0
+      '@babel/types': 7.28.2
 
   '@babel/template@7.24.7':
     dependencies:
-      '@babel/code-frame': 7.24.7
-      '@babel/parser': 7.24.8
-      '@babel/types': 7.24.9
+      '@babel/code-frame': 7.27.1
+      '@babel/parser': 7.28.0
+      '@babel/types': 7.28.2
 
   '@babel/template@7.27.2':
     dependencies:
@@ -9087,8 +9094,8 @@ snapshots:
       '@babel/helper-function-name': 7.18.9
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.21.9
-      '@babel/types': 7.23.0
+      '@babel/parser': 7.28.0
+      '@babel/types': 7.28.2
       debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
@@ -9102,8 +9109,8 @@ snapshots:
       '@babel/helper-function-name': 7.24.7
       '@babel/helper-hoist-variables': 7.24.7
       '@babel/helper-split-export-declaration': 7.24.7
-      '@babel/parser': 7.24.8
-      '@babel/types': 7.24.9
+      '@babel/parser': 7.28.0
+      '@babel/types': 7.28.2
       debug: 4.4.1
       globals: 11.12.0
     transitivePeerDependencies:
@@ -9129,8 +9136,8 @@ snapshots:
 
   '@babel/types@7.24.9':
     dependencies:
-      '@babel/helper-string-parser': 7.24.8
-      '@babel/helper-validator-identifier': 7.24.7
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
       to-fast-properties: 2.0.0
 
   '@babel/types@7.28.2':
@@ -9819,9 +9826,9 @@ snapshots:
 
   '@graphql-tools/graphql-tag-pluck@7.1.7(graphql@16.3.0)':
     dependencies:
-      '@babel/parser': 7.24.8
-      '@babel/traverse': 7.24.8
-      '@babel/types': 7.24.9
+      '@babel/parser': 7.28.0
+      '@babel/traverse': 7.28.0
+      '@babel/types': 7.28.2
       '@graphql-tools/utils': 8.6.3(graphql@16.3.0)
       graphql: 16.3.0
       tslib: 2.3.1
@@ -11074,24 +11081,28 @@ snapshots:
 
   '@types/babel__core@7.1.19':
     dependencies:
-      '@babel/parser': 7.21.9
-      '@babel/types': 7.23.0
+      '@babel/parser': 7.28.0
+      '@babel/types': 7.28.2
       '@types/babel__generator': 7.6.4
       '@types/babel__template': 7.4.1
-      '@types/babel__traverse': 7.18.1
+      '@types/babel__traverse': 7.28.0
 
   '@types/babel__generator@7.6.4':
     dependencies:
-      '@babel/types': 7.23.0
+      '@babel/types': 7.28.2
 
   '@types/babel__template@7.4.1':
     dependencies:
-      '@babel/parser': 7.21.9
-      '@babel/types': 7.23.0
+      '@babel/parser': 7.28.0
+      '@babel/types': 7.28.2
 
   '@types/babel__traverse@7.18.1':
     dependencies:
-      '@babel/types': 7.23.0
+      '@babel/types': 7.28.2
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.28.2
 
   '@types/body-parser@1.19.6':
     dependencies:
@@ -11810,17 +11821,17 @@ snapshots:
 
   babel-plugin-jest-hoist@29.0.0:
     dependencies:
-      '@babel/template': 7.24.7
-      '@babel/types': 7.23.0
+      '@babel/template': 7.27.2
+      '@babel/types': 7.28.2
       '@types/babel__core': 7.1.19
-      '@types/babel__traverse': 7.18.1
+      '@types/babel__traverse': 7.28.0
 
   babel-plugin-jest-hoist@29.6.3:
     dependencies:
-      '@babel/template': 7.24.7
+      '@babel/template': 7.27.2
       '@babel/types': 7.28.2
       '@types/babel__core': 7.1.19
-      '@types/babel__traverse': 7.18.1
+      '@types/babel__traverse': 7.28.0
 
   babel-plugin-macros@3.1.0:
     dependencies:
@@ -14458,7 +14469,7 @@ snapshots:
   istanbul-lib-instrument@5.2.0:
     dependencies:
       '@babel/core': 7.24.9
-      '@babel/parser': 7.24.8
+      '@babel/parser': 7.28.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
       semver: 6.3.1
@@ -14468,7 +14479,7 @@ snapshots:
   istanbul-lib-instrument@6.0.2:
     dependencies:
       '@babel/core': 7.24.9
-      '@babel/parser': 7.24.8
+      '@babel/parser': 7.28.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
       semver: 7.6.3
@@ -14911,7 +14922,7 @@ snapshots:
 
   jest-message-util@28.1.3:
     dependencies:
-      '@babel/code-frame': 7.24.7
+      '@babel/code-frame': 7.27.1
       '@jest/types': 28.1.3
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
@@ -14923,7 +14934,7 @@ snapshots:
 
   jest-message-util@29.7.0:
     dependencies:
-      '@babel/code-frame': 7.24.2
+      '@babel/code-frame': 7.27.1
       '@jest/types': 29.6.3
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
@@ -15098,10 +15109,10 @@ snapshots:
   jest-snapshot@29.7.0:
     dependencies:
       '@babel/core': 7.24.9
-      '@babel/generator': 7.24.10
+      '@babel/generator': 7.28.0
       '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.24.9)
       '@babel/plugin-syntax-typescript': 7.18.6(@babel/core@7.24.9)
-      '@babel/types': 7.24.9
+      '@babel/types': 7.28.2
       '@jest/expect-utils': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
@@ -15918,11 +15929,11 @@ snapshots:
 
   node-source-walk@4.3.0:
     dependencies:
-      '@babel/parser': 7.24.8
+      '@babel/parser': 7.28.0
 
   node-source-walk@5.0.2:
     dependencies:
-      '@babel/parser': 7.24.8
+      '@babel/parser': 7.28.0
 
   normalize-package-data@2.5.0:
     dependencies:
@@ -16153,7 +16164,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.24.7
+      '@babel/code-frame': 7.27.1
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -16204,8 +16215,6 @@ snapshots:
   path-type@4.0.0: {}
 
   picocolors@1.0.0: {}
-
-  picocolors@1.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -17903,7 +17912,7 @@ snapshots:
     dependencies:
       browserslist: 4.22.2
       escalade: 3.1.1
-      picocolors: 1.0.1
+      picocolors: 1.1.1
 
   update-browserslist-db@1.1.0(browserslist@4.23.2):
     dependencies:


### PR DESCRIPTION
## Why?

Exploration and research 😬 I was curious to see if a library could be built to convert from jsx + tailwind into a makeswift schema (controls and page structure)

## What?

- New package that provides a library to convert jsx + tailwind into a makeswift schema using the controls package with capabilities to convert jsx + tailwind into makeswift and the other way around


https://github.com/user-attachments/assets/7496e068-4093-43d3-aaaa-2f2c8c8a23c2

## Notes

This is all experimental, and my first time submitting a PR for this repo, please let me know if I need to adjust or make any changes to the PR.