### PR TITLE
fix: lazy load box video background

### DIFF
--- a/.changeset/wise-walls-double.md
+++ b/.changeset/wise-walls-double.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+Lazy load the builtin box component's video player to avoid automatically loading `react-player`

--- a/packages/runtime/src/components/shared/BackgroundsContainer/components/Backgrounds/index.tsx
+++ b/packages/runtime/src/components/shared/BackgroundsContainer/components/Backgrounds/index.tsx
@@ -1,14 +1,15 @@
-import { ReactNode } from 'react'
+import { lazy, ReactNode, Suspense } from 'react'
 import { BackgroundsPropControllerValue, BackgroundsData } from '../../../../hooks'
 import { type ResponsiveValue } from '@makeswift/controls'
 import { ColorValue as Color } from '../../../../utils/types'
 import { colorToString } from '../../../../utils/colorToString'
 import Parallax from '../Parallax'
-import BackgroundVideo from '../BackgroundVideo'
 import { type CSSObject } from '@emotion/serialize'
 import { useStyle } from '../../../../../runtimes/react/use-style'
 import { useResponsiveStyle } from '../../../../utils/responsive-style'
 import { useFrameworkContext } from '../../../../../runtimes/react/components/hooks/use-framework-context'
+
+const BackgroundVideo = lazy(() => import('../BackgroundVideo'))
 
 function getColor(color: Color | null | undefined) {
   if (color == null) return 'black'
@@ -257,13 +258,15 @@ function VideoBackground({
     <Parallax strength={parallax}>
       {getParallaxProps => (
         <div {...getParallaxProps({ className: useStyle(containerStyle) })}>
-          <BackgroundVideo
-            url={url}
-            zoom={zoom}
-            opacity={opacity}
-            aspectRatio={getAspectRatio(aspectRatio)}
-            maskColor={maskColor}
-          />
+          <Suspense>
+            <BackgroundVideo
+              url={url}
+              zoom={zoom}
+              opacity={opacity}
+              aspectRatio={getAspectRatio(aspectRatio)}
+              maskColor={maskColor}
+            />
+          </Suspense>
         </div>
       )}
     </Parallax>


### PR DESCRIPTION
Lazy loads the box video background to avoid pulling in the React player dependency whenever a box is used.

Notably: Next.js eagerly includes dependencies in the bundle, so we're not expecting to see a change in bundle size. That being said, this does make a difference in other environments like Hono Cloudflare.

Behavior on `main`:

https://github.com/user-attachments/assets/f4797551-729f-422e-aad7-1a553726a670

With lazy-loading:

https://github.com/user-attachments/assets/80254ee2-9666-4fe4-92dd-467a8f7b3748


