### PR TITLE
fix: handle ops where deletion path is not in new element tree

### DIFF
--- a/.changeset/perfect-gorillas-grin.md
+++ b/.changeset/perfect-gorillas-grin.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+Fixes an issue where during updating the element tree cache, we use an element path that's only valid during an intermediate state to read into the final element tree.

--- a/packages/runtime/src/state/modules/__tests__/element-trees.test.ts
+++ b/packages/runtime/src/state/modules/__tests__/element-trees.test.ts
@@ -3,6 +3,8 @@ import * as Fixtures from './fixtures/element-trees'
 import {
   ELEMENT_TREE_DEMO_COMPONENT_TYPE,
   ElementTreesDemo,
+  SLOT_DEMO_COMPONENT_TYPE,
+  SlotDemo,
 } from './fixtures/element-trees-demo-component'
 
 import { createReactRuntime } from '../../../runtimes/react/testing/react-runtime'
@@ -183,5 +185,63 @@ describe('resetting an element tree', () => {
     // they should share no common keys
     expect(initialElementKeys.some(key => elementKeysAfterReset.includes(key))).toBe(false)
     expect(elementKeysAfterReset.some(key => initialElementKeys.includes(key))).toBe(false)
+  })
+})
+
+describe('applyChanges', () => {
+  const runtime = createReactRuntime()
+  runtime.registerComponent(SlotDemo, {
+    type: SLOT_DEMO_COMPONENT_TYPE,
+    label: 'Slot Demo',
+    props: {
+      children: Slot(),
+    },
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  test('handle element reparenting op', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(jest.fn())
+
+    const descriptors = getPropControllerDescriptors(runtime.protoStore.getState())
+    const documentKey = '11111111-1111-1111-111111111111'
+
+    const oldDocument = {
+      key: documentKey,
+      rootElement: Fixtures.reparentingElementTree.before,
+    }
+
+    const initialState = ElementTrees.reducer(
+      ElementTrees.getInitialState(),
+      createElementTree({
+        document: oldDocument,
+        descriptors,
+      }),
+    )
+
+    const newDocument = {
+      key: documentKey,
+      rootElement: Fixtures.reparentingElementTree.after,
+    }
+
+    const reparentOp = Fixtures.reparentingElementTree.op
+
+    const updatedState = ElementTrees.reducer(
+      initialState,
+      changeElementTree({
+        oldDocument,
+        newDocument,
+        descriptors,
+        operation: reparentOp,
+      }),
+    )
+
+    expect(consoleError).not.toHaveBeenCalled()
+
+    const elements = ElementTrees.getElements(updatedState, documentKey)
+    const rootKey = Fixtures.reparentingElementTree.before.key
+    expect(elements.get(rootKey)).toEqual(Fixtures.reparentingElementTree.after)
   })
 })

--- a/packages/runtime/src/state/modules/__tests__/fixtures/element-trees-demo-component.tsx
+++ b/packages/runtime/src/state/modules/__tests__/fixtures/element-trees-demo-component.tsx
@@ -10,3 +10,9 @@ export function ElementTreesDemo({ left, right }: { left: ReactNode; right: Reac
     </div>
   )
 }
+
+export const SLOT_DEMO_COMPONENT_TYPE = 'SlotDemo'
+
+export function SlotDemo({ children }: { children: ReactNode }) {
+  return <div>{children}</div>
+}

--- a/packages/runtime/src/state/modules/__tests__/fixtures/element-trees.ts
+++ b/packages/runtime/src/state/modules/__tests__/fixtures/element-trees.ts
@@ -1,3 +1,6 @@
+import { type Operation } from 'ot-json0'
+import { type ElementData } from '@makeswift/controls'
+
 export const homePage = {
   key: '1cbb8e34-bf1c-4449-a002-71177d2f61ab',
   props: {
@@ -4286,4 +4289,333 @@ export const resetElementTree = {
       },
     },
   },
+}
+
+// Testing fixture that demonstrates reparenting an image from a deeply nested
+// position in the element tree to the top level of the tree.
+export const reparentingElementTree: {
+  before: ElementData
+  after: ElementData
+  op: Operation
+} = {
+  before: {
+    key: 'c18ae419-b096-46f0-8411-3a5af9e0ef50',
+    props: {
+      children: {
+        '@@makeswift/type': 'prop-controllers::grid::v1',
+        value: {
+          columns: [
+            {
+              deviceId: 'desktop',
+              value: {
+                count: 12,
+                spans: [[12]],
+              },
+            },
+          ],
+          elements: [
+            {
+              key: 'ecd818e4-a909-4349-a9d3-52ac7e48b040',
+              props: {
+                children: {
+                  columns: [
+                    {
+                      deviceId: 'desktop',
+                      value: {
+                        count: 12,
+                        spans: [[12]],
+                      },
+                    },
+                  ],
+                  elements: [
+                    {
+                      key: 'a0ea33d7-a220-4876-81dc-d43d06c0e4df',
+                      props: {
+                        children: {
+                          columns: [
+                            {
+                              deviceId: 'desktop',
+                              value: {
+                                count: 12,
+                                spans: [[12]],
+                              },
+                            },
+                          ],
+                          elements: [
+                            {
+                              key: 'f3dc7f9f-62c3-4bd8-8e8f-3028100dc396',
+                              props: {
+                                children: {
+                                  columns: [
+                                    {
+                                      deviceId: 'desktop',
+                                      value: {
+                                        count: 12,
+                                        spans: [[12]],
+                                      },
+                                    },
+                                  ],
+                                  elements: [
+                                    {
+                                      key: '32da0440-21bb-4b89-841d-4217bacb7ab8',
+                                      props: {},
+                                      type: './components/Image/index.js',
+                                    },
+                                  ],
+                                },
+                              },
+                              type: 'SlotDemo',
+                            },
+                          ],
+                        },
+                      },
+                      type: 'SlotDemo',
+                    },
+                  ],
+                },
+              },
+              type: 'SlotDemo',
+            },
+          ],
+        },
+      },
+    },
+    type: './components/Root/index.js',
+  },
+  after: {
+    key: 'c18ae419-b096-46f0-8411-3a5af9e0ef50',
+    props: {
+      children: {
+        '@@makeswift/type': 'prop-controllers::grid::v1',
+        value: {
+          columns: [
+            {
+              deviceId: 'desktop',
+              value: {
+                spans: [[12], [12]],
+                count: 12,
+              },
+            },
+          ],
+          elements: [
+            {
+              key: '32da0440-21bb-4b89-841d-4217bacb7ab8',
+              props: {},
+              type: './components/Image/index.js',
+            },
+            {
+              key: 'ecd818e4-a909-4349-a9d3-52ac7e48b040',
+              props: {
+                children: {
+                  columns: [
+                    {
+                      deviceId: 'desktop',
+                      value: {
+                        count: 12,
+                        spans: [[12]],
+                      },
+                    },
+                  ],
+                  elements: [
+                    {
+                      key: 'a0ea33d7-a220-4876-81dc-d43d06c0e4df',
+                      props: {
+                        children: {
+                          columns: [
+                            {
+                              deviceId: 'desktop',
+                              value: {
+                                count: 12,
+                                spans: [[12]],
+                              },
+                            },
+                          ],
+                          elements: [
+                            {
+                              key: 'f3dc7f9f-62c3-4bd8-8e8f-3028100dc396',
+                              props: {},
+                              type: 'SlotDemo',
+                            },
+                          ],
+                        },
+                      },
+                      type: 'SlotDemo',
+                    },
+                  ],
+                },
+              },
+              type: 'SlotDemo',
+            },
+          ],
+        },
+      },
+    },
+    type: './components/Root/index.js',
+  },
+
+  op: [
+    {
+      p: [
+        'props',
+        'children',
+        'value',
+        'elements',
+        0,
+        'props',
+        'children',
+        'elements',
+        0,
+        'props',
+        'children',
+        'elements',
+        0,
+        'props',
+        'children',
+      ],
+      od: {
+        columns: [
+          {
+            deviceId: 'desktop',
+            value: {
+              count: 12,
+              spans: [[12]],
+            },
+          },
+        ],
+        elements: [
+          {
+            key: '32da0440-21bb-4b89-841d-4217bacb7ab8',
+            props: {},
+            type: './components/Image/index.js',
+          },
+        ],
+      },
+    },
+    {
+      p: ['props', 'children'],
+      od: {
+        '@@makeswift/type': 'prop-controllers::grid::v1',
+        value: {
+          columns: [
+            {
+              deviceId: 'desktop',
+              value: {
+                spans: [[12]],
+                count: 12,
+              },
+            },
+          ],
+          elements: [
+            {
+              key: 'ecd818e4-a909-4349-a9d3-52ac7e48b040',
+              props: {
+                children: {
+                  columns: [
+                    {
+                      deviceId: 'desktop',
+                      value: {
+                        count: 12,
+                        spans: [[12]],
+                      },
+                    },
+                  ],
+                  elements: [
+                    {
+                      key: 'a0ea33d7-a220-4876-81dc-d43d06c0e4df',
+                      props: {
+                        children: {
+                          columns: [
+                            {
+                              deviceId: 'desktop',
+                              value: {
+                                count: 12,
+                                spans: [[12]],
+                              },
+                            },
+                          ],
+                          elements: [
+                            {
+                              key: 'f3dc7f9f-62c3-4bd8-8e8f-3028100dc396',
+                              props: {},
+                              type: 'SlotDemo',
+                            },
+                          ],
+                        },
+                      },
+                      type: 'SlotDemo',
+                    },
+                  ],
+                },
+              },
+              type: 'SlotDemo',
+            },
+          ],
+        },
+      },
+      oi: {
+        '@@makeswift/type': 'prop-controllers::grid::v1',
+        value: {
+          columns: [
+            {
+              deviceId: 'desktop',
+              value: {
+                spans: [[12], [12]],
+                count: 12,
+              },
+            },
+          ],
+          elements: [
+            {
+              key: '32da0440-21bb-4b89-841d-4217bacb7ab8',
+              props: {},
+              type: './components/Image/index.js',
+            },
+            {
+              key: 'ecd818e4-a909-4349-a9d3-52ac7e48b040',
+              props: {
+                children: {
+                  columns: [
+                    {
+                      deviceId: 'desktop',
+                      value: {
+                        count: 12,
+                        spans: [[12]],
+                      },
+                    },
+                  ],
+                  elements: [
+                    {
+                      key: 'a0ea33d7-a220-4876-81dc-d43d06c0e4df',
+                      props: {
+                        children: {
+                          columns: [
+                            {
+                              deviceId: 'desktop',
+                              value: {
+                                count: 12,
+                                spans: [[12]],
+                              },
+                            },
+                          ],
+                          elements: [
+                            {
+                              key: 'f3dc7f9f-62c3-4bd8-8e8f-3028100dc396',
+                              props: {},
+                              type: 'SlotDemo',
+                            },
+                          ],
+                        },
+                      },
+                      type: 'SlotDemo',
+                    },
+                  ],
+                },
+              },
+              type: 'SlotDemo',
+            },
+          ],
+        },
+      },
+    },
+  ],
 }

