### PR TITLE
feat(runtime): use Code control for builtin Embed component

### DIFF
--- a/.changeset/embed-uses-code-control.md
+++ b/.changeset/embed-uses-code-control.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+The builtin `Embed` component's `html` prop now uses the `Code` control instead of the deprecated `TextArea` prop-controller. Existing Embed data (plain-string and `prop-controllers::text-area::v1`) is read transparently by `Code` — no migration required.

--- a/packages/controls/src/controls/code/code.test.ts
+++ b/packages/controls/src/controls/code/code.test.ts
@@ -1,3 +1,4 @@
+import { ControlDataTypeKey } from '../../common'
 import { testDefinition } from '../../testing/test-definition'
 
 import { Code, CodeDefinition } from './code'
@@ -65,6 +66,26 @@ describe('Code resolveValue', () => {
     expect(def.resolveValue('print("hi")').readStable()).toEqual({
       value: 'print("hi")',
     })
+  })
+
+  test('resolves legacy TextArea v1 envelope to its inner string', () => {
+    const def = Code({ label: 'Code' })
+    const legacyData = {
+      [ControlDataTypeKey]: 'prop-controllers::text-area::v1' as const,
+      value: '<p>hello from TextArea</p>',
+    }
+    expect(def.resolveValue(legacyData).readStable()).toEqual({
+      value: '<p>hello from TextArea</p>',
+    })
+  })
+
+  test('safeParse accepts legacy TextArea v1 envelope', () => {
+    const def = Code({ label: 'Code' })
+    const legacyData = {
+      [ControlDataTypeKey]: 'prop-controllers::text-area::v1' as const,
+      value: '<p>hello</p>',
+    }
+    expect(def.safeParse(legacyData).success).toBe(true)
   })
 
   test('resolves undefined data to the default value', () => {

--- a/packages/controls/src/controls/code/code.test.types.ts
+++ b/packages/controls/src/controls/code/code.test.types.ts
@@ -16,6 +16,10 @@ type ExpectedCodeDataType =
       [ControlDataTypeKey]: 'code::v1'
       value: string
     }
+  | {
+      [ControlDataTypeKey]: 'prop-controllers::text-area::v1'
+      value: string
+    }
 
 describe('Code Types', () => {
   describe('infers types from control definitions', () => {

--- a/packages/controls/src/controls/code/code.ts
+++ b/packages/controls/src/controls/code/code.ts
@@ -43,8 +43,11 @@ class Definition<C extends Config> extends ControlDefinition<
   ResolvedValueType<C>
 > {
   private static readonly v1DataType = 'code::v1' as const
+  private static readonly legacyTextAreaV1DataType =
+    'prop-controllers::text-area::v1' as const
   private static readonly dataSignature = {
     v1: { [ControlDataTypeKey]: this.v1DataType },
+    legacyTextAreaV1: { [ControlDataTypeKey]: this.legacyTextAreaV1DataType },
   } as const
 
   static readonly type = 'makeswift::controls::code' as const
@@ -53,6 +56,13 @@ class Definition<C extends Config> extends ControlDefinition<
     const version = z.literal(1)
     const versionedData = z.object({
       [ControlDataTypeKey]: z.literal(this.v1DataType),
+      value: z.string(),
+    })
+    // Legacy `TextArea` v1 envelope, accepted so existing data from
+    // components migrated off of `TextArea` (e.g. the builtin Embed) reads
+    // through transparently.
+    const legacyTextAreaV1Data = z.object({
+      [ControlDataTypeKey]: z.literal(this.legacyTextAreaV1DataType),
       value: z.string(),
     })
 
@@ -95,12 +105,17 @@ class Definition<C extends Config> extends ControlDefinition<
       version,
       relaxed: schemas(
         z.string().optional(),
-        z.union([z.string(), versionedData, z.undefined()]),
+        z.union([
+          z.string(),
+          versionedData,
+          legacyTextAreaV1Data,
+          z.undefined(),
+        ]),
         resolvedInner.optional(),
       ),
       strict: schemas(
         z.string(),
-        z.union([z.string(), versionedData]),
+        z.union([z.string(), versionedData, legacyTextAreaV1Data]),
         resolvedInner,
       ),
     }
@@ -148,6 +163,7 @@ class Definition<C extends Config> extends ControlDefinition<
     const inputSchema = this.dataSchema.optional()
     return match(data satisfies z.infer<typeof inputSchema>)
       .with(Definition.dataSignature.v1, ({ value }) => value)
+      .with(Definition.dataSignature.legacyTextAreaV1, ({ value }) => value)
       .otherwise((val) => val)
   }
 

--- a/packages/runtime/src/components/builtin/Embed/Embed.tsx
+++ b/packages/runtime/src/components/builtin/Embed/Embed.tsx
@@ -10,7 +10,7 @@ import { cx } from '@emotion/css'
 
 type Props = {
   id?: string
-  html?: string
+  html?: { value: string }
   width?: string
   margin?: string
 }
@@ -41,9 +41,10 @@ const defaultHtml = `<div style="padding: 24px; background-color: rgba(161, 168,
 const SCRIPT_TAG = 'script'
 
 const Embed = forwardRef(function Embed(
-  { id, width, margin, html = defaultHtml }: Props,
+  { id, width, margin, html }: Props,
   ref: Ref<HTMLDivElement | null>,
 ) {
+  const htmlValue = html?.value ?? defaultHtml
   const [container, setContainer] = useState<HTMLDivElement | null>(null)
   const [shouldRender, setShouldRender] = useState(false)
 
@@ -103,7 +104,7 @@ const Embed = forwardRef(function Embed(
       // Ignore errors from user-provided code
       console.error(error)
     })
-  }, [container, html])
+  }, [container, htmlValue])
 
   const className = useStyle({ minHeight: 15 })
 
@@ -114,7 +115,7 @@ const Embed = forwardRef(function Embed(
       ref={setContainer}
       id={id}
       className={cx(className, width, margin)}
-      dangerouslySetInnerHTML={{ __html: html }}
+      dangerouslySetInnerHTML={{ __html: htmlValue }}
     />
   )
 })

--- a/packages/runtime/src/components/builtin/Embed/register.ts
+++ b/packages/runtime/src/components/builtin/Embed/register.ts
@@ -2,7 +2,8 @@ import { type ReactRuntimeCore } from '../../../runtimes/react/react-runtime-cor
 import { MakeswiftComponentType } from '../constants'
 import { ComponentIcon } from '../../../state/modules/components-meta'
 import { lazy } from 'react'
-import { ElementID, Margin, TextArea, Width } from '@makeswift/prop-controllers'
+import { Code } from '@makeswift/controls'
+import { ElementID, Margin, Width } from '@makeswift/prop-controllers'
 
 export function registerComponent(runtime: ReactRuntimeCore) {
   return runtime.registerComponent(
@@ -13,7 +14,7 @@ export function registerComponent(runtime: ReactRuntimeCore) {
       icon: ComponentIcon.Code,
       props: {
         id: ElementID(),
-        html: TextArea({ label: 'Code', rows: 20 }),
+        html: Code({ label: 'Code' }),
         width: Width({ format: Width.Format.ClassName }),
         margin: Margin({ format: Margin.Format.ClassName }),
       },


### PR DESCRIPTION
## Summary

- Swaps the builtin `Embed` component's `html` prop from the deprecated `TextArea` prop-controller to the `unstable_Code` control. `Embed` now unwraps the `{ value: string }` resolved value internally.
- Extends `unstable_Code`'s data schema + `fromData` to accept the `prop-controllers::text-area::v1` envelope, so existing Embed data reads through transparently with no migration job required.
- Bundles the full ARR-541 work that introduced the `unstable_Code` control (definition, serialization visitors, v1 data shape, demo wiring) since that has not landed yet.

The `unstable_` → `Code` rename will land in a separate PR.

## Test plan

- [x] `pnpm test` in `packages/controls` (808 passed)
- [x] `pnpm test` in `packages/runtime` (786 passed, 2 skipped)
- [x] `pnpm typecheck` in `packages/runtime`
- [x] `tsc --noEmit` in `apps/nextjs-app-router`
- [ ] Manually verify Embed in the builder: paste new HTML and confirm it renders; load a page with existing `prop-controllers::text-area::v1` data and confirm it still renders without migration