### PR TITLE
fix: global resource cache is shared across draft and live requests

### DIFF
--- a/.changeset/chilly-rules-sleep.md
+++ b/.changeset/chilly-rules-sleep.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+fix: global resource cache is shared across draft and live requests

--- a/.changeset/nine-actors-occur.md
+++ b/.changeset/nine-actors-occur.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/hono-react': patch
+---
+
+Add an option to scope runtime instance by request key

--- a/packages/hono-react/src/runtime.ts
+++ b/packages/hono-react/src/runtime.ts
@@ -1,7 +1,16 @@
-import { type Breakpoints, ReactRuntime } from '@makeswift/runtime/unstable-framework-support'
+import {
+  type Breakpoints,
+  type StoreKey,
+  ReactRuntime,
+} from '@makeswift/runtime/unstable-framework-support'
 
 export class HonoReactRuntime extends ReactRuntime {
-  constructor(args: { appOrigin?: string; apiOrigin?: string; breakpoints?: Breakpoints } = {}) {
+  constructor(args: {
+    requestKey?: StoreKey
+    appOrigin?: string
+    apiOrigin?: string
+    breakpoints?: Breakpoints
+  }) {
     super({
       ...args,
       fetch: (url, init) => fetch(url, init), // TODO: revalidation support

--- a/packages/runtime/src/api/client.ts
+++ b/packages/runtime/src/api/client.ts
@@ -61,16 +61,14 @@ export class MakeswiftHostApiClient {
   constructor({
     uri,
     fetch,
-    cacheData,
+    preloadedState,
   }: {
     uri: string
     fetch: MakeswiftApiClient.HttpFetch
-    cacheData?: CacheData
+    preloadedState: Partial<MakeswiftApiClient.State>
   }) {
     this.graphqlClient = new GraphQLClient(uri)
-    this.makeswiftApiClient = MakeswiftApiClient.configureStore({
-      serializedState: cacheData,
-    })
+    this.makeswiftApiClient = MakeswiftApiClient.configureStore({ preloadedState })
     this.fetch = fetch
     this.subscribe = this.makeswiftApiClient.subscribe
   }

--- a/packages/runtime/src/client/index.ts
+++ b/packages/runtime/src/client/index.ts
@@ -335,10 +335,12 @@ const getPageAPISchema = z.object({
 type GetPageAPI = z.infer<typeof getPageAPISchema>
 
 const getFontsAPISchema = z.object({
-  googleFonts: z.array(z.object({
-    family: z.string(),
-    variants: z.array(z.string()),
-  })),
+  googleFonts: z.array(
+    z.object({
+      family: z.string(),
+      variants: z.array(z.string()),
+    }),
+  ),
   siteId: z.string(),
 })
 
@@ -534,8 +536,7 @@ export class MakeswiftClient {
     siteVersion: SiteVersion | null,
     locale: string | null,
   ): Promise<CacheData> {
-    const runtime = this.runtime
-    const descriptors = getPropControllerDescriptors(runtime.store.getState())
+    const descriptors = this.getElementDescriptors()
     const swatchIds = new Set<string>()
     const fileIds = new Set<string>()
     const typographyIds = new Set<string>()
@@ -980,18 +981,11 @@ export class MakeswiftClient {
   }
 
   getTranslatableData(elementTree: ElementData): Record<string, Data> {
-    return getTranslatableContent(
-      getPropControllerDescriptors(this.runtime.store.getState()),
-      elementTree,
-    )
+    return getTranslatableContent(this.getElementDescriptors(), elementTree)
   }
 
   mergeTranslatedData(elementTree: ElementData, translatedData: Record<string, Data>): Element {
-    return mergeTranslatedContent(
-      getPropControllerDescriptors(this.runtime.store.getState()),
-      elementTree,
-      translatedData,
-    )
+    return mergeTranslatedContent(this.getElementDescriptors(), elementTree, translatedData)
   }
 
   async readPreviewToken(token: string): Promise<PreviewTokenPayload | null> {
@@ -1034,9 +1028,7 @@ export class MakeswiftClient {
     return parsed.data
   }
 
-  async unstable_getFonts(
-    siteVersion: SiteVersion | null = null,
-  ): Promise<GetFontsAPI | null> {
+  async unstable_getFonts(siteVersion: SiteVersion | null = null): Promise<GetFontsAPI | null> {
     const response = await this.fetch('v1_unstable/fonts', siteVersion)
 
     if (!response.ok) {
@@ -1061,5 +1053,9 @@ export class MakeswiftClient {
     }
 
     return parsed.data
+  }
+
+  private getElementDescriptors() {
+    return getPropControllerDescriptors(this.runtime.protoStore.getState())
   }
 }

--- a/packages/runtime/src/next/components/tests/controls/page-control-prop-rendering.tsx
+++ b/packages/runtime/src/next/components/tests/controls/page-control-prop-rendering.tsx
@@ -119,7 +119,7 @@ export async function testPageControlPropRendering<D extends ControlDefinition>(
   }
 
   const runtime = Testing.createReactRuntime()
-  runtime.store.dispatch(setIsInBuilder(isInBuilder))
+  runtime.protoStore.dispatch(setIsInBuilder(isInBuilder))
   registerComponents?.(runtime)
 
   // Act

--- a/packages/runtime/src/runtimes/react/components/RuntimeProvider.tsx
+++ b/packages/runtime/src/runtimes/react/components/RuntimeProvider.tsx
@@ -1,11 +1,12 @@
 'use client'
 
-import { ReactNode, useMemo } from 'react'
+import { ReactNode, useEffect, useMemo } from 'react'
 
 import { type SiteVersion } from '../../../api/site-version'
 
 import { ReactRuntimeContext } from '../hooks/use-react-runtime'
 import { useAsyncEffect } from '../hooks/use-async-effect'
+import { StoreContext } from '../hooks/use-store'
 import { type ReactRuntimeCore } from '../react-runtime-core'
 
 import { PreviewSwitcher } from './preview-switcher/preview-switcher'
@@ -23,25 +24,28 @@ export function RuntimeProvider({
 }) {
   const siteVersion = siteVersionProp ?? null
   const isPreview = siteVersion != null
-  // TODO: we need to decouple editability from the site version; specifically, previewing
-  // a draft version of the site should not lead to switching to the read-write state
-  const isReadOnly = siteVersion == null
 
-  // setting idempotent part of the state on render to have parity between server-side and
-  // client-side rendering depending on this state; `useMemo` here is purely a performance
-  // optimization; prior art for performing idempotent side effects on render:
-  // https://github.com/TanStack/query/blob/8f9f183f11df3709a1a38c4efce1452788041f88/packages/react-query/src/HydrationBoundary.tsx#L41
-  useMemo(
-    () => runtime.setIdempotent({ siteVersion, isReadOnly, locale }),
-    [runtime, siteVersion, isReadOnly, locale],
+  // see `getOrCreateStore` for the description of the stores' lifecycle
+  const store = useMemo(
+    () => runtime.getOrCreateStore({ siteVersion, locale }),
+    [runtime, siteVersion, locale],
   )
 
-  useAsyncEffect(() => runtime.setupStore({ isReadOnly }), [runtime, isReadOnly])
+  useEffect(() => {
+    runtime.retainStore({ siteVersion, locale }, store)
+    return () => runtime.releaseStore({ siteVersion, locale }, store)
+  }, [runtime, siteVersion, locale, store])
+
+  // if we're in the read-write mode, the reducers & middleware required for builder
+  // interactions are loaded only on client side, lazily and asynchronously
+  useAsyncEffect(() => store.loadReadWriteStateIfNeeded(), [store])
 
   return (
     <ReactRuntimeContext.Provider value={runtime}>
-      {children}
-      <PreviewSwitcher isPreview={isPreview} />
+      <StoreContext.Provider value={store}>
+        {children}
+        <PreviewSwitcher isPreview={isPreview} />
+      </StoreContext.Provider>
     </ReactRuntimeContext.Provider>
   )
 }

--- a/packages/runtime/src/runtimes/react/hooks/use-store.ts
+++ b/packages/runtime/src/runtimes/react/hooks/use-store.ts
@@ -1,8 +1,15 @@
 'use client'
 
+import { createContext, useContext } from 'react'
 import { type Store } from '../../../state/store'
-import { useReactRuntime } from './use-react-runtime'
+
+export const StoreContext = createContext<Store | null>(null)
 
 export function useStore(): Store {
-  return useReactRuntime().store
+  const store = useContext(StoreContext)
+  if (store == null) {
+    throw new Error('`useStore` must be used within a `StoreProvider`')
+  }
+
+  return store
 }

--- a/packages/runtime/src/runtimes/react/host-api-client.tsx
+++ b/packages/runtime/src/runtimes/react/host-api-client.tsx
@@ -2,8 +2,8 @@
 
 import { MakeswiftHostApiClient } from '../../api/client'
 
-import { useReactRuntime } from './hooks/use-react-runtime'
+import { useStore } from './hooks/use-store'
 
 export function useMakeswiftHostApiClient(): MakeswiftHostApiClient {
-  return useReactRuntime().hostApiClient
+  return useStore().hostApiClient
 }

--- a/packages/runtime/src/runtimes/react/react-runtime-core.ts
+++ b/packages/runtime/src/runtimes/react/react-runtime-core.ts
@@ -55,7 +55,7 @@ export class ReactRuntimeCore extends RuntimeCore {
   ): () => void {
     validateComponentType(type, component as unknown as ComponentType)
 
-    const unregisterComponent = this.store.dispatch(
+    const unregisterComponent = this.protoStore.dispatch(
       registerComponentEffect(
         type,
         { label, icon, hidden, description, builtinSuspense },
@@ -69,7 +69,7 @@ export class ReactRuntimeCore extends RuntimeCore {
       )
     }
 
-    const unregisterReactComponent = this.store.dispatch(
+    const unregisterReactComponent = this.protoStore.dispatch(
       registerReactComponentEffect(type, component as unknown as ComponentType),
     )
 

--- a/packages/runtime/src/runtimes/react/react-runtime.ts
+++ b/packages/runtime/src/runtimes/react/react-runtime.ts
@@ -1,6 +1,8 @@
 import { registerBuiltinComponents } from '../../components/builtin/register'
 import { ReactRuntimeCore } from './react-runtime-core'
 
+export { type StoreKey } from './runtime-core'
+
 export class ReactRuntime extends ReactRuntimeCore {
   constructor(...args: ConstructorParameters<typeof ReactRuntimeCore>) {
     super(...args)

--- a/packages/runtime/src/runtimes/react/runtime-core.ts
+++ b/packages/runtime/src/runtimes/react/runtime-core.ts
@@ -13,78 +13,146 @@ import {
 import { copyElementTree } from '../../state/ops/copy-element-tree'
 
 import { getBreakpoints, type Element, type ElementData } from '../../state/read-only-state'
-import { configureStore, type Store } from '../../state/store'
-import { setLocale } from '../../builder'
 import {
-  resetLocaleState,
-  setIsReadOnly,
-  setSiteVersion,
-} from '../../state/actions/internal/read-only-actions'
+  configureProtoStore,
+  configureReadWriteStore,
+  type ProtoStore,
+  type Store,
+} from '../../state/store'
+
+import { RefCountedMap } from '../../utils/ref-counted-map'
+import { isServer } from '../../utils/is-server'
+
+export type StoreKey = {
+  siteVersion: SiteVersion | null
+  locale: string | undefined
+}
+
+const VERSION_TAG_LIVE = 'ref:live'
 
 export class RuntimeCore {
-  readonly store: Store
-  readonly hostApiClient: MakeswiftHostApiClient
+  // The unowned entry TTL affects performance, not correctness. The TTL controls how long an unretained store stays
+  // in the map. If an entry expires and is removed from the map before React commits, the store remains retained
+  // via `<StoreContext.Provider>`. The only impact is that future lookups will create a new store instance instead of
+  // reusing the existing one, reducing cache efficiency.
+  private readonly activeStores = new RefCountedMap<string | null, Store>({
+    unownedEntryTtlMs: 1000,
+    // Checking on retain/release is sufficient on the client, and we don't need to check on get on the server
+    // as the only scenario in which we add the store to the map is when the runtime is already bound to the
+    // requested site version, which should be the only site version for which the store is requested
+    ttlCheck: RefCountedMap.TTLCheck.ON_RETAIN | RefCountedMap.TTLCheck.ON_RELEASE,
+  })
+
+  readonly protoStore: ProtoStore
   readonly appOrigin: string
   readonly apiOrigin: string
+  readonly requestKey: StoreKey | undefined
+  readonly fetch: MakeswiftApiClient.HttpFetch
 
   constructor({
     appOrigin = 'https://app.makeswift.com',
     apiOrigin = 'https://api.makeswift.com',
     breakpoints,
+    requestKey,
     fetch,
   }: {
     appOrigin?: string
     apiOrigin?: string
     breakpoints?: BreakpointsInput
+    requestKey?: StoreKey
     fetch: MakeswiftApiClient.HttpFetch
   }) {
     this.appOrigin = validateOrigin(appOrigin, 'appOrigin')
     this.apiOrigin = validateOrigin(apiOrigin, 'apiOrigin')
+    this.requestKey = requestKey
+    this.fetch = fetch
 
-    this.hostApiClient = new MakeswiftHostApiClient({
-      uri: new URL('graphql', this.apiOrigin).href,
-      fetch: fetch,
-    })
-
-    this.store = configureStore({
-      name: 'Runtime store',
-      hostApiClient: this.hostApiClient,
-      appOrigin: this.appOrigin,
-      preloadedState: null,
+    this.protoStore = configureProtoStore({
+      name: 'Runtime proto-store',
       breakpoints: breakpoints ? parseBreakpointsInput(breakpoints) : undefined,
     })
   }
 
-  setIdempotent({
-    siteVersion,
-    isReadOnly,
-    locale,
-  }: {
-    siteVersion: SiteVersion | null
-    isReadOnly: boolean
-    locale: string | undefined
-  }): void {
-    this.store.dispatch(setSiteVersion(siteVersion))
-    this.store.dispatch(setIsReadOnly(isReadOnly))
-    this.store.dispatch(locale != null ? setLocale(new Intl.Locale(locale)) : resetLocaleState())
+  getOrCreateStore({ siteVersion, locale }: StoreKey): Store {
+    const key = storeCacheKey({ siteVersion, locale })
+
+    const createStore = () => {
+      // host API client includes an in-memory cache of the site's resources and thus also has to be versioned
+      const hostApiClient = new MakeswiftHostApiClient({
+        uri: new URL('graphql', this.apiOrigin).href,
+        fetch: this.fetch,
+        preloadedState: { siteVersion, locale },
+      })
+
+      // TODO: we need to decouple editability from the site version; specifically, previewing
+      // a draft version of the site should not lead to switching to the read-write state
+      const isReadOnly = siteVersion == null
+
+      return configureReadWriteStore({
+        name: `Runtime read-write store (site version: ${key})`,
+        appOrigin: this.appOrigin,
+        hostApiClient,
+        preloadedState: { ...this.protoStore.getState(), siteVersion, isReadOnly, locale },
+      })
+    }
+
+    // On the server, stores are ephemeral by default so SSR does not retain them in a long-lived runtime.
+    // The exception is a runtime that is already bound to the requested site version & locale, where we
+    // can safely reuse the store across multiple root regions and benefit from the host API client's
+    // in-memory cache.
+    //
+    // On the client, stores are reference-counted by site version so multiple root regions can share a store
+    // instance, which preserves the pre-v0.17 per-site-version store behavior without requiring a separate
+    // runtime per root.
+    const usePersistentStore = this.shouldUsePersistentStore(key)
+    return usePersistentStore ? this.activeStores.getOrCreate(key, createStore) : createStore()
   }
 
-  async setupStore({ isReadOnly }: { isReadOnly: boolean }): Promise<() => void> {
-    const unloadReadWriteState = await this.store.loadReadWriteState({ isReadOnly })
-    return () => unloadReadWriteState()
+  retainStore({ siteVersion, locale }: StoreKey, store: Store): void {
+    const key = storeCacheKey({ siteVersion, locale })
+
+    if (!this.shouldUsePersistentStore(key)) {
+      console.error('RuntimeCore: attempt to retain an ephemeral store', { key })
+      return
+    }
+
+    this.activeStores.retain(key, store)
+  }
+
+  releaseStore({ siteVersion, locale }: StoreKey, store: Store): void {
+    const key = storeCacheKey({ siteVersion, locale })
+
+    if (!this.shouldUsePersistentStore(key)) {
+      console.error('RuntimeCore: attempt to release an ephemeral store', { key })
+      return
+    }
+
+    this.activeStores.release(key, store)
   }
 
   copyElementTree(
     elementTree: ElementData,
     replacementContext: SerializableReplacementContext,
   ): Element {
-    return copyElementTree(this.store.getState(), elementTree, replacementContext)
+    return copyElementTree(this.protoStore.getState(), elementTree, replacementContext)
   }
 
   getBreakpoints(): Breakpoints {
-    return getBreakpoints(this.store.getState())
+    return getBreakpoints(this.protoStore.getState())
+  }
+
+  private shouldUsePersistentStore(key: string): boolean {
+    // don't persist stores on the server unless the runtime instance is bound to a request
+    // and the requested store matches the request's site version and locale
+    return !isServer() || (this.requestKey !== undefined && storeCacheKey(this.requestKey) === key)
   }
 }
+
+const storeCacheKey = ({ siteVersion, locale }: StoreKey): string =>
+  `${siteVersionTag(siteVersion)}/${locale ?? 'default'}`
+
+const siteVersionTag = (siteVersion: SiteVersion | null): string =>
+  siteVersion?.version ?? VERSION_TAG_LIVE
 
 function validateOrigin(url: string, name: string): string {
   try {

--- a/packages/runtime/src/state/__tests__/react-builder-preview.test.ts
+++ b/packages/runtime/src/state/__tests__/react-builder-preview.test.ts
@@ -81,7 +81,7 @@ describe('elementTreeMiddleware', () => {
     const runtime = createReactRuntime()
     const store = configureReduxStore({
       reducer: createRootReducer(),
-      preloadedState: runtime.store.getState(),
+      preloadedState: runtime.protoStore.getState(),
       middleware: getDefaultMiddleware =>
         getDefaultMiddleware(middlewareOptions).concat(
           readOnlyElementTreeMiddleware(),
@@ -94,7 +94,7 @@ describe('elementTreeMiddleware', () => {
     const newElementTree = () =>
       buildElementTree(
         State.getDocument(store.getState(), documentKey)?.rootElement!,
-        State.getPropControllerDescriptors(runtime.store.getState()),
+        State.getPropControllerDescriptors(runtime.protoStore.getState()),
       )
 
     // Act / Assert

--- a/packages/runtime/src/state/__tests__/store.read-write-state.test.ts
+++ b/packages/runtime/src/state/__tests__/store.read-write-state.test.ts
@@ -1,5 +1,5 @@
 import { TestOrigins } from '../../testing/fixtures'
-import { configureStore } from '../store'
+import { configureReadWriteStore } from '../store'
 
 const teardownSpy = jest.fn()
 const builderProxyMock = jest.fn(() => ({}))
@@ -25,8 +25,14 @@ jest.mock('../read-write-state', () => ({
   setupBuilderProxy: setupBuilderProxyMock,
 }))
 
-const createStore = () =>
-  configureStore({
+const createStore = ({
+  isReadOnly,
+  locale = null,
+}: {
+  isReadOnly: boolean
+  locale?: string | null
+}) =>
+  configureReadWriteStore({
     name: 'test-store',
     appOrigin: TestOrigins.appOrigin,
     hostApiClient: {
@@ -34,10 +40,13 @@ const createStore = () =>
         dispatch: jest.fn(),
       },
     } as any,
-    preloadedState: null,
+    preloadedState: {
+      isReadOnly,
+      locale,
+    },
   })
 
-describe('loadReadWriteState', () => {
+describe('read-write store state', () => {
   let consoleError: jest.SpyInstance
   beforeEach(() => {
     consoleError = jest.spyOn(console, 'error').mockImplementation(jest.fn())
@@ -55,12 +64,12 @@ describe('loadReadWriteState', () => {
     createRootReducerMock.mockClear()
   })
 
-  it('calling `loadReadWriteState` with isReadOnly=true has no effect', async () => {
-    const store = createStore()
+  it('calling `loadReadWriteStateIfNeeded` on a read-only store has no effect', async () => {
+    const store = createStore({ isReadOnly: true })
 
     const [unloadA, unloadB] = await Promise.all([
-      store.loadReadWriteState({ isReadOnly: true }),
-      store.loadReadWriteState({ isReadOnly: true }),
+      store.loadReadWriteStateIfNeeded(),
+      store.loadReadWriteStateIfNeeded(),
     ])
 
     unloadA()
@@ -72,29 +81,12 @@ describe('loadReadWriteState', () => {
     expect(consoleError).not.toHaveBeenCalled()
   })
 
-  it('cleanly switches from read-only to read=write state', async () => {
-    const store = createStore()
-
-    const unloadA = await store.loadReadWriteState({ isReadOnly: true })
-    unloadA()
-
-    const unloadB = await store.loadReadWriteState({ isReadOnly: false })
-
-    expect(builderProxyMock).toHaveBeenCalledTimes(1)
-    expect(createReadWriteMiddlewareMock).toHaveBeenCalledTimes(1)
-    expect(teardownSpy).not.toHaveBeenCalled()
-
-    unloadB()
-    expect(teardownSpy).toHaveBeenCalledTimes(1)
-    expect(consoleError).not.toHaveBeenCalled()
-  })
-
   it('read-write state is not unloaded until all providers have unmounted', async () => {
-    const store = createStore()
+    const store = createStore({ isReadOnly: false })
 
     const [unloadA, unloadB] = await Promise.all([
-      store.loadReadWriteState({ isReadOnly: false }),
-      store.loadReadWriteState({ isReadOnly: false }),
+      store.loadReadWriteStateIfNeeded(),
+      store.loadReadWriteStateIfNeeded(),
     ])
 
     expect(builderProxyMock).toHaveBeenCalledTimes(1)
@@ -108,20 +100,5 @@ describe('loadReadWriteState', () => {
 
     expect(teardownSpy).toHaveBeenCalledTimes(1)
     expect(consoleError).not.toHaveBeenCalled()
-  })
-
-  it('read-write state inconsistencies are detected and logged', async () => {
-    const store = createStore()
-
-    const unloadA = await store.loadReadWriteState({ isReadOnly: false })
-    const unloadB = await store.loadReadWriteState({ isReadOnly: true })
-
-    expect(consoleError).toHaveBeenCalledWith('Read-write state mismatch', {
-      isReadOnly: true,
-      refCount: 1,
-    })
-
-    unloadA()
-    unloadB()
   })
 })

--- a/packages/runtime/src/state/actions/internal/read-only-actions.ts
+++ b/packages/runtime/src/state/actions/internal/read-only-actions.ts
@@ -5,7 +5,6 @@ import { ControlInstance } from '@makeswift/controls'
 import { ElementImperativeHandle } from '../../../runtimes/react/element-imperative-handle'
 
 import { type APIResource, APIResourceType, APIResourceLocale } from '../../../api/types'
-import { type SiteVersion } from '../../../api/site-version'
 import { type Descriptor as PropControllerDescriptor } from '../../../prop-controllers/descriptors'
 
 import { type ComponentMeta } from '../../modules/components-meta'
@@ -38,11 +37,6 @@ export const ReadOnlyActionTypes = {
 
   SET_IS_IN_BUILDER: 'SET_IS_IN_BUILDER',
   SET_IS_READ_ONLY: 'SET_IS_READ_ONLY',
-  SET_SITE_VERSION: 'SET_SITE_VERSION',
-
-  // TODO: consolidate with `SET_LOCALE` action in `shared-api.ts`
-  // (requires changes to the builder to handle null locales)
-  RESET_LOCALE_STATE: 'RESET_LOCALE_STATE',
 } as const
 
 type APIResourceFulfilledAction = {
@@ -133,15 +127,6 @@ type SetIsReadOnlyAction = {
   payload: boolean
 }
 
-type SetSiteVersionAction = {
-  type: typeof ReadOnlyActionTypes.SET_SITE_VERSION
-  payload: SiteVersion | null
-}
-
-type ResetLocaleStateAction = {
-  type: typeof ReadOnlyActionTypes.RESET_LOCALE_STATE
-}
-
 export type ReadOnlyAction =
   | APIResourceFulfilledAction
   | CreateElementTreeAction
@@ -158,8 +143,6 @@ export type ReadOnlyAction =
   | UnregisterReactComponentAction
   | SetIsInBuilderAction
   | SetIsReadOnlyAction
-  | SetSiteVersionAction
-  | ResetLocaleStateAction
 
 export function apiResourceFulfilled<T extends APIResourceType>(
   resourceType: T,
@@ -324,12 +307,4 @@ export function setIsInBuilder(isInBuilder: boolean): SetIsInBuilderAction {
 
 export function setIsReadOnly(isReadOnly: boolean): SetIsReadOnlyAction {
   return { type: ReadOnlyActionTypes.SET_IS_READ_ONLY, payload: isReadOnly }
-}
-
-export function setSiteVersion(siteVersion: SiteVersion | null): SetSiteVersionAction {
-  return { type: ReadOnlyActionTypes.SET_SITE_VERSION, payload: siteVersion }
-}
-
-export function resetLocaleState(): ResetLocaleStateAction {
-  return { type: ReadOnlyActionTypes.RESET_LOCALE_STATE }
 }

--- a/packages/runtime/src/state/makeswift-api-client.ts
+++ b/packages/runtime/src/state/makeswift-api-client.ts
@@ -15,8 +15,7 @@ import * as APIResources from './modules/api-resources'
 import * as LocalizedResourcesMap from './modules/localized-resources-map'
 
 import { type Action, ActionTypes } from './actions'
-import { apiResourceFulfilled, ReadOnlyActionTypes } from './actions/internal/read-only-actions'
-import { clearAPIClientCache } from './actions/internal/read-write-actions'
+import { apiResourceFulfilled } from './actions/internal/read-only-actions'
 import { setLocalizedResourceId } from './host-api'
 import { actionMiddleware, middlewareOptions, devToolsConfig } from './toolkit'
 
@@ -244,33 +243,13 @@ function defaultLocaleMiddleware(): ThunkMiddleware<State, UnknownAction> {
   })
 }
 
-function cacheVersioningMiddleware(): ThunkMiddleware<State, UnknownAction> {
-  return actionMiddleware(({ getState, dispatch }) => next => {
-    return (action: Action) => {
-      switch (action.type) {
-        case ReadOnlyActionTypes.SET_SITE_VERSION: {
-          const cacheVersion = SiteVersionState.getSiteVersion(getState().siteVersion)
-          if (cacheVersion?.version !== action.payload?.version) {
-            dispatch(clearAPIClientCache())
-          }
-        }
-      }
-
-      return next(action)
-    }
-  })
-}
-
 export function configureStore({ preloadedState }: { preloadedState: Partial<State> }) {
   return configureReduxStore({
     reducer,
     preloadedState,
 
     middleware: getDefaultMiddleware =>
-      getDefaultMiddleware(middlewareOptions).concat(
-        defaultLocaleMiddleware(),
-        cacheVersioningMiddleware(),
-      ),
+      getDefaultMiddleware(middlewareOptions).concat(defaultLocaleMiddleware()),
 
     devTools: devToolsConfig({
       name: `API client store (${new Date().toISOString()})`,

--- a/packages/runtime/src/state/makeswift-api-client.ts
+++ b/packages/runtime/src/state/makeswift-api-client.ts
@@ -261,15 +261,10 @@ function cacheVersioningMiddleware(): ThunkMiddleware<State, UnknownAction> {
   })
 }
 
-export function configureStore({ serializedState }: { serializedState?: SerializedState }) {
+export function configureStore({ preloadedState }: { preloadedState: Partial<State> }) {
   return configureReduxStore({
     reducer,
-    preloadedState: {
-      apiResources: APIResources.getInitialState(serializedState?.apiResources),
-      localizedResourcesMap: LocalizedResourcesMap.getInitialState(
-        serializedState?.localizedResourcesMap,
-      ),
-    },
+    preloadedState,
 
     middleware: getDefaultMiddleware =>
       getDefaultMiddleware(middlewareOptions).concat(

--- a/packages/runtime/src/state/middleware/read-write/builder-api/initialize-connection.ts
+++ b/packages/runtime/src/state/middleware/read-write/builder-api/initialize-connection.ts
@@ -309,6 +309,10 @@ export function initializeBuilderConnection(
 
     const breakpoints = ReadOnlyState.getBreakpoints(getState())
     dispatch(Builder.setBreakpoints(breakpoints))
+
+    const locale = ReadOnlyState.getLocale(getState())
+    if (locale != null) dispatch(Builder.setLocale(new Intl.Locale(locale)))
+
     dispatch(ReadOnly.setIsInBuilder(true))
     builderProxy.dispatchBuffered()
 

--- a/packages/runtime/src/state/modules/__tests__/element-trees.test.ts
+++ b/packages/runtime/src/state/modules/__tests__/element-trees.test.ts
@@ -15,7 +15,7 @@ describe('traverseElementTree', () => {
   const runtime = createReactRuntime()
 
   test('walks the tree in the correct order', () => {
-    const descriptors = getPropControllerDescriptors(runtime.store.getState())
+    const descriptors = getPropControllerDescriptors(runtime.protoStore.getState())
     const elements = ElementTrees.traverseElementTree(Fixtures.homePage, descriptors)
     expect([...elements].map(({ key, type }) => ({ key, type }))).toMatchSnapshot()
   })
@@ -136,7 +136,7 @@ describe('resetting an element tree', () => {
   })
 
   test('garbage collects all elements that were removed on reset', () => {
-    const descriptors = getPropControllerDescriptors(runtime.store.getState())
+    const descriptors = getPropControllerDescriptors(runtime.protoStore.getState())
     const documentKey = '0f567942-3ef5-4e66-abb0-969044145606'
 
     const oldDocument = {

--- a/packages/runtime/src/state/modules/locale.ts
+++ b/packages/runtime/src/state/modules/locale.ts
@@ -1,6 +1,5 @@
 import { type Action, type UnknownAction, isKnownAction } from '../actions'
 import { SharedActionTypes } from '../shared-api'
-import { ReadOnlyActionTypes } from '../actions/internal/read-only-actions'
 
 export type State = string | null
 
@@ -18,9 +17,6 @@ export function reducer(state = getInitialState(), action: Action | UnknownActio
   switch (action.type) {
     case SharedActionTypes.SET_LOCALE:
       return action.payload.locale
-
-    case ReadOnlyActionTypes.RESET_LOCALE_STATE:
-      return getInitialState()
 
     default:
       return state

--- a/packages/runtime/src/state/modules/site-version.ts
+++ b/packages/runtime/src/state/modules/site-version.ts
@@ -1,6 +1,5 @@
 import { type SiteVersion } from '../../api/site-version'
 import { type Action, type UnknownAction, isKnownAction } from '../actions'
-import { ReadOnlyActionTypes } from '../actions/internal/read-only-actions'
 
 export type State = SiteVersion | null
 
@@ -16,9 +15,6 @@ export function reducer(state = getInitialState(), action: Action | UnknownActio
   if (!isKnownAction(action)) return state
 
   switch (action.type) {
-    case ReadOnlyActionTypes.SET_SITE_VERSION:
-      return action.payload
-
     default:
       return state
   }

--- a/packages/runtime/src/state/read-only-state.ts
+++ b/packages/runtime/src/state/read-only-state.ts
@@ -3,6 +3,7 @@ import { type ThunkDispatch } from '@reduxjs/toolkit'
 import { createSelector } from 'reselect'
 
 import * as SiteVersion from './modules/site-version'
+import * as Locale from './modules/locale'
 import * as Documents from './modules/read-only-documents'
 import * as ElementTrees from './modules/element-trees'
 import * as ReactComponents from './modules/react-components'
@@ -36,8 +37,9 @@ export type { ComponentType } from './modules/react-components'
 export type { ComponentMeta } from './modules/components-meta'
 
 export const reducers = {
-  isReadOnly: IsReadOnly.reducer,
   siteVersion: SiteVersion.reducer,
+  isReadOnly: IsReadOnly.reducer,
+  locale: Locale.reducer,
   documents: Documents.reducer,
   elementTrees: ElementTrees.reducer,
   reactComponents: ReactComponents.reducer,
@@ -50,8 +52,9 @@ export const reducers = {
 }
 
 export type State = {
-  isReadOnly: IsReadOnly.State
   siteVersion: SiteVersion.State
+  isReadOnly: IsReadOnly.State
+  locale: Locale.State
   documents: Documents.State
   elementTrees: ElementTrees.State
   reactComponents: ReactComponents.State
@@ -222,4 +225,8 @@ export function getBuilderEditMode(state: State): BuilderEditMode.State {
 
 export function getBreakpoints(state: State): Breakpoints.State {
   return state.breakpoints
+}
+
+export function getLocale(state: State): string | null {
+  return state.locale
 }

--- a/packages/runtime/src/state/store.ts
+++ b/packages/runtime/src/state/store.ts
@@ -2,6 +2,7 @@ import {
   type Middleware,
   type StoreEnhancer,
   type MiddlewareAPI,
+  Tuple,
   configureStore as configureReduxStore,
   combineReducers,
   compose,
@@ -16,18 +17,74 @@ import { HostActionTypes } from './host-api'
 import * as Breakpoints from './modules/breakpoints'
 
 import { readOnlyElementTreeMiddleware } from './middleware/read-only-element-tree'
+import { makeswiftApiClientSyncMiddleware } from './middleware/makeswift-api-client-sync'
 
 import { type Action } from './actions'
+
 import { type State as ReadWriteState } from './read-write-state'
 import * as ReadOnlyState from './read-only-state'
-
 import {
   type State,
   type Dispatch,
   type ReadOnlyReducer,
   type ReadWriteDispatch,
 } from './unified-state'
-import { makeswiftApiClientSyncMiddleware } from './middleware/makeswift-api-client-sync'
+
+export { type State } from './unified-state'
+
+const configureStore = <Items extends readonly StoreEnhancer[] = []>({
+  name,
+  preloadedState,
+  enhancers,
+  middleware,
+}: {
+  name: string
+  preloadedState: Partial<State>
+  enhancers: () => Tuple<Items>
+  middleware?: () => Middleware[]
+}) => {
+  const store = configureReduxStore({
+    reducer: combineReducers(ReadOnlyState.reducers),
+    preloadedState,
+
+    middleware: getDefaultMiddleware =>
+      getDefaultMiddleware(middlewareOptions).concat([
+        readOnlyElementTreeMiddleware(),
+        ...(middleware ? middleware() : []),
+      ]),
+
+    enhancers: getDefaultEnhancers => getDefaultEnhancers().concat(enhancers()),
+
+    devTools: devToolsConfig({
+      name: `${name} (${new Date().toISOString()})`,
+      actionsDenylist: [
+        HostActionTypes.BUILDER_POINTER_MOVE,
+        BuilderActionTypes.HANDLE_POINTER_MOVE,
+        BuilderActionTypes.ELEMENT_FROM_POINT_CHANGE,
+      ],
+    }),
+  })
+
+  return store
+}
+
+export function configureProtoStore({
+  name,
+  breakpoints,
+}: {
+  name: string
+  breakpoints: Breakpoints.State | undefined
+}) {
+  return configureStore({
+    name,
+    preloadedState: {
+      breakpoints: Breakpoints.getInitialState(breakpoints),
+    },
+    enhancers: () => new Tuple(),
+  })
+}
+
+export type ProtoStore = ReturnType<typeof configureProtoStore>
 
 type ReadWriteMiddleware = ReturnType<
   typeof import('./middleware/read-write').createReadWriteMiddleware
@@ -98,31 +155,29 @@ export function conditionalReadWriteMiddleware(
   })
 }
 
-interface ReadWriteStateMixin {
-  loadReadWriteState: ({ isReadOnly }: { isReadOnly: boolean }) => Promise<() => void>
+export interface ReadWriteStateMixin {
+  readonly hostApiClient: MakeswiftHostApiClient
+
+  loadReadWriteStateIfNeeded(): Promise<() => void>
 }
 
-function withReadWriteState(
-  loadReadWriteState: ReadWriteStateMixin['loadReadWriteState'],
-): StoreEnhancer<ReadWriteStateMixin> {
+function withMixin<M extends {}>(mixin: M): StoreEnhancer<M> {
   return next => (reducer, preloadedState?) => ({
     ...next(reducer, preloadedState),
-    loadReadWriteState,
+    ...mixin,
   })
 }
 
-export function configureStore({
+export function configureReadWriteStore({
   name,
   appOrigin,
   hostApiClient,
   preloadedState,
-  breakpoints,
 }: {
   name: string
   appOrigin: string
   hostApiClient: MakeswiftHostApiClient
-  preloadedState: Partial<State> | null
-  breakpoints?: Breakpoints.State
+  preloadedState: Partial<State>
 }) {
   const readWriteMiddlewareRef: ReadWriteMiddlewareRef = {
     current: null,
@@ -179,65 +234,52 @@ export function configureStore({
     }
   }
 
-  const store = configureReduxStore({
-    reducer: combineReducers(ReadOnlyState.reducers),
+  const store = configureStore({
+    name,
+    preloadedState,
 
-    preloadedState: {
-      ...preloadedState,
-      breakpoints: Breakpoints.getInitialState(breakpoints ?? preloadedState?.breakpoints),
-    },
+    middleware: () => [
+      makeswiftApiClientSyncMiddleware(hostApiClient),
+      conditionalReadWriteMiddleware(readWriteMiddlewareRef),
+    ],
 
-    middleware: getDefaultMiddleware =>
-      getDefaultMiddleware(middlewareOptions).concat([
-        readOnlyElementTreeMiddleware(),
-        makeswiftApiClientSyncMiddleware(hostApiClient),
-        conditionalReadWriteMiddleware(readWriteMiddlewareRef),
-      ]),
+    enhancers: () =>
+      new Tuple(
+        withMixin<ReadWriteStateMixin>({
+          hostApiClient,
+          loadReadWriteStateIfNeeded: async () => {
+            const { isReadOnly } = store.getState()
 
-    enhancers: getDefaultEnhancers =>
-      getDefaultEnhancers().concat(
-        withReadWriteState(async ({ isReadOnly }) => {
-          if (isReadOnly) {
-            if (refCount > 0) {
-              console.error('Read-write state mismatch', {
-                isReadOnly,
-                refCount,
-              })
+            if (isReadOnly) {
+              if (refCount > 0) {
+                console.error('Read-write state mismatch', { isReadOnly, refCount })
+              }
+
+              return () => {}
             }
 
-            return () => {}
-          }
+            await loadReadWriteState()
+            refCount += 1
 
-          await loadReadWriteState()
-          refCount += 1
+            let didCleanup = false
+            return () => {
+              if (didCleanup) {
+                return
+              }
 
-          let didCleanup = false
-          return () => {
-            if (didCleanup) {
-              return
+              didCleanup = true
+              refCount -= 1
+              if (refCount === 0 && readWriteCleanup != null) {
+                readWriteCleanup()
+                readWriteCleanup = null
+              }
             }
-
-            didCleanup = true
-            refCount -= 1
-            if (refCount === 0 && readWriteCleanup != null) {
-              readWriteCleanup()
-              readWriteCleanup = null
-            }
-          }
+          },
         }),
       ),
-
-    devTools: devToolsConfig({
-      name: `${name} (${new Date().toISOString()})`,
-      actionsDenylist: [
-        HostActionTypes.BUILDER_POINTER_MOVE,
-        BuilderActionTypes.HANDLE_POINTER_MOVE,
-        BuilderActionTypes.ELEMENT_FROM_POINT_CHANGE,
-      ],
-    }),
   })
 
   return store
 }
 
-export type Store = ReturnType<typeof configureStore>
+export type Store = ReturnType<typeof configureReadWriteStore>

--- a/packages/runtime/src/unstable-framework-support/index.ts
+++ b/packages/runtime/src/unstable-framework-support/index.ts
@@ -42,4 +42,4 @@ export {
   type RootStyleProps,
 } from '../runtimes/react/root-style-registry'
 
-export { ReactRuntime } from '../runtimes/react/react-runtime'
+export { ReactRuntime, type StoreKey } from '../runtimes/react/react-runtime'

--- a/packages/runtime/src/utils/__tests__/ref-counted-map.test.ts
+++ b/packages/runtime/src/utils/__tests__/ref-counted-map.test.ts
@@ -1,0 +1,187 @@
+import { RefCountedMap } from '../ref-counted-map'
+
+interface Cat {
+  name: string
+}
+
+describe('RefCountedMap', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('entries are unowned by default', () => {
+    const map = new RefCountedMap<string, Cat>({ unownedEntryTtlMs: 100 })
+
+    const whiskers = map.getOrCreate('whiskers', () => ({ name: 'Whiskers' }))
+
+    expect(whiskers).toEqual({ name: 'Whiskers' })
+    expect(map.size).toBe(1)
+
+    jest.advanceTimersByTime(101)
+
+    // 'whiskers' entry should be evicted after TTL expiration
+    const mittens = map.getOrCreate('mittens', () => ({ name: 'Mittens' }))
+
+    expect(mittens).toEqual({ name: 'Mittens' })
+    expect(map.size).toBe(1)
+    expect(map.get('whiskers')).toBeUndefined()
+  })
+
+  it("unowned entry's TTL is refreshed when it is accessed again", () => {
+    const map = new RefCountedMap<string, Cat>({ unownedEntryTtlMs: 100 })
+    const key = 'whiskers'
+    const whiskers = map.getOrCreate(key, () => ({ name: 'Whiskers' }))
+
+    jest.advanceTimersByTime(101)
+
+    // no new entry should be created
+    const whiskers2 = map.getOrCreate(key, () => ({ name: 'Whiskers' }))
+    expect(whiskers2).toBe(whiskers)
+
+    // whiskers entry should still be in the map
+    expect(map.size).toBe(1)
+    expect(map.get('whiskers')).toBe(whiskers)
+  })
+
+  it('retained entries are not affected by TTL expiration, are properly reference-counted', () => {
+    const map = new RefCountedMap<string, Cat>({ unownedEntryTtlMs: 100 })
+    const key = 'whiskers'
+
+    const whiskers = map.getOrCreate(key, () => ({ name: 'Whiskers' }))
+    map.retain(key, whiskers)
+
+    jest.advanceTimersByTime(101)
+
+    // 'whiskers' entry should NOT be evicted
+    const mittens = map.getOrCreate('mittens', () => ({ name: 'Mittens' }))
+    expect(mittens).toEqual({ name: 'Mittens' })
+    expect(map.get(key)).toBe(whiskers)
+    expect(map.size).toBe(2)
+
+    // returns the existing instance of 'whiskers' entry
+    const whiskers2 = map.getOrCreate(key, () => ({ name: 'Whiskers' }))
+    map.retain(key, whiskers)
+    expect(whiskers2).toBe(whiskers)
+
+    // 'whiskers' should still be in the map
+    map.release(key, whiskers)
+    expect(map.get(key)).toBe(whiskers)
+    expect(map.size).toBe(2)
+
+    // this should remove 'whiskers' from the map
+    map.release(key, whiskers)
+    expect(map.get(key)).toBeUndefined()
+    expect(map.size).toBe(1)
+  })
+
+  it('calling `retain` on an evicted entry adds it back to the map', () => {
+    const map = new RefCountedMap<string, Cat>({ unownedEntryTtlMs: 100 })
+    const key = 'whiskers'
+
+    const whiskers = map.getOrCreate(key, () => ({ name: 'Whiskers' }))
+    expect(map.get(key)).toBe(whiskers)
+    expect(map.size).toBe(1)
+
+    jest.advanceTimersByTime(101)
+
+    // trigger 'whiskers' entry eviction
+    map.getOrCreate('mittens', () => ({ name: 'Mittens' }))
+    expect(map.get(key)).toBeUndefined()
+
+    map.retain(key, whiskers)
+
+    // 'whiskers' entry should be added back to the map
+    expect(map.get(key)).toBe(whiskers)
+    expect(map.size).toBe(2)
+
+    // ... and cleaned up properly on release
+    map.release(key, whiskers)
+    expect(map.get(key)).toBeUndefined()
+    expect(map.size).toBe(1)
+  })
+
+  it('`retain` calls for a different value tracked under the same key are ignored', () => {
+    const map = new RefCountedMap<string, Cat>({ unownedEntryTtlMs: 100 })
+    const key = 'whiskers'
+
+    const whiskers = map.getOrCreate(key, () => ({ name: 'Whiskers' }))
+
+    jest.advanceTimersByTime(101)
+
+    // trigger 'whiskers' entry eviction
+    map.getOrCreate('mittens', () => ({ name: 'Mittens' }))
+    expect(map.get(key)).toBeUndefined()
+
+    const otherWhiskers = map.getOrCreate(key, () => ({ name: 'Other Whiskers' }))
+    expect(map.get(key)).toBe(otherWhiskers)
+
+    // should have no effect
+    map.retain(key, whiskers)
+
+    jest.advanceTimersByTime(101)
+    // should have no effect, trigger 'otherWhiskers' eviction
+    map.retain(key, whiskers)
+    expect(map.get(key)).toBeUndefined()
+    expect(map.size).toBe(0)
+  })
+
+  describe('`release` calls', () => {
+    it('for an evicted entry are ignored', () => {
+      const map = new RefCountedMap<string, Cat>({ unownedEntryTtlMs: 100 })
+      const key = 'whiskers'
+
+      const whiskers = map.getOrCreate(key, () => ({ name: 'Whiskers' }))
+      expect(map.get(key)).toBe(whiskers)
+      expect(map.size).toBe(1)
+
+      jest.advanceTimersByTime(101)
+      // trigger 'whiskers' entry eviction
+      map.getOrCreate('mittens', () => ({ name: 'Mittens' }))
+      expect(map.get(key)).toBeUndefined()
+
+      // should have no effect
+      map.release(key, whiskers)
+      expect(map.get(key)).toBeUndefined()
+      expect(map.size).toBe(1)
+    })
+
+    it('for an unowned entry are ignored', () => {
+      const map = new RefCountedMap<string, Cat>({ unownedEntryTtlMs: 100 })
+      const key = 'whiskers'
+
+      const whiskers = map.getOrCreate(key, () => ({ name: 'Whiskers' }))
+      expect(map.get(key)).toBe(whiskers)
+      expect(map.size).toBe(1)
+
+      // should have no effect
+      map.release(key, whiskers)
+      expect(map.get(key)).toBe(whiskers)
+      expect(map.size).toBe(1)
+    })
+
+    it('for a different value tracked under the same key are ignored', () => {
+      const map = new RefCountedMap<string, Cat>({ unownedEntryTtlMs: 100 })
+      const key = 'whiskers'
+
+      const whiskers = map.getOrCreate(key, () => ({ name: 'Whiskers' }))
+      expect(map.get(key)).toBe(whiskers)
+
+      jest.advanceTimersByTime(101)
+
+      // trigger 'whiskers' entry eviction
+      map.getOrCreate('mittens', () => ({ name: 'Mittens' }))
+      expect(map.get(key)).toBeUndefined()
+
+      const otherWhiskers = map.getOrCreate(key, () => ({ name: 'Other Whiskers' }))
+      expect(map.get(key)).toBe(otherWhiskers)
+
+      // should have no effect
+      map.release(key, whiskers)
+      expect(map.get(key)).toBe(otherWhiskers)
+    })
+  })
+})

--- a/packages/runtime/src/utils/ref-counted-map.ts
+++ b/packages/runtime/src/utils/ref-counted-map.ts
@@ -1,0 +1,116 @@
+type RefCountedMapEntry<V> = {
+  value: V
+  count: number
+}
+
+type UnownedMapEntry<V> = {
+  value: V
+  count: undefined
+  accessedAt: number
+}
+
+type MapEntry<V> = RefCountedMapEntry<V> | UnownedMapEntry<V>
+
+const TTLCheck = {
+  ON_GET: 1 << 0,
+  ON_RETAIN: 1 << 1,
+  ON_RELEASE: 1 << 2,
+} as const
+
+/**
+ * Ref-counted map with explicit retention semantics. Entries are unowned by default and may be evicted after their
+ * TTL unless explicitly retained. This provides TTL-based caching for unowned entries, while allowing consumers to
+ * opt into stronger lifetime control via explicit retention.
+ */
+export class RefCountedMap<K, V> {
+  private readonly map = new Map<K, MapEntry<V>>()
+  private readonly unownedEntryTtlMs: number
+  private readonly ttlCheck: number
+
+  static readonly TTLCheck = TTLCheck
+
+  constructor({
+    unownedEntryTtlMs,
+    ttlCheck = TTLCheck.ON_GET | TTLCheck.ON_RETAIN | TTLCheck.ON_RELEASE,
+  }: {
+    unownedEntryTtlMs: number
+    ttlCheck?: number
+  }) {
+    this.unownedEntryTtlMs = unownedEntryTtlMs
+    this.ttlCheck = ttlCheck
+  }
+
+  get size(): number {
+    return this.map.size
+  }
+
+  get(key: K): V | undefined {
+    return this.map.get(key)?.value
+  }
+
+  getOrCreate(key: K, init: () => V): V {
+    try {
+      const existing = this.map.get(key)
+
+      if (existing) {
+        if (isUnowned(existing)) existing.accessedAt = Date.now()
+        return existing.value
+      }
+
+      const value = init()
+      this.map.set(key, { value, count: undefined, accessedAt: Date.now() })
+      return value
+    } finally {
+      if (this.ttlCheck & TTLCheck.ON_GET) this.removeExpired()
+    }
+  }
+
+  retain(key: K, value: V): void {
+    try {
+      const existing = this.map.get(key)
+
+      // `retain` might be called on a unowned entry that has already been evicted from the map due to TTL expiration
+      // *and* possibly replaced by a new unowned entry with the same key; handle this gracefully
+      if (existing != null) {
+        if (existing.value !== value) return
+        existing.count = (existing.count ?? 0) + 1
+      } else {
+        this.map.set(key, { value, count: 1 })
+      }
+    } finally {
+      if (this.ttlCheck & TTLCheck.ON_RETAIN) this.removeExpired()
+    }
+  }
+
+  release(key: K, value: V): void {
+    try {
+      const existing = this.map.get(key)
+
+      // `release` might be called on an entry that remained unowned due being superseded by a new entry with the same
+      // key after TTL expiration of the original entry; handle this gracefully
+      if (existing == null) return
+      if (isUnowned(existing)) return
+      if (existing.value !== value) return
+
+      if (existing.count > 1) {
+        existing.count -= 1
+      } else {
+        this.map.delete(key)
+      }
+    } finally {
+      if (this.ttlCheck & TTLCheck.ON_RELEASE) this.removeExpired()
+    }
+  }
+
+  private removeExpired(): void {
+    const now = Date.now()
+    const isExpired = (entry: MapEntry<V>): boolean =>
+      isUnowned(entry) && now - entry.accessedAt > this.unownedEntryTtlMs
+
+    this.map.forEach((entry, key) => {
+      if (isExpired(entry)) this.map.delete(key)
+    })
+  }
+}
+
+const isUnowned = <V>(entry: MapEntry<V>): entry is UnownedMapEntry<V> => entry.count === undefined


### PR DESCRIPTION
Scope the runtime's store and host API client by site version + locale.

Demo/smoke test:

https://github.com/user-attachments/assets/49cfa37a-a791-4109-8dbe-e5fdb17653bb

(Correction for the video: "runtime version 0.17" -> "runtime version 0.27")

