### PR TITLE
fix: client-side localized global element requests on non-null locale

### DIFF
--- a/.changeset/purple-trains-sin.md
+++ b/.changeset/purple-trains-sin.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Fix client-side localized global element requests when on non-null locale.

--- a/packages/runtime/src/client/index.ts
+++ b/packages/runtime/src/client/index.ts
@@ -571,6 +571,10 @@ export class MakeswiftClient {
 
             localizedResourcesMap.set(globalElementId, localizedGlobalElement.id)
             localizedGlobalElements.set(localizedGlobalElement.id, localizedGlobalElement)
+          } else {
+            // Record that this localized global element doesn't exist so the
+            // client won't try to fetch it again (which would result in a 404).
+            localizedResourcesMap.set(globalElementId, null)
           }
         }
 


### PR DESCRIPTION
## Summary

Fixes unintended 404 client-side requests for localized global elements when the document locale is non-null (e.g., in MoS where locale defaults to `'en'`). The number of 404s scales linearly with the number of global elements on a page.

This also happens on localized pages in `apps/nextjs-app-router`.


https://github.com/user-attachments/assets/82ebab41-1f4b-472c-b3aa-05ba763b1d43



## Problem

During server-side introspection (`MakeswiftClient.introspect`), when a localized global element doesn't exist, nothing was recorded in `localizedResourcesMap`. The client-side `fetchAPIResource` distinguishes between these two states:

```ts
// getLocalizedResourceId uses Map.get() which returns:
//   undefined → key not in map, i.e. "haven't checked yet, please fetch"
//   null     → key exists with null value, i.e. "already checked, doesn't exist, skip fetch"

// If `getLocalizedResourceId` returns null, it means we have tried to fetch the resource,
// but the resource is not available. If we haven't fetched it yet, it'll return undefined.
if (getLocalizedResourceId(state, locale, resourceId) === null) {
  return null
}
```

Since the server never recorded `null` for missing localized elements, the client always saw `undefined` and fired a fetch that returned 404.

## Fix

Record `null` in `localizedResourcesMap` when a localized global element is not found during introspection. This tells the client the resource was already looked up and doesn't exist.

```
introspect() → localizedResourcesMap.set(globalElementId, null)
  ↓ serialized in snapshot.cacheData
useCacheData() → dispatch(updateAPIClientCache)
  ↓ populates localized-resources-map store
fetchAPIResource() → getLocalizedResourceId() returns null → skip fetch
```

## Note for MoS

After deploying, existing KV-cached snapshots must be invalidated (or allowed to expire) since they contain the old `localizedResourcesMap` without the `null` entries.