### PR TITLE
Remove rethrow of error in `renderToReadableStream`

### DIFF
--- a/.changeset/thirty-buttons-brake.md
+++ b/.changeset/thirty-buttons-brake.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/hono-react': patch
+---
+
+Allow providing a custom `onError` handler to `renderToReadableStream`.

--- a/packages/hono-react/src/server/render.tsx
+++ b/packages/hono-react/src/server/render.tsx
@@ -23,6 +23,7 @@ type RenderOptions = RootStyleProps &
     | 'bootstrapScripts'
     | 'bootstrapModules'
     | 'progressiveChunkSize'
+    | 'onError'
   >
 
 export async function renderHtml(
@@ -36,12 +37,7 @@ export async function renderHtml(
     <RootStyleRegistry cache={cache} enableCssReset={enableCssReset}>
       {children}
     </RootStyleRegistry>,
-    {
-      ...renderOptions,
-      onError(error: unknown) {
-        throw Error(`Server-side rendering error: ${error}`)
-      },
-    },
+    { ...renderOptions },
   )
 
   return { html, getStyles }


### PR DESCRIPTION
Part of [ARR-628](https://linear.app/makeswift/issue/ARR-628/sleep-country-specific-page-intermittently-fails-to-load), context is here: https://makeswifthq.slack.com/archives/C08JCF04397/p1775580422241279?thread_ts=1775258919.810929&cid=C08JCF04397 



