### PR TITLE
feat: always show row and column gap for boxes

### DIFF
--- a/.changeset/spicy-jobs-wave.md
+++ b/.changeset/spicy-jobs-wave.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Always show row and column gap controls for box elements

--- a/packages/runtime/src/components/builtin/Box/register.ts
+++ b/packages/runtime/src/components/builtin/Box/register.ts
@@ -100,12 +100,8 @@ export function registerComponent(runtime: ReactRuntimeCore) {
         border: Border({ format: Border.Format.ClassName }),
         borderRadius: BorderRadius({ format: BorderRadius.Format.ClassName }),
         boxShadow: Shadows({ format: Shadows.Format.ClassName }),
-        rowGap: GapY(props => ({
-          hidden: props.children == null,
-        })),
-        columnGap: GapX(props => ({
-          hidden: props.children == null,
-        })),
+        rowGap: GapY(),
+        columnGap: GapX(),
         boxAnimateType: ResponsiveSelect({
           label: 'Animate box in',
           labelOrientation: 'vertical',


### PR DESCRIPTION
This pull request makes a small adjustment to the `registerComponent` function for the Box component. The change removes the logic that conditionally hides the `rowGap` and `columnGap` properties when there are no children, making these properties always visible regardless of the presence of children.

<img width="2990" height="1548" alt="CleanShot 2026-04-17 at 23 26 21@2x" src="https://github.com/user-attachments/assets/2e82b405-f9f9-438f-8802-a541f912fa4a" />
