### PR TITLE
fix(CLI): unblock create CLI by closing handshake keep-alive sockets

### DIFF
--- a/.changeset/quiet-sockets-shutdown.md
+++ b/.changeset/quiet-sockets-shutdown.md
@@ -1,0 +1,5 @@
+---
+'makeswift': patch
+---
+
+Fix `npx makeswift@latest init` from stalling on first redirect.

--- a/packages/makeswift/src/utils/handshake.ts
+++ b/packages/makeswift/src/utils/handshake.ts
@@ -134,17 +134,25 @@ export async function getSiteMetadata({
         destinationURL.searchParams.set('api_key', siteApiKey)
         res.writeHead(302, {
           Location: destinationURL.toString(),
+          Connection: 'close',
         })
         res.end(() => {
+          // Destroy any keep-alive sockets the browser may be holding open;
+          // otherwise `server.close()` waits for them and never resolves.
+          sockets.forEach(socket => socket.destroy())
+
+          let settled = false
+          const settle = (err?: Error | null) => {
+            if (settled) return
+            settled = true
+            if (err != null) reject(err)
+            else resolve({ siteApiKey, example, envVars })
+          }
+
+          const closeTimeout = setTimeout(() => settle(), 5000)
           server.close(err => {
-            if (err != null) {
-              reject(err)
-            }
-            resolve({
-              siteApiKey,
-              example,
-              envVars,
-            })
+            clearTimeout(closeTimeout)
+            settle(err)
           })
         })
       })


### PR DESCRIPTION
## Summary

* `makeswift create` was hanging after the browser select-site redirect because the local handshake server's `server.close()` was waiting on idle browser keep-alive sockets that never closed on their own.
* The hang led users to manually re-open the printed URL, which re-ran step 1 of the handshake and **created a duplicate site**. The CLI then resolved with the *first* site's API key while the builder showed the *second* site, producing a **401 in the builder**.
* Fix: send `Connection: close` on the redirect, force-destroy any tracked sockets in `res.end`'s callback (the `sockets` array was already collected for this purpose but never used), and bound `server.close()` with a 5s safety timeout.

## Why this fixes all the visible symptoms

<!-- linear:table-colwidths:400,400 -->
| Symptom | Cause |
| -- | -- |
| CLI stalls after redirect | `server.close()` blocked on browser keep-alive socket |
| User clicks URL → second site appears | Manual click re-runs handshake step 1 |
| Builder 401s | CLI persisted site [#1](<https://github.com/makeswift/makeswift/issues/1>)'s key, browser ended up on site [#2](<https://github.com/makeswift/makeswift/issues/2>) |

## Test plan

https://github.com/user-attachments/assets/b804a283-a007-481b-90e6-bc39f45da2b5

- [X] End-to-end manual run against production: `makeswift create` proceeds within \~1s of the browser redirect, only one site is created, and the builder loads without 401.