### PR TITLE
fix(runtime): move current breakpoint calculation to the root

### DIFF
--- a/.changeset/silver-grapes-pay.md
+++ b/.changeset/silver-grapes-pay.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Improve Safari rendering performance (`window.matchMedia` refactoring)

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -285,6 +285,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "jsdom": "^26.0.0",
     "madge": "^6.0.0",
+    "mock-match-media": "^1.0.3",
     "msw": "^2.3.1",
     "next": "15.5.18",
     "node-mocks-http": "^1.16.2",

--- a/packages/runtime/src/components/hooks/__tests__/useMediaQuery.test.tsx
+++ b/packages/runtime/src/components/hooks/__tests__/useMediaQuery.test.tsx
@@ -1,0 +1,95 @@
+/** @jest-environment jsdom */
+
+import { act } from 'react'
+import { render, screen } from '@testing-library/react'
+
+import { matchMedia, setMedia } from 'mock-match-media'
+
+import { useMediaQuery } from '../useMediaQuery'
+
+import { createReactRuntime } from '../../../runtimes/react/testing/react-runtime'
+import { RuntimeProvider } from '../../../runtimes/react/components/RuntimeProvider'
+
+const breakpoints = {
+  mobile: { width: 575, viewport: 390, label: 'Mobile' },
+  tablet: { width: 768, viewport: 765, label: 'Tablet' },
+  laptop: { width: 1024, viewport: 1000, label: 'Laptop' },
+  external: { width: 1280, label: 'External' },
+}
+
+type DeviceId = keyof typeof breakpoints | 'desktop'
+
+const responsiveValue: Array<{ deviceId: DeviceId; value: string }> = [
+  {
+    deviceId: 'desktop',
+    value: 'none',
+  },
+  {
+    deviceId: 'external',
+    value: 'fadeTop',
+  },
+  {
+    deviceId: 'laptop',
+    value: 'fadeRight',
+  },
+  {
+    deviceId: 'tablet',
+    value: 'fadeLeft',
+  },
+  {
+    deviceId: 'mobile',
+    value: 'blurIn',
+  },
+]
+
+const testId = 'test-id'
+
+const TestComponent = () => {
+  const value = useMediaQuery(responsiveValue)
+  return <div data-testid={testId}>{value}</div>
+}
+
+let oldMatchMedia: any
+
+describe('useMediaQuery', () => {
+  beforeEach(() => {
+    oldMatchMedia = window.matchMedia
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: matchMedia,
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'matchMedia', { writable: true, value: oldMatchMedia })
+  })
+
+  test.each([
+    { width: 1300, expectedValue: 'none' },
+    { width: 1280, expectedValue: 'fadeTop' },
+    { width: 1100, expectedValue: 'fadeTop' },
+    { width: 1024, expectedValue: 'fadeRight' },
+    { width: 800, expectedValue: 'fadeRight' },
+    { width: 768, expectedValue: 'fadeLeft' },
+    { width: 600, expectedValue: 'fadeLeft' },
+    { width: 575, expectedValue: 'blurIn' },
+    { width: 200, expectedValue: 'blurIn' },
+  ])(
+    'returns responsive value matching current media breakpoint ($width px)',
+    async ({ width, expectedValue }) => {
+      const runtime = createReactRuntime({ breakpoints })
+
+      setMedia({ width })
+
+      await act(async () =>
+        render(
+          <RuntimeProvider runtime={runtime} siteVersion={null}>
+            <TestComponent />
+          </RuntimeProvider>,
+        ),
+      )
+
+      expect(screen.getByTestId(testId)).toHaveTextContent(expectedValue)
+    },
+  )
+})

--- a/packages/runtime/src/components/hooks/useMediaQuery.ts
+++ b/packages/runtime/src/components/hooks/useMediaQuery.ts
@@ -1,49 +1,14 @@
-import { useCallback, useSyncExternalStore } from 'react'
-import {
-  type Breakpoints,
-  type DeviceOverride,
-  findBreakpointOverride,
-  getBaseBreakpoint,
-  getBreakpointMediaQuery,
-} from '@makeswift/controls'
+import { useMemo } from 'react'
+import { type DeviceOverride, findBreakpointOverride } from '@makeswift/controls'
 
 import { useBreakpoints } from '../../runtimes/react/hooks/use-breakpoints'