--- a/packages/runtime/src/state/modules/element-trees.ts
+++ b/packages/runtime/src/state/modules/element-trees.ts
@@ -1,5 +1,5 @@
 import { type Operation } from 'ot-json0'
-import { getIn } from 'immutable'
+import { getIn, removeIn, setIn } from 'immutable'
 
 import { type Element, type ElementData, isElementReference } from '@makeswift/controls'
 
@@ -269,17 +269,19 @@ function deleteElement(
 function applyDelete(
   elementTree: ElementTree,
   descriptors: DescriptorsByComponentType,
-  rootElements: { old: Element; new: Element },
+  rootElements: { before: Element; after: Element },
   path: OperationPath,
 ): ElementTree {
   const [deleteElementPath, ...parentElementPaths] = getChangedElementsPaths(path)
-  const [deletedElement, propName] = getElementAndPropName(rootElements.old, deleteElementPath)
+  const [deletedElement, propName] = getElementAndPropName(rootElements.before, deleteElementPath)
 
   const elements = new Map(elementTree.elements)
   const elementIds = new Map(elementTree.elementIds)
 
   deleteElement({ elements, elementIds }, deletedElement, propName, descriptors)
-  updateParentElements(elements, parentElementPaths, rootElements.new)
+
+  // Use the "after" state to efficiently update all of parent subtrees in the state
+  updateParentElements(elements, parentElementPaths, rootElements.after)
 
   return {
     elements,
@@ -313,17 +315,19 @@ function insertElement(
 function applyInsert(
   elementTree: ElementTree,
   descriptors: DescriptorsByComponentType,
-  rootElements: { old: Element; new: Element },
+  rootElements: { before: Element; after: Element },
   path: OperationPath,
 ): ElementTree {
   const [insertedElementPath, ...parentElementPaths] = getChangedElementsPaths(path)
-  const [insertedElement, propName] = getElementAndPropName(rootElements.new, insertedElementPath)
+  const [insertedElement, propName] = getElementAndPropName(rootElements.after, insertedElementPath)
 
   const elements = new Map(elementTree.elements)
   const elementIds = new Map(elementTree.elementIds)
 
   insertElement({ elements, elementIds }, insertedElement, propName, descriptors)
-  updateParentElements(elements, parentElementPaths, rootElements.new)
+
+  // Use the "after" state to efficiently update all of parent subtrees in the state
+  updateParentElements(elements, parentElementPaths, rootElements.after)
 
   return {
     elements,
@@ -334,12 +338,12 @@ function applyInsert(
 function applyUpdate(
   elementTree: ElementTree,
   descriptors: DescriptorsByComponentType,
-  rootElements: { old: Element; new: Element },
+  rootElements: { before: Element; after: Element },
   path: OperationPath,
 ): ElementTree {
   const [updateElementPath, ...parentElementPaths] = getChangedElementsPaths(path)
-  const [deletedElement, propName] = getElementAndPropName(rootElements.old, updateElementPath)
-  const [insertedElement, _] = getElementAndPropName(rootElements.new, updateElementPath)
+  const [deletedElement, propName] = getElementAndPropName(rootElements.before, updateElementPath)
+  const [insertedElement, _] = getElementAndPropName(rootElements.after, updateElementPath)
 
   const elements = new Map(elementTree.elements)
   const elementIds = new Map(elementTree.elementIds)
@@ -347,12 +351,42 @@ function applyUpdate(
   deleteElement({ elements, elementIds }, deletedElement, propName, descriptors)
   insertElement({ elements, elementIds }, insertedElement, propName, descriptors)
 
-  updateParentElements(elements, parentElementPaths, rootElements.new)
+  // Use the "after" state to efficiently update all of parent subtrees in the state
+  updateParentElements(elements, parentElementPaths, rootElements.after)
 
   return {
     elements,
     elementIds,
   }
+}
+
+function applyOpComponent(root: Element, component: Operation[number]): Element {
+  let applied: Element = root
+
+  if ('ld' in component || 'od' in component) {
+    applied = removeIn(applied, component.p)
+  }
+
+  if ('li' in component) {
+    applied = setIn(applied, component.p, component.li)
+  }
+
+  if ('oi' in component) {
+    applied = setIn(applied, component.p, component.oi)
+  }
+
+  return applied
+}
+
+function selectTreeTransform(op: Operation[number]): typeof applyUpdate {
+  const hasDelete = 'ld' in op || 'od' in op
+  const hasInsert = 'li' in op || 'oi' in op
+
+  if (hasDelete && hasInsert) return applyUpdate
+  if (hasDelete) return applyDelete
+  if (hasInsert) return applyInsert
+
+  return elementTree => elementTree
 }
 
 function applyChanges(
@@ -361,15 +395,29 @@ function applyChanges(
   rootElements: { old: Element; new: Element },
   operation: Operation,
 ): ElementTree {
-  return operation.reduce((tree, op) => {
-    const hasDelete = 'ld' in op || 'od' in op
-    const hasInsert = 'li' in op || 'oi' in op
-    if (hasDelete && hasInsert) {
-      return applyUpdate(tree, descriptors, rootElements, op.p)
-    }
+  // Updates the element tree "cache" based on the provided operation, which can
+  // be composed of 1-n component ops. We apply each component op sequentially
+  // to the 'old' root element to determine the changed elements and update the
+  // cache accordingly at each intermediate step.
+  const result = operation.reduce(
+    (acc, op) => {
+      const rootBefore = acc.rootBefore
 
-    if (hasDelete) return applyDelete(tree, descriptors, rootElements, op.p)
-    if (hasInsert) return applyInsert(tree, descriptors, rootElements, op.p)
-    return tree
-  }, elementTree)
+      // If there's only one component op, we can skip the application of the op
+      // and assume that the result will be the 'new' root element provided to
+      // us by the builder.
+      const rootAfter = operation.length > 1 ? applyOpComponent(rootBefore, op) : rootElements.new
+
+      const roots = { before: rootBefore, after: rootAfter }
+      const applyChange = selectTreeTransform(op)
+
+      return {
+        elementTree: applyChange(acc.elementTree, descriptors, roots, op.p),
+        rootBefore: rootAfter,
+      }
+    },
+    { elementTree, rootBefore: rootElements.old },
+  )
+
+  return result.elementTree
 }


### PR DESCRIPTION
Fixes an issue where attempting to apply a deletion op can result in an error if the path of the deletion op is not present in the new element tree. Can organically occur when reparenting a deeply nested element to the top of the root, since the deletion path will be for the deeply nested path.