### PR TITLE
fix: stop treating bulk element-trees 404s as errors

### DIFF
--- a/.changeset/four-snakes-love.md
+++ b/.changeset/four-snakes-love.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+fix: `unstable_getComponentSnapshots` now treats bulk 404s as `null` documents instead of logging and throwing.

--- a/packages/runtime/src/client/index.ts
+++ b/packages/runtime/src/client/index.ts
@@ -546,6 +546,9 @@ export class MakeswiftClient {
     if (!response.ok) {
       const failedBody = await failedResponseBody(response)
 
+      // 404 can mean the requested version has no commit (e.g., site never published)
+      if (response.status === 404) return ids.map(() => null)
+
       console.error(`Failed to get element trees for [${ids.join(', ')}]`, {
         response: failedBody,
         siteVersion,

--- a/packages/runtime/src/client/tests/client.get-component-snapshots.test.ts
+++ b/packages/runtime/src/client/tests/client.get-component-snapshots.test.ts
@@ -105,7 +105,7 @@ describe('unstable_getComponentSnapshots', () => {
     expect(results[2].document.data).not.toBeNull()
   })
 
-  test('throws when bulk fetch fails', async () => {
+  test('throws when bulk fetch fails with non-404', async () => {
     // Arrange
     const client = createTestClient()
 
@@ -121,6 +121,63 @@ describe('unstable_getComponentSnapshots', () => {
         siteVersion: TestWorkingSiteVersion,
       }),
     ).rejects.toThrow('Failed to get element trees')
+  })
+
+  test('returns fallback documents silently when bulk fetch returns 404', async () => {
+    // Arrange
+    const client = createTestClient()
+    const consoleErrorSpy = jest.spyOn(console, 'error')
+    setupGraphqlMock()
+
+    server.use(
+      http.post(
+        baseUrl,
+        () =>
+          HttpResponse.json(
+            { object: 'error', code: 'not_found', message: 'Element trees for requested version not found' },
+            { status: 404 },
+          ),
+        { once: true },
+      ),
+    )
+
+    // Act
+    const results = await client.unstable_getComponentSnapshots(['comp-1', 'comp-2'], {
+      siteVersion: TestWorkingSiteVersion,
+    })
+
+    // Assert
+    expect(results).toHaveLength(2)
+    expect(results[0].document.data).toBeNull()
+    expect(results[1].document.data).toBeNull()
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+  })
+
+  test('returns fallback documents silently when bulk fetch returns 404 with a locale', async () => {
+    // Arrange
+    const client = createTestClient()
+    const consoleErrorSpy = jest.spyOn(console, 'error')
+    setupGraphqlMock()
+
+    const httpHandler = jest.fn(() =>
+      HttpResponse.json(
+        { object: 'error', code: 'not_found', message: 'Element trees for requested version not found' },
+        { status: 404 },
+      ),
+    )
+    server.use(http.post(baseUrl, httpHandler))
+
+    // Act
+    const results = await client.unstable_getComponentSnapshots(['comp-1', 'comp-2'], {
+      siteVersion: TestWorkingSiteVersion,
+      locale: 'fr-FR',
+    })
+
+    // Assert
+    expect(results).toHaveLength(2)
+    expect(results[0].document.data).toBeNull()
+    expect(results[1].document.data).toBeNull()
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
   })
 
   test('locale fallback — second-pass: first call with locale returns some nulls, second call without locale fills them in', async () => {


### PR DESCRIPTION
## Summary

`POST v0/element-trees/bulk` returns 404 when the requested version's commit can't be resolved. The common case is **a site that has never been published**, there is no live commit yet, so every request 404s until the first publish.

Today the runtime's `getElementTreesBulk` treats this as a hard error: it `console.error`s verbosely and throws, and the thrown error gets re-caught and re-logged at every caller of `unstable_getComponentSnapshots`. 

The single-fetch sibling `getComponentSnapshot` already handles this correctly, it silently returns a fallback `{ data: null }` document on 404:
<img width="784" height="568" alt="image" src="https://github.com/user-attachments/assets/f41f54cf-e5f5-4dd6-9af4-442df8625537" />


See this Linear issue on example logs that appear on the MoS worker: [ARR-731: Handle 'Failed to get element trees' errors in MoS worker](https://linear.app/commerce/issue/ARR-731/handle-failed-to-get-element-trees-errors-in-mos-worker).

See proof on the [worker PR](https://github.com/bigcommerce/makeswift-stencil-worker/pull/177)

## Change

Mirror the single-fetch 404 contract:

| Response | Before | After |
|---|---|---|
| 404 | `console.error` + throw | Return `ids.map(() => null)` silently |
| Other non-ok (5xx, etc.) | `console.error` + throw | `console.error` + throw (unchanged) |

- `unstable_getComponentSnapshots` already turns null documents into fallback `{ data: null }` snapshots, so no caller changes are required.
- Non-404 errors still throw so consumers don't cache empty results from transient backend failures.
