### PR TITLE
feat: communicate element visibility to builder

### DIFF
--- a/.changeset/lazy-jars-divide.md
+++ b/.changeset/lazy-jars-divide.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+Measure element visibility as part of box model data

--- a/.changeset/short-humans-lay.md
+++ b/.changeset/short-humans-lay.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/controls": patch
+---
+
+Expose `BoxDisplayModel` type to augment `BoxModel` with visibility data

--- a/packages/controls/src/common/types.ts
+++ b/packages/controls/src/common/types.ts
@@ -1,8 +1,11 @@
+import { type BoxModel } from 'css-box-model'
 import { z } from 'zod'
 
 import * as Schema from './schema'
 
 export { type BoxModel } from 'css-box-model'
+
+export type BoxDisplayModel = BoxModel & { visible?: boolean }
 
 export type Data = z.infer<typeof Schema.data>
 export type Device = z.infer<typeof Schema.deviceId>

--- a/packages/controls/src/controls/slot/slot-control.ts
+++ b/packages/controls/src/controls/slot/slot-control.ts
@@ -1,15 +1,15 @@
-import { type BoxModel } from '../../common'
+import { type BoxDisplayModel } from '../../common'
 
 import { ControlInstance } from '../instance'
 
 type BoxModelChangeMessage = {
   type: typeof SlotControl.CONTAINER_BOX_MODEL_CHANGE
-  payload: { boxModel: BoxModel | null }
+  payload: { boxModel: BoxDisplayModel | null }
 }
 
 type ItemBoxModelChangeMessage = {
   type: typeof SlotControl.ITEM_BOX_MODEL_CHANGE
-  payload: { index: number; boxModel: BoxModel | null }
+  payload: { index: number; boxModel: BoxDisplayModel | null }
 }
 
 type Message = BoxModelChangeMessage | ItemBoxModelChangeMessage
@@ -26,14 +26,14 @@ export class SlotControl extends ControlInstance<Message> {
     return undefined
   }
 