-
-const getDeviceQueries = (breakpoints: Breakpoints) =>
-  breakpoints.map(device => ({
-    id: device.id,
-    query: getBreakpointMediaQuery(device).replace('@media', ''),
-  }))
+import { useCurrentBreakpoint } from '../../runtimes/react/hooks/use-current-breakpoint'
 
 export function useMediaQuery<S>(responsiveValue?: Array<DeviceOverride<S>>): S | undefined {
   const breakpoints = useBreakpoints()
-  const baseBreakpointId = getBaseBreakpoint(breakpoints).id
-  const subscribe = useCallback(
-    (notify: () => void) => {
-      const cleanUpFns = getDeviceQueries(breakpoints).map(q => {
-        const mediaQueryList = window.matchMedia(q.query)
-        mediaQueryList.addEventListener('change', notify)
-        return () => mediaQueryList.removeEventListener('change', notify)
-      })
-      return () => cleanUpFns.forEach(fn => fn())
-    },
-    [breakpoints],
+  const breakpointId = useCurrentBreakpoint()
+  return useMemo(
+    () => findBreakpointOverride(breakpoints, responsiveValue, breakpointId)?.value,
+    [breakpoints, breakpointId, responsiveValue],
   )
-  const getServerSnapshot = () =>
-    findBreakpointOverride(breakpoints, responsiveValue, baseBreakpointId)?.value
-
-  function getSnapshot() {
-    const deviceId: string = getDeviceQueries(breakpoints).reduce(
-      (matchedDevice, deviceQueries) => {
-        if (window.matchMedia(deviceQueries.query).matches) {
-          return deviceQueries.id
-        }
-        return matchedDevice
-      },
-      baseBreakpointId,
-    )
-    return findBreakpointOverride(breakpoints, responsiveValue, deviceId)?.value
-  }
-
-  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 }

--- a/packages/runtime/src/runtimes/react/hooks/use-breakpoints.ts
+++ b/packages/runtime/src/runtimes/react/hooks/use-breakpoints.ts
@@ -1,5 +1,6 @@
-import { Breakpoints } from '../../../state/modules/breakpoints'
+import { type Breakpoints } from '../../../state/modules/breakpoints'
 import { getBreakpoints } from '../../../state/read-only-state'
+
 import { useSelector } from './use-selector'
 
 export function useBreakpoints(): Breakpoints {

--- a/packages/runtime/src/runtimes/react/hooks/use-current-breakpoint.ts
+++ b/packages/runtime/src/runtimes/react/hooks/use-current-breakpoint.ts
@@ -1,0 +1,16 @@
+import { useSyncExternalStore } from 'react'
+
+import { type BreakpointId } from '../../../state/modules/breakpoints'
+import { getBaseBreakpoint, getClientBreakpoint } from '../../../state/read-only-state'
+
+import { useStore } from './use-store'
+
+export function useCurrentBreakpoint(): BreakpointId {
+  const store = useStore()
+
+  return useSyncExternalStore(
+    store.subscribe,
+    () => getClientBreakpoint(store.getState()),
+    () => getBaseBreakpoint(store.getState()),
+  )
+}

--- a/packages/runtime/src/runtimes/react/runtime-core.ts
+++ b/packages/runtime/src/runtimes/react/runtime-core.ts
@@ -116,7 +116,9 @@ export class RuntimeCore {
       return
     }
 
-    this.activeStores.retain(key, store)
+    if (this.activeStores.retain(key, store)) {
+      store.startBreakpointWatch()
+    }
   }
 
   releaseStore({ siteVersion, locale }: StoreKey, store: Store): void {
@@ -127,7 +129,9 @@ export class RuntimeCore {
       return
     }
 
-    this.activeStores.release(key, store)
+    if (this.activeStores.release(key, store)) {
+      store.stopBreakpointWatch()
+    }
   }
 
   copyElementTree(

--- a/packages/runtime/src/runtimes/react/testing/react-runtime.tsx
+++ b/packages/runtime/src/runtimes/react/testing/react-runtime.tsx
@@ -1,6 +1,7 @@
+import { type BreakpointsInput } from '../../../state/modules/breakpoints'
 import { TestOrigins } from '../../../testing/fixtures'
 import { ReactRuntime } from '../react-runtime'
 
-export function createReactRuntime() {
-  return new ReactRuntime({ fetch, ...TestOrigins })
+export function createReactRuntime({ breakpoints }: { breakpoints?: BreakpointsInput } = {}) {
+  return new ReactRuntime({ fetch, breakpoints, ...TestOrigins })
 }

--- a/packages/runtime/src/state/actions/internal/read-only-actions.ts
+++ b/packages/runtime/src/state/actions/internal/read-only-actions.ts
@@ -35,6 +35,8 @@ export const ReadOnlyActionTypes = {
   REGISTER_REACT_COMPONENT: 'REGISTER_REACT_COMPONENT',
   UNREGISTER_REACT_COMPONENT: 'UNREGISTER_REACT_COMPONENT',
 
+  UPDATE_CLIENT_BREAKPOINT: 'UPDATE_CLIENT_BREAKPOINT',
+
   SET_IS_IN_BUILDER: 'SET_IS_IN_BUILDER',
   SET_IS_READ_ONLY: 'SET_IS_READ_ONLY',
 } as const
@@ -117,6 +119,10 @@ type UnregisterReactComponentAction = {
   payload: { type: string }
 }
 
+type UpdateClientBreakpointAction = {
+  type: typeof ReadOnlyActionTypes.UPDATE_CLIENT_BREAKPOINT
+}
+
 type SetIsInBuilderAction = {
   type: typeof ReadOnlyActionTypes.SET_IS_IN_BUILDER
   payload: boolean
@@ -141,6 +147,7 @@ export type ReadOnlyAction =
   | UnregisterPropControllersAction
   | RegisterReactComponentAction
   | UnregisterReactComponentAction
+  | UpdateClientBreakpointAction
   | SetIsInBuilderAction
   | SetIsReadOnlyAction
 
@@ -299,6 +306,10 @@ export function registerReactComponentEffect(
       dispatch(unregisterReactComponent(type))
     }
   }
+}
+
+export function updateClientBreakpoint(): UpdateClientBreakpointAction {
+  return { type: ReadOnlyActionTypes.UPDATE_CLIENT_BREAKPOINT }
 }
 
 export function setIsInBuilder(isInBuilder: boolean): SetIsInBuilderAction {

--- a/packages/runtime/src/state/mixins/breakpoint-watch.ts
+++ b/packages/runtime/src/state/mixins/breakpoint-watch.ts
@@ -1,0 +1,70 @@
+import { updateClientBreakpoint } from '../actions/internal/read-only-actions'
+import { Breakpoints, getDeviceQueries } from '../modules/breakpoints'
+
+import { type State, type Dispatch } from '../unified-state'
+import { getBreakpoints } from '../read-only-state'
+
+export interface BreakpointWatch {
+  startBreakpointWatch(): void
+  stopBreakpointWatch(): void
+}
+
+export function breakpointWatchMixin({
+  dispatch,
+  getState,
+  subscribe: storeSubscribe,
+}: {
+  dispatch: Dispatch
+  getState: () => State
+  subscribe: (listener: VoidFunction) => VoidFunction
+}): BreakpointWatch {
+  let mediaQueryUnsubscribes: VoidFunction[] = []
+  let storeUnsubscribe: VoidFunction | null = null
+  let watchedBreakpoints: Breakpoints = []
+
+  // client-side breakpoint watch
+  const startWatch = (breakpoints: Breakpoints) => {
+    mediaQueryUnsubscribes.forEach(fn => fn())
+
+    const updateState = () => dispatch(updateClientBreakpoint())
+
+    mediaQueryUnsubscribes = getDeviceQueries(breakpoints).map(q => {
+      const mediaQueryList = window.matchMedia(q.query)
+      mediaQueryList.addEventListener('change', updateState)
+      return () => mediaQueryList.removeEventListener('change', updateState)
+    })
+
+    watchedBreakpoints = breakpoints
+
+    // reconcile the store with the current client breakpoint after subscribing;
+    // this heals any stale breakpoint state from changes that happened
+    // after the store was created or updated but before the listeners were attached
+    updateState()
+  }
+
+  return {
+    startBreakpointWatch: () => {
+      if (storeUnsubscribe !== null) {
+        console.warn('Unexpected `BreakpointWatch.startBreakpointWatch` call, already watching')
+        return
+      }
+
+      startWatch(getBreakpoints(getState()))
+
+      storeUnsubscribe = storeSubscribe(() => {
+        const breakpoints = getBreakpoints(getState())
+        if (breakpoints !== watchedBreakpoints) {
+          startWatch(breakpoints)
+        }
+      })
+    },
+
+    stopBreakpointWatch: () => {
+      mediaQueryUnsubscribes.forEach(fn => fn())
+      mediaQueryUnsubscribes = []
+
+      storeUnsubscribe?.()
+      storeUnsubscribe = null
+    },
+  }
+}

--- a/packages/runtime/src/state/modules/breakpoints.ts
+++ b/packages/runtime/src/state/modules/breakpoints.ts
@@ -1,7 +1,15 @@
-import { type Breakpoint, type Breakpoints } from '@makeswift/controls'
+import {
+  type Breakpoint,
+  type BreakpointId,
+  type Breakpoints,
+  getBaseBreakpoint,
+  getBreakpointMediaQuery,
+} from '@makeswift/controls'
 
 import { type Action, type UnknownAction, isKnownAction } from '../actions'
+import { InternalActionTypes } from '../actions/internal'
 import { BuilderActionTypes } from '../builder-api/actions'
+import { isServer } from '../../utils/is-server'
 
 export {
   getBreakpoint,
@@ -10,7 +18,11 @@ export {
   type Breakpoints,
 } from '@makeswift/controls'
 
-export type State = Breakpoints
+export type State = {
+  breakpoints: Breakpoints
+  baseBreakpoint: BreakpointId
+  clientBreakpoint: BreakpointId
+}
 
 export const DefaultBreakpointID = {
   Desktop: 'desktop',
@@ -41,8 +53,51 @@ export const DEFAULT_BREAKPOINTS: Breakpoints = [
   },
 ]
 
+export const getDeviceQueries = (breakpoints: Breakpoints) =>
+  breakpoints.map(device => ({
+    id: device.id,
+    query: getBreakpointMediaQuery(device).replace('@media', ''),
+  }))
+
+const getBaseBreakpointId = (breakpoints: Breakpoints): BreakpointId =>
+  getBaseBreakpoint(breakpoints).id
+
+// Intentional impurity in the reducer buys us several practical upsides here:
+//
+// - We can keep `SET_BREAKPOINTS` atomic by recalculating the client breakpoint
+//   state when we update the set of available breakpoints; if we don't do that
+//   here, we'll have to do it from the outside, and the state will temporarily
+//   hold a stale client breakpoint value in between
+//
+// - We can have a valid, internally consistent *initial* state for the client
+//   breakpoint; if we move the client breakpoint calculation out of the reducer,
+//   we'll be forced to start with a stale initial state, which will introduce
+//   implicit coupling and potential timing issues between the
+//   `useCurrentBreakpoint` hook and the client breakpoint synchronization code
+//   in `BreakpointWatch`
+//
+// - `UPDATE_CLIENT_BREAKPOINT` can compute the client breakpoint from browser
+//    state using the current breakpoint set instead of having to validate and
+//    handle external payload
+
+export function getMatchingMediaBreakpointId(breakpoints: Breakpoints): BreakpointId {
+  const baseBreakpoint = getBaseBreakpointId(breakpoints)
+  if (isServer()) return baseBreakpoint
+
+  // using `findLast` to preserve the legacy behavior; might not be necessary
+  const matchingBreakpoint = getDeviceQueries(breakpoints).findLast(
+    ({ query }) => window.matchMedia(query).matches,
+  )
+
+  return matchingBreakpoint?.id ?? baseBreakpoint
+}
+
 export function getInitialState(breakpoints = DEFAULT_BREAKPOINTS): State {
-  return breakpoints
+  return {
+    breakpoints,
+    baseBreakpoint: getBaseBreakpointId(breakpoints),
+    clientBreakpoint: getMatchingMediaBreakpointId(breakpoints),
+  }
 }
 
 export function reducer(state: State = getInitialState(), action: Action | UnknownAction): State {
@@ -54,7 +109,18 @@ export function reducer(state: State = getInitialState(), action: Action | Unkno
 
       if (breakpoints.length === 0) throw new Error('Breakpoints cannot be empty.')
 
-      return breakpoints
+      return {
+        breakpoints,
+        baseBreakpoint: getBaseBreakpointId(breakpoints),
+        clientBreakpoint: getMatchingMediaBreakpointId(breakpoints),
+      }
+    }
+
+    case InternalActionTypes.UPDATE_CLIENT_BREAKPOINT: {
+      const clientBreakpoint = getMatchingMediaBreakpointId(state.breakpoints)
+      if (clientBreakpoint === state.clientBreakpoint) return state
+
+      return { ...state, clientBreakpoint }
     }
 
     default:

--- a/packages/runtime/src/state/read-only-state.ts
+++ b/packages/runtime/src/state/read-only-state.ts
@@ -223,8 +223,20 @@ export function getBuilderEditMode(state: State): BuilderEditMode.State {
   return state.builderEditMode
 }
 
-export function getBreakpoints(state: State): Breakpoints.State {
+function getBreakpointsStateSlice(state: State): Breakpoints.State {
   return state.breakpoints
+}
+
+export function getBreakpoints(state: State): Breakpoints.Breakpoints {
+  return getBreakpointsStateSlice(state).breakpoints
+}
+
+export function getBaseBreakpoint(state: State): Breakpoints.BreakpointId {
+  return getBreakpointsStateSlice(state).baseBreakpoint
+}
+
+export function getClientBreakpoint(state: State): Breakpoints.BreakpointId {
+  return getBreakpointsStateSlice(state).clientBreakpoint
 }
 
 export function getLocale(state: State): string | null {

--- a/packages/runtime/src/state/store.ts
+++ b/packages/runtime/src/state/store.ts
@@ -18,6 +18,7 @@ import * as Breakpoints from './modules/breakpoints'
 
 import { readOnlyElementTreeMiddleware } from './middleware/read-only-element-tree'
 import { makeswiftApiClientSyncMiddleware } from './middleware/makeswift-api-client-sync'
+import { type BreakpointWatch, breakpointWatchMixin } from './mixins/breakpoint-watch'
 
 import { type Action } from './actions'
 
@@ -73,7 +74,7 @@ export function configureProtoStore({
   breakpoints,
 }: {
   name: string
-  breakpoints: Breakpoints.State | undefined
+  breakpoints: Breakpoints.Breakpoints | undefined
 }) {
   return configureStore({
     name,
@@ -245,6 +246,14 @@ export function configureReadWriteStore({
 
     enhancers: () =>
       new Tuple(
+        withMixin<BreakpointWatch>(
+          breakpointWatchMixin({
+            dispatch: (...args: Parameters<Dispatch>) => store.dispatch(...args),
+            getState: (): State => store.getState(),
+            subscribe: (listener): VoidFunction => store.subscribe(listener),
+          }),
+        ),
+
         withMixin<ReadWriteStateMixin>({
           hostApiClient,
           loadReadWriteStateIfNeeded: async () => {

--- a/packages/runtime/src/utils/__tests__/ref-counted-map.test.ts
+++ b/packages/runtime/src/utils/__tests__/ref-counted-map.test.ts
@@ -52,7 +52,7 @@ describe('RefCountedMap', () => {
     const key = 'whiskers'
 
     const whiskers = map.getOrCreate(key, () => ({ name: 'Whiskers' }))
-    map.retain(key, whiskers)
+    expect(map.retain(key, whiskers)).toBe(true)
 
     jest.advanceTimersByTime(101)
 
@@ -64,16 +64,16 @@ describe('RefCountedMap', () => {
 
     // returns the existing instance of 'whiskers' entry
     const whiskers2 = map.getOrCreate(key, () => ({ name: 'Whiskers' }))
-    map.retain(key, whiskers)
+    expect(map.retain(key, whiskers)).toBe(false)
     expect(whiskers2).toBe(whiskers)
 
     // 'whiskers' should still be in the map
-    map.release(key, whiskers)
+    expect(map.release(key, whiskers)).toBe(false)
     expect(map.get(key)).toBe(whiskers)
     expect(map.size).toBe(2)
 
     // this should remove 'whiskers' from the map
-    map.release(key, whiskers)
+    expect(map.release(key, whiskers)).toBe(true)
     expect(map.get(key)).toBeUndefined()
     expect(map.size).toBe(1)
   })
@@ -92,14 +92,14 @@ describe('RefCountedMap', () => {
     map.getOrCreate('mittens', () => ({ name: 'Mittens' }))
     expect(map.get(key)).toBeUndefined()
 
-    map.retain(key, whiskers)
+    expect(map.retain(key, whiskers)).toBe(true)
 
     // 'whiskers' entry should be added back to the map
     expect(map.get(key)).toBe(whiskers)
     expect(map.size).toBe(2)
 
     // ... and cleaned up properly on release
-    map.release(key, whiskers)
+    expect(map.release(key, whiskers)).toBe(true)
     expect(map.get(key)).toBeUndefined()
     expect(map.size).toBe(1)
   })
@@ -120,11 +120,11 @@ describe('RefCountedMap', () => {
     expect(map.get(key)).toBe(otherWhiskers)
 
     // should have no effect
-    map.retain(key, whiskers)
+    expect(map.retain(key, whiskers)).toBe(false)
 
     jest.advanceTimersByTime(101)
     // should have no effect, trigger 'otherWhiskers' eviction
-    map.retain(key, whiskers)
+    expect(map.retain(key, whiskers)).toBe(false)
     expect(map.get(key)).toBeUndefined()
     expect(map.size).toBe(0)
   })
@@ -144,7 +144,7 @@ describe('RefCountedMap', () => {
       expect(map.get(key)).toBeUndefined()
 
       // should have no effect
-      map.release(key, whiskers)
+      expect(map.release(key, whiskers)).toBe(false)
       expect(map.get(key)).toBeUndefined()
       expect(map.size).toBe(1)
     })
@@ -158,7 +158,7 @@ describe('RefCountedMap', () => {
       expect(map.size).toBe(1)
 
       // should have no effect
-      map.release(key, whiskers)
+      expect(map.release(key, whiskers)).toBe(false)
       expect(map.get(key)).toBe(whiskers)
       expect(map.size).toBe(1)
     })
@@ -180,7 +180,7 @@ describe('RefCountedMap', () => {
       expect(map.get(key)).toBe(otherWhiskers)
 
       // should have no effect
-      map.release(key, whiskers)
+      expect(map.release(key, whiskers)).toBe(false)
       expect(map.get(key)).toBe(otherWhiskers)
     })
   })

--- a/packages/runtime/src/utils/ref-counted-map.ts
+++ b/packages/runtime/src/utils/ref-counted-map.ts
@@ -65,38 +65,51 @@ export class RefCountedMap<K, V> {
     }
   }
 
-  retain(key: K, value: V): void {
+  /**
+   * Returns true on transition from unowned to owned
+   */
+  retain(key: K, value: V): boolean {
     try {
       const existing = this.map.get(key)
 
+      if (existing == null) {
+        this.map.set(key, { value, count: 1 })
+        return true
+      }
+
       // `retain` might be called on a unowned entry that has already been evicted from the map due to TTL expiration
       // *and* possibly replaced by a new unowned entry with the same key; handle this gracefully
-      if (existing != null) {
-        if (existing.value !== value) return
+      if (existing.value === value) {
         existing.count = (existing.count ?? 0) + 1
-      } else {
-        this.map.set(key, { value, count: 1 })
+        return existing.count === 1
       }
+
+      return false
     } finally {
       if (this.ttlCheck & TTLCheck.ON_RETAIN) this.removeExpired()
     }
   }
 
-  release(key: K, value: V): void {
+  /**
+   * Returns true on transition from owned to unowned
+   */
+  release(key: K, value: V): boolean {
     try {
       const existing = this.map.get(key)
 
       // `release` might be called on an entry that remained unowned due being superseded by a new entry with the same
       // key after TTL expiration of the original entry; handle this gracefully
-      if (existing == null) return
-      if (isUnowned(existing)) return
-      if (existing.value !== value) return
+      if (existing == null) return false
+      if (isUnowned(existing)) return false
+      if (existing.value !== value) return false
 
-      if (existing.count > 1) {
-        existing.count -= 1
-      } else {
+      if (existing.count === 1) {
         this.map.delete(key)
+        return true
       }
+
+      existing.count -= 1
+      return false
     } finally {
       if (this.ttlCheck & TTLCheck.ON_RELEASE) this.removeExpired()
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -654,6 +654,9 @@ importers:
       madge:
         specifier: ^6.0.0
         version: 6.0.0
+      mock-match-media:
+        specifier: ^1.0.3
+        version: 1.0.3
       msw:
         specifier: ^2.3.1
         version: 2.3.1(typescript@5.9.2)
@@ -2923,6 +2926,7 @@ packages:
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@use-gesture/core@10.2.24':
     resolution: {integrity: sha512-ZL7F9mgOn3Qlnp6QLI9jaOfcvqrx6JPE/BkdVSd8imveaFTm/a3udoO6f5Us/1XtqnL4347PsIiK6AtCvMHk2Q==}
@@ -6056,6 +6060,9 @@ packages:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
     hasBin: true
+
+  mock-match-media@1.0.3:
+    resolution: {integrity: sha512-f7wFizlZ9pE19xxzp1lYKIEp1Va2ghszE0tOToSfrTOcK1ZNg+vEkUGnJcEg1S8cqdQx3/rkimADQQHPs+hK4A==}
 
   module-definition@3.4.0:
     resolution: {integrity: sha512-XxJ88R1v458pifaSkPNLUTdSPNVGMP2SXVncVmApGO+gAfrLANiYe6JofymCzVceGOMwQE2xogxBSc8uB7XegA==}
@@ -12658,7 +12665,7 @@ snapshots:
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
@@ -12700,8 +12707,8 @@ snapshots:
       debug: 4.3.5
       enhanced-resolve: 5.14.1
       eslint: 8.56.0
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.15.1
@@ -12729,7 +12736,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -12751,7 +12758,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -12762,7 +12769,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
@@ -12772,7 +12779,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -15313,6 +15320,8 @@ snapshots:
   mixme@0.5.10: {}
 
   mkdirp@1.0.4: {}
+
+  mock-match-media@1.0.3: {}
 
   module-definition@3.4.0:
     dependencies:


### PR DESCRIPTION
Moving current breakpoint calculation to the root reduces the number of `window.matchMedia` calls/event handlers, which significantly improves rendering performance on Safari.

Before:

https://github.com/user-attachments/assets/d6e65250-a6ae-4c30-9074-b58353eb7fbc

After:

https://github.com/user-attachments/assets/b5eb2927-72a7-4cdd-9b30-8d1bdc0b6431