-  changeContainerBoxModel(boxModel: BoxModel | null): void {
+  changeContainerBoxModel(boxModel: BoxDisplayModel | null): void {
     this.sendMessage({
       type: SlotControl.CONTAINER_BOX_MODEL_CHANGE,
       payload: { boxModel },
     })
   }
 
-  changeItemBoxModel(index: number, boxModel: BoxModel | null): void {
+  changeItemBoxModel(index: number, boxModel: BoxDisplayModel | null): void {
     this.sendMessage({
       type: SlotControl.ITEM_BOX_MODEL_CHANGE,
       payload: { index, boxModel },

--- a/packages/controls/src/controls/style/v1/style-control.ts
+++ b/packages/controls/src/controls/style/v1/style-control.ts
@@ -1,10 +1,10 @@
-import { type BoxModel } from '../../../common'
+import { type BoxDisplayModel } from '../../../common'
 
 import { ControlInstance } from '../../instance'
 
 type Message = {
   type: typeof StyleControl.CHANGE_BOX_MODEL
-  payload: { boxModel: BoxModel | null }
+  payload: { boxModel: BoxDisplayModel | null }
 }
 
 export class StyleControl extends ControlInstance<Message> {
@@ -17,7 +17,7 @@ export class StyleControl extends ControlInstance<Message> {
     return undefined
   }
 
-  changeBoxModel(boxModel: BoxModel | null): void {
+  changeBoxModel(boxModel: BoxDisplayModel | null): void {
     this.sendMessage({
       type: StyleControl.CHANGE_BOX_MODEL,
       payload: { boxModel },

--- a/packages/controls/src/controls/style/v2/style-v2-control.ts
+++ b/packages/controls/src/controls/style/v2/style-v2-control.ts
@@ -1,11 +1,11 @@
-import { type BoxModel } from '../../../common'
+import { type BoxDisplayModel } from '../../../common'
 
 import { ControlDefinition } from '../../definition'
 import { ControlInstance, ControlMessage, SendMessage } from '../../instance'
 
 type ItemBoxModelChangeMessage = {
   type: typeof StyleV2Control.CHANGE_BOX_MODEL
-  payload: { boxModel: BoxModel | null }
+  payload: { boxModel: BoxDisplayModel | null }
 }
 
 type ChildControlMessage = {
@@ -46,7 +46,7 @@ export class StyleV2Control extends ControlInstance<Message> {
     }
   }
 
-  changeBoxModel(boxModel: BoxModel | null): void {
+  changeBoxModel(boxModel: BoxDisplayModel | null): void {
     this.sendMessage({
       type: StyleV2Control.CHANGE_BOX_MODEL,
       payload: { boxModel },

--- a/packages/controls/src/stylesheet.ts
+++ b/packages/controls/src/stylesheet.ts
@@ -1,5 +1,5 @@
 import { type Breakpoint, type Breakpoints } from './breakpoints'
-import { type BoxModel } from './common/types'
+import { type BoxDisplayModel } from './common/types'
 import { type ResolvedStyleData, type StyleProperty } from './controls/style'
 import { type ResolvedStyle as ResolvedTypographyStyle } from './controls/typography/style'
 
@@ -21,7 +21,7 @@ export interface Stylesheet {
   breakpoints(): Breakpoints
   defineStyle(
     style: ResolvedStyle,
-    onBoxModelChange?: (boxModel: BoxModel | null) => void,
+    onBoxModelChange?: (boxModel: BoxDisplayModel | null) => void,
   ): string
 
   child(id: string): Stylesheet

--- a/packages/controls/src/testing/mocks/stylesheet.ts
+++ b/packages/controls/src/testing/mocks/stylesheet.ts
@@ -1,5 +1,5 @@
 import { type Breakpoints } from '../../breakpoints'
-import { type BoxModel, type ResponsiveValue } from '../../common/types'
+import { type BoxDisplayModel, type ResponsiveValue } from '../../common/types'
 import { type ResolvedStyleV1, type Stylesheet } from '../../stylesheet'
 
 export const noOpStylesheet: Stylesheet = {
@@ -9,7 +9,7 @@ export const noOpStylesheet: Stylesheet = {
 
   defineStyle(
     _style: ResolvedStyleV1 | ResponsiveValue<any>,
-    _onBoxModelChange?: (boxModel: BoxModel | null) => void,
+    _onBoxModelChange?: (boxModel: BoxDisplayModel | null) => void,
   ): string {
     return ''
   },

--- a/packages/runtime/src/builder/core/index.ts
+++ b/packages/runtime/src/builder/core/index.ts
@@ -1,5 +1,6 @@
 export {
   type BoxModel,
+  type BoxDisplayModel,
   type Breakpoint,
   type BreakpointId,
   type Breakpoints,

--- a/packages/runtime/src/components/builtin/Box/Box.tsx
+++ b/packages/runtime/src/components/builtin/Box/Box.tsx
@@ -15,7 +15,12 @@ import { v4 as uuid } from 'uuid'
 import { Element } from '../../../runtimes/react'
 import Placeholder from './components/Placeholder'
 import { areBoxAnimationPropsEqual, BoxAnimationProps, useBoxAnimation } from './animations'
-import { parse, createBox, type BoxModelHandle } from '../../../state/modules/read-write/box-models'
+import {
+  parse,
+  createBox,
+  isElementVisible,
+  type BoxModelHandle,
+} from '../../../state/modules/read-write/box-models'
 import BackgroundsContainer from '../../shared/BackgroundsContainer'
 import { useResponsiveStyle } from '../../utils/responsive-style'
 import { GridItem } from '../../shared/grid-item'
@@ -122,7 +127,9 @@ const Box = forwardRef(function Box(
           left: parse(marginBoxComputedStyle.marginLeft),
         }
 
-        return borderBox ? createBox({ borderBox, padding, border, margin }) : null
+        const visible = marginBoxElement ? isElementVisible(marginBoxElement) : undefined
+
+        return borderBox ? createBox({ borderBox, padding, border, margin, visible }) : null
       },
     }),
     [],

--- a/packages/runtime/src/controls/rich-text-v2/control.ts
+++ b/packages/runtime/src/controls/rich-text-v2/control.ts
@@ -6,7 +6,7 @@ import {
   RichTextDefinition,
   ControlInstance,
   Slate,
-  type BoxModel,
+  type BoxDisplayModel,
   type DataType,
   type SendMessage,
   type Data,
@@ -47,7 +47,7 @@ type SwitchToBuildModeMessage = {
 
 type ChangeBoxModelMessage = {
   type: typeof RichTextV2Control.CHANGE_BOX_MODEL
-  payload: { boxModel: BoxModel | null }
+  payload: { boxModel: BoxDisplayModel | null }
 }
 
 type UndoMessage = { type: typeof RichTextV2Control.UNDO }
@@ -190,7 +190,7 @@ export class RichTextV2Control extends ControlInstance<Message> {
     this.sendMessage({ type: RichTextV2Control.REDO })
   }
 
-  changeBoxModel(boxModel: BoxModel | null): void {
+  changeBoxModel(boxModel: BoxDisplayModel | null): void {
     this.sendMessage({
       type: RichTextV2Control.CHANGE_BOX_MODEL,
       payload: { boxModel },

--- a/packages/runtime/src/controls/rich-text/control.ts
+++ b/packages/runtime/src/controls/rich-text/control.ts
@@ -5,7 +5,7 @@ import { BuilderEditMode } from '../../state/modules/builder-edit-mode'
 import {
   ControlInstance,
   richTextDAOToDTO,
-  type BoxModel,
+  type BoxDisplayModel,
   type RichTextValue,
 } from '@makeswift/controls'
 
@@ -42,7 +42,7 @@ type RedoMessage = {
 
 type BoxModelChangeMessage = {
   type: typeof RichTextControl.CHANGE_BOX_MODEL
-  payload: { boxModel: BoxModel | null }
+  payload: { boxModel: BoxDisplayModel | null }
 }
 
 type Message =
@@ -131,7 +131,7 @@ export class RichTextControl extends ControlInstance<Message> {
     this.sendMessage({ type: RichTextControl.REDO })
   }
 
-  changeBoxModel(boxModel: BoxModel | null): void {
+  changeBoxModel(boxModel: BoxDisplayModel | null): void {
     this.sendMessage({
       type: RichTextControl.CHANGE_BOX_MODEL,
       payload: { boxModel },

--- a/packages/runtime/src/prop-controllers/instances.ts
+++ b/packages/runtime/src/prop-controllers/instances.ts
@@ -1,8 +1,8 @@
 import { type Descriptor, isLegacyDescriptor } from './descriptors'
-import { type BoxModel } from '../state/modules/read-write/box-models'
 import { Types as PropControllerTypes } from '@makeswift/prop-controllers'
 
 import {
+  type BoxDisplayModel,
   type ControlMessage,
   type SendMessage,
   type InstanceType,
@@ -19,12 +19,12 @@ export const TableFormFieldsMessageType = {
 
 type TableLayoutTableFormFieldsMessage = {
   type: typeof TableFormFieldsMessageType.TABLE_FORM_LAYOUT_CHANGE
-  payload: { layout: BoxModel }
+  payload: { layout: BoxDisplayModel }
 }
 
 type TableFieldLayoutTableFormFieldsMessage = {
   type: typeof TableFormFieldsMessageType.TABLE_FORM_FIELD_LAYOUT_CHANGE
-  payload: { layout: BoxModel; index: number }
+  payload: { layout: BoxDisplayModel; index: number }
 }
 
 export type TableFormFieldsMessage =
@@ -37,11 +37,11 @@ export class TableFormFieldsPropController extends ControlInstance<TableFormFiel
     return undefined
   }
 
-  tableFormLayoutChange(payload: { layout: BoxModel }) {
+  tableFormLayoutChange(payload: { layout: BoxDisplayModel }) {
     this.sendMessage({ type: TableFormFieldsMessageType.TABLE_FORM_LAYOUT_CHANGE, payload })
   }
 
-  tableFormFieldLayoutChange(payload: { layout: BoxModel; index: number }) {
+  tableFormFieldLayoutChange(payload: { layout: BoxDisplayModel; index: number }) {
     this.sendMessage({ type: TableFormFieldsMessageType.TABLE_FORM_FIELD_LAYOUT_CHANGE, payload })
   }
 }

--- a/packages/runtime/src/runtimes/react/element-imperative-handle.ts
+++ b/packages/runtime/src/runtimes/react/element-imperative-handle.ts
@@ -1,5 +1,4 @@
-import { BoxModel } from '@makeswift/controls'
-import { BoxModelHandle } from '../../state/modules/read-write/box-models'
+import { BoxModelHandle, type BoxDisplayModel } from '../../state/modules/read-write/box-models'
 import { Descriptor } from '../../prop-controllers/descriptors'
 import { DescriptorsPropControllers } from '../../prop-controllers/instances'
 import { isMeasurable, measure } from '../../state/modules/read-write/box-models'
@@ -26,7 +25,7 @@ export class ElementImperativeHandle<
     if (this.lastPropControllers !== null) this.setPropControllers(this.lastPropControllers)
   }
 
-  getBoxModel(): BoxModel | null {
+  getBoxModel(): BoxDisplayModel | null {
     const current = this.getCurrent()
 
     return isMeasurable(current) ? measure(current) : null

--- a/packages/runtime/src/runtimes/react/hooks/use-stylesheet-factory.ts
+++ b/packages/runtime/src/runtimes/react/hooks/use-stylesheet-factory.ts
@@ -4,8 +4,8 @@ import { type EmotionCache } from '@emotion/cache'
 import { type SerializedStyles } from '@emotion/utils'
 
 import {
+  type BoxDisplayModel,
   type Breakpoints,
-  type BoxModel,
   type Stylesheet,
   type ResolvedStyle,
   type ResolvedStyleV2,
@@ -35,7 +35,7 @@ export function useStylesheetFactory(): StylesheetFactory {
   const componentUid = useCssId()
 
   const computedStyles = useRef<Record<string, SerializedStyles>>({}).current
-  const boxModelCallbacks = useRef<Record<string, (boxModel: BoxModel | null) => void>>({}).current
+  const boxModelCallbacks = useRef<Record<string, (boxModel: BoxDisplayModel | null) => void>>({}).current
 
   return useMemo(() => {
     const getStylesheet = (styleSheetId: string): Stylesheet => ({
@@ -45,7 +45,7 @@ export function useStylesheetFactory(): StylesheetFactory {
 
       defineStyle(
         style: ResolvedStyle,
-        onBoxModelChange?: (boxModel: BoxModel | null) => void,
+        onBoxModelChange?: (boxModel: BoxDisplayModel | null) => void,
       ): string {
         const serialized = serializeStyle(breakpoints, style, cache)
         const uid = `u-${componentUid}-${styleSheetId}`

--- a/packages/runtime/src/runtimes/react/poll-box-model.ts
+++ b/packages/runtime/src/runtimes/react/poll-box-model.ts
@@ -1,4 +1,4 @@
-import { BoxModel, getBox } from '../../state/modules/read-write/box-models'
+import { BoxDisplayModel, getBox } from '../../state/modules/read-write/box-models'
 import deepEqual from '../../utils/deepEqual'
 
 export function pollBoxModel({
@@ -6,9 +6,9 @@ export function pollBoxModel({
   onBoxModelChange,
 }: {
   element: Element | null
-  onBoxModelChange(boxModel: BoxModel | null): void
+  onBoxModelChange(boxModel: BoxDisplayModel | null): void
 }): () => void {
-  let currentBoxModel: BoxModel | null = null
+  let currentBoxModel: BoxDisplayModel | null = null
 
   const handleAnimationFrameRequest = () => {
     const measuredBoxModel = element == null ? null : getBox(element)

--- a/packages/runtime/src/state/builder-api/actions.ts
+++ b/packages/runtime/src/state/builder-api/actions.ts
@@ -5,7 +5,7 @@ import { type PropControllerMessage } from '../../prop-controllers/instances'
 
 import { type Document } from '../modules/read-only-documents'
 import { type ComponentMeta } from '../modules/components-meta'
-import { type BoxModel } from '../modules/read-write/box-models'
+import { type BoxDisplayModel } from '../modules/read-write/box-models'
 
 import { type ElementSize } from '../middleware/read-write/builder-api/element-size'
 import { type DocumentPayload, type SharedAction, SharedActionTypes } from '../shared-api'
@@ -70,7 +70,7 @@ type ChangeDocumentElementSizeAction = {
 
 type ChangeElementBoxModelsAction = {
   type: typeof BuilderActionTypes.CHANGE_ELEMENT_BOX_MODELS
-  payload: { changedElementBoxModels: Map<string, Map<string, BoxModel | null>> }
+  payload: { changedElementBoxModels: Map<string, Map<string, BoxDisplayModel | null>> }
 }
 
 type MessageBuilderPropControllerAction<T = PropControllerMessage> = {
@@ -169,7 +169,7 @@ export function changeDocumentElementSize(size: ElementSize): ChangeDocumentElem
 }
 
 export function changeElementBoxModels(
-  changedElementBoxModels: Map<string, Map<string, BoxModel | null>>,
+  changedElementBoxModels: Map<string, Map<string, BoxDisplayModel | null>>,
 ): ChangeElementBoxModelsAction {
   return {
     type: BuilderActionTypes.CHANGE_ELEMENT_BOX_MODELS,

--- a/packages/runtime/src/state/middleware/read-write/builder-api/initialize-connection.ts
+++ b/packages/runtime/src/state/middleware/read-write/builder-api/initialize-connection.ts
@@ -30,10 +30,10 @@ function measureElements(): ThunkAction<void, State, unknown, Action> {
   return (dispatch, getState) => {
     const measurables = getMeasurables(getState())
     const currentBoxModels = getBoxModels(getState())
-    const measuredBoxModels = new Map<string, Map<string, BoxModels.BoxModel>>()
+    const measuredBoxModels = new Map<string, Map<string, BoxModels.BoxDisplayModel>>()
 
     measurables.forEach((documentMeasurables, documentKey) => {
-      const measuredDocumentBoxModels = new Map<string, BoxModels.BoxModel>()
+      const measuredDocumentBoxModels = new Map<string, BoxModels.BoxDisplayModel>()
 
       documentMeasurables.forEach((measurable, elementKey) => {
         const boxModel = BoxModels.measure(measurable)
@@ -46,10 +46,10 @@ function measureElements(): ThunkAction<void, State, unknown, Action> {
       }
     })
 
-    const changedBoxModels = new Map<string, Map<string, BoxModels.BoxModel | null>>()
+    const changedBoxModels = new Map<string, Map<string, BoxModels.BoxDisplayModel | null>>()
 
     currentBoxModels.forEach((currentDocumentBoxModels, documentKey) => {
-      const changedDocumentBoxModels = new Map<string, BoxModels.BoxModel | null>()
+      const changedDocumentBoxModels = new Map<string, BoxModels.BoxDisplayModel | null>()
 
       currentDocumentBoxModels.forEach((_boxModel, elementKey) => {
         if (!measuredBoxModels.get(documentKey)?.has(elementKey)) {
@@ -63,7 +63,7 @@ function measureElements(): ThunkAction<void, State, unknown, Action> {
     })
 
     measuredBoxModels.forEach((measuredDocumentBoxModels, documentKey) => {
-      const changedDocumentBoxModels = new Map<string, BoxModels.BoxModel | null>()
+      const changedDocumentBoxModels = new Map<string, BoxModels.BoxDisplayModel | null>()
 
       measuredDocumentBoxModels.forEach((measuredBoxModel, elementKey) => {
         const currentBoxModel = getBoxModel(getState(), documentKey, elementKey)

--- a/packages/runtime/src/state/modules/read-write/box-models.ts
+++ b/packages/runtime/src/state/modules/read-write/box-models.ts
@@ -1,4 +1,4 @@
-import { type BoxModel } from '@makeswift/controls'
+import { type BoxDisplayModel } from '@makeswift/controls'
 import {
   createBox as createBoxWithoutScroll,
   CreateBoxArgs,
@@ -10,7 +10,7 @@ import { type Action, type UnknownAction, isKnownAction } from '../../actions'
 import { ReadWriteActionTypes } from '../../actions/internal/read-write-actions'
 import { BuilderActionTypes } from '../../builder-api/actions'
 
-export type { BoxModel }
+export type { BoxDisplayModel }
 
 export function parse(rawString: string): number {
   const value = Number(rawString.replace(/px$/, ''))
@@ -18,16 +18,35 @@ export function parse(rawString: string): number {
   return Number.isFinite(value) ? value : 0
 }
 
-export function createBox(boxArgs: CreateBoxArgs): BoxModel {
-  return withScroll(createBoxWithoutScroll(boxArgs))
+export function createBox(boxArgs: CreateBoxArgs & { visible?: boolean }): BoxDisplayModel {
+  const box = withScroll(createBoxWithoutScroll(boxArgs))
+  return { ...box, visible: boxArgs.visible }
 }
 
-export function getBox(element: Element): BoxModel {
-  return withScroll(getBoxWithoutScroll(element))
+export function isElementVisible(element: Element): boolean {
+  // checkVisibility is widely supported as of March 2024, but we're adding this
+  // check as a precaution for browsers where it may not be available.
+  // https://developer.mozilla.org/en-US/docs/Web/API/Element/checkVisibility
+  if (element.checkVisibility == null) {
+    return true
+  }
+
+  return element.checkVisibility({
+    visibilityProperty: true,
+    contentVisibilityAuto: true,
+    opacityProperty: true,
+  })
+}
+
+export function getBox(element: Element): BoxDisplayModel {
+  const visible = isElementVisible(element)
+  const boxModel = withScroll(getBoxWithoutScroll(element))
+
+  return { ...boxModel, visible }
 }
 
 export interface BoxModelHandle {
-  getBoxModel(): BoxModel | null
+  getBoxModel(): BoxDisplayModel | null
 }
 
 export type Measurable = Element | BoxModelHandle
@@ -47,7 +66,7 @@ export function isMeasurable(value: unknown): value is Measurable {
   return false
 }
 
-export function measure(measurable: Measurable): BoxModel | null {
+export function measure(measurable: Measurable): BoxDisplayModel | null {
   if (measurable instanceof Element) return getBox(measurable)
 
   return measurable.getBoxModel()
@@ -55,7 +74,7 @@ export function measure(measurable: Measurable): BoxModel | null {
 
 export type State = {
   measurables: Map<string, Map<string, Measurable>>
-  boxModels: Map<string, Map<string, BoxModel>>
+  boxModels: Map<string, Map<string, BoxDisplayModel>>
 }
 
 export function getInitialState(): State {
@@ -66,7 +85,7 @@ export function getMeasurables(state: State): Map<string, Map<string, Measurable
   return state.measurables
 }
 
-export function getBoxModels(state: State): Map<string, Map<string, BoxModel>> {
+export function getBoxModels(state: State): Map<string, Map<string, BoxDisplayModel>> {
   return state.boxModels
 }
 
@@ -74,7 +93,7 @@ export function getBoxModel(
   state: State,
   documentKey: string,
   elementKey: string,
-): BoxModel | null {
+): BoxDisplayModel | null {
   return getBoxModels(state).get(documentKey)?.get(elementKey) ?? null
 }
 

--- a/packages/runtime/src/state/read-write-state.ts
+++ b/packages/runtime/src/state/read-write-state.ts
@@ -57,7 +57,7 @@ export function getMeasurables(state: State): Map<string, Map<string, BoxModels.
   return BoxModels.getMeasurables(getBoxModelsStateSlice(state))
 }
 
-export function getBoxModels(state: State): Map<string, Map<string, BoxModels.BoxModel>> {
+export function getBoxModels(state: State): Map<string, Map<string, BoxModels.BoxDisplayModel>> {
   return BoxModels.getBoxModels(getBoxModelsStateSlice(state))
 }
 
@@ -65,7 +65,7 @@ export function getBoxModel(
   state: State,
   documentKey: string,
   elementKey: string,
-): BoxModels.BoxModel | null {
+): BoxModels.BoxDisplayModel | null {
   return BoxModels.getBoxModel(getBoxModelsStateSlice(state), documentKey, elementKey)
 }
 


### PR DESCRIPTION
Updates the box model data sent to the builder to include whether the [element is visible or not](https://developer.mozilla.org/en-US/docs/Web/API/Element/checkVisibility).