### PR TITLE
feat(controls): share data markers across primitive control groups

### DIFF
--- a/.changeset/control-interop-shared-markers.md
+++ b/.changeset/control-interop-shared-markers.md
@@ -1,0 +1,6 @@
+---
+'@makeswift/controls': patch
+'@makeswift/prop-controllers': patch
+---
+
+Text and number primitives now read shared markers across `@makeswift/controls` and `@makeswift/prop-controllers`, so swapping a prop's control type — or overriding a built-in component and reverting — preserves the saved value. Modern controls write the canonical `'text'` / `'number'` marker on next edit.

--- a/.changeset/control-interop-shared-markers.md
+++ b/.changeset/control-interop-shared-markers.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/controls': patch
+---
+
+`TextInput`, `TextArea`, and `Code` now share a `'text'` data marker; `Number` uses `'number'`. Swapping between controls in the same group preserves the saved value. The deprecated `@makeswift/prop-controllers` text and number markers are also accepted on read, so migrating a prop from the legacy package to the modern equivalent preserves its value too. Rewrite to the canonical marker happens lazily on next edit.

--- a/packages/controls/src/common/data-types.ts
+++ b/packages/controls/src/common/data-types.ts
@@ -1,0 +1,31 @@
+export const ControlDataTypeKey = '@@makeswift/type'
+
+export const DataType = {
+  Text: 'text',
+  Number: 'number',
+} as const
+
+const LegacyTextDataTypes = ['text-input::v1', 'text-area::v1'] as const
+
+const LegacyPropControllerTextDataTypes = [
+  'prop-controllers::text-input::v1',
+  'prop-controllers::text-area::v1',
+] as const
+
+export const AcceptedTextDataTypes = [
+  DataType.Text,
+  ...LegacyTextDataTypes,
+  ...LegacyPropControllerTextDataTypes,
+] as const
+
+const LegacyNumberDataTypes = ['number::v1'] as const
+
+const LegacyPropControllerNumberDataTypes = [
+  'prop-controllers::number::v1',
+] as const
+
+export const AcceptedNumberDataTypes = [
+  DataType.Number,
+  ...LegacyNumberDataTypes,
+  ...LegacyPropControllerNumberDataTypes,
+] as const

--- a/packages/controls/src/common/index.ts
+++ b/packages/controls/src/common/index.ts
@@ -1,2 +1,10 @@
 export * as Schema from './schema'
 export * from './types'
+// `DataType` (the canonical-marker enum) is intentionally kept internal so it
+// doesn't collide with the `DataType<D>` associated type re-exported at the
+// package root. Internal consumers import it directly from './data-types'.
+export {
+  ControlDataTypeKey,
+  AcceptedTextDataTypes,
+  AcceptedNumberDataTypes,
+} from './data-types'

--- a/packages/controls/src/common/types.ts
+++ b/packages/controls/src/common/types.ts
@@ -25,3 +25,35 @@ export function isElementReference(
 }
 
 export const ControlDataTypeKey = '@@makeswift/type'
+
+export const TextDataType = 'text' as const
+export const NumberDataType = 'number' as const
+
+export const LegacyTextDataTypes = [
+  'text-input::v1',
+  'text-area::v1',
+  'code::v1',
+] as const
+
+export const LegacyPropControllerTextDataTypes = [
+  'prop-controllers::text-input::v1',
+  'prop-controllers::text-area::v1',
+] as const
+
+export const AcceptedTextDataTypes = [
+  TextDataType,
+  ...LegacyTextDataTypes,
+  ...LegacyPropControllerTextDataTypes,
+] as const
+
+export const LegacyNumberDataTypes = ['number::v1'] as const
+
+export const LegacyPropControllerNumberDataTypes = [
+  'prop-controllers::number::v1',
+] as const
+
+export const AcceptedNumberDataTypes = [
+  NumberDataType,
+  ...LegacyNumberDataTypes,
+  ...LegacyPropControllerNumberDataTypes,
+] as const

--- a/packages/controls/src/common/types.ts
+++ b/packages/controls/src/common/types.ts
@@ -23,5 +23,3 @@ export function isElementReference(
 ): element is ElementReference {
   return !('props' in element)
 }
-
-export const ControlDataTypeKey = '@@makeswift/type'

--- a/packages/controls/src/controls/__tests__/interop.test.ts
+++ b/packages/controls/src/controls/__tests__/interop.test.ts
@@ -1,0 +1,259 @@
+import {
+  AcceptedNumberDataTypes,
+  AcceptedTextDataTypes,
+  ControlDataTypeKey,
+} from '../../common'
+
+import { Code, CodeDefinition } from '../code'
+import { Number, NumberDefinition } from '../number'
+import { TextArea, TextAreaDefinition } from '../text-area'
+import { TextInput, TextInputDefinition } from '../text-input'
+
+const textControls = {
+  TextInput: TextInput(),
+  TextArea: TextArea(),
+  Code: Code(),
+} as const
+
+const numberControls = {
+  Number: Number(),
+} as const
+
+describe('cross-control interop', () => {
+  describe('text group', () => {
+    describe.each(Object.entries(textControls))(
+      'data written by %s',
+      (writerName, writer) => {
+        const value = `hello from ${writerName}`
+        const written = writer.toData(value)
+
+        describe('writes the shared text marker', () => {
+          test('toData uses the shared "text" marker', () => {
+            expect(written).toEqual({
+              [ControlDataTypeKey]: 'text',
+              value,
+            })
+          })
+        })
+
+        describe.each(Object.entries(textControls))(
+          'parses under %s',
+          (readerName, reader) => {
+            test(`${readerName}.safeParse succeeds`, () => {
+              expect(reader.safeParse(written).success).toBe(true)
+            })
+
+            test(`${readerName}.fromData returns the inner value`, () => {
+              expect(reader.fromData(written)).toBe(value)
+            })
+          },
+        )
+      },
+    )
+
+    describe('backward compatibility: every accepted text marker is parsable by every text control', () => {
+      describe.each(AcceptedTextDataTypes)('marker %s', (marker) => {
+        const legacyData = {
+          [ControlDataTypeKey]: marker,
+          value: 'legacy value',
+        }
+
+        describe.each(Object.entries(textControls))('%s', (_name, control) => {
+          test('safeParse succeeds', () => {
+            expect(control.safeParse(legacyData).success).toBe(true)
+          })
+
+          test('fromData returns the inner value', () => {
+            expect(control.fromData(legacyData as never)).toBe('legacy value')
+          })
+        })
+      })
+    })
+
+    describe('raw string (pre-versioned) shape is still parsable', () => {
+      describe.each(Object.entries(textControls))('%s', (_name, control) => {
+        test('safeParse succeeds on raw string', () => {
+          expect(control.safeParse('plain').success).toBe(true)
+        })
+
+        test('fromData returns the raw string', () => {
+          expect(control.fromData('plain' as never)).toBe('plain')
+        })
+      })
+    })
+  })
+
+  describe('number group', () => {
+    describe.each(Object.entries(numberControls))(
+      'data written by %s',
+      (_writerName, writer) => {
+        const value = 42
+        const written = writer.toData(value)
+
+        describe('writes the shared number marker', () => {
+          test('toData uses the shared "number" marker', () => {
+            expect(written).toEqual({
+              [ControlDataTypeKey]: 'number',
+              value,
+            })
+          })
+        })
+
+        describe.each(Object.entries(numberControls))(
+          'parses under %s',
+          (readerName, reader) => {
+            test(`${readerName}.safeParse succeeds`, () => {
+              expect(reader.safeParse(written).success).toBe(true)
+            })
+
+            test(`${readerName}.fromData returns the inner value`, () => {
+              expect(reader.fromData(written)).toBe(value)
+            })
+          },
+        )
+      },
+    )
+
+    describe('backward compatibility: every accepted number marker is parsable by every number control', () => {
+      describe.each(AcceptedNumberDataTypes)('marker %s', (marker) => {
+        const legacyData = {
+          [ControlDataTypeKey]: marker,
+          value: 7,
+        }
+
+        describe.each(Object.entries(numberControls))(
+          '%s',
+          (_name, control) => {
+            test('safeParse succeeds', () => {
+              expect(control.safeParse(legacyData).success).toBe(true)
+            })
+
+            test('fromData returns the inner value', () => {
+              expect(control.fromData(legacyData as never)).toBe(7)
+            })
+          },
+        )
+      })
+    })
+
+    describe('raw number (pre-versioned) shape is still parsable', () => {
+      describe.each(Object.entries(numberControls))('%s', (_name, control) => {
+        test('safeParse succeeds on raw number', () => {
+          expect(control.safeParse(123).success).toBe(true)
+        })
+
+        test('fromData returns the raw number', () => {
+          expect(control.fromData(123 as never)).toBe(123)
+        })
+      })
+    })
+  })
+
+  describe('cross-group rejection', () => {
+    test('a text-group marker does not parse under Number', () => {
+      const textShape = { [ControlDataTypeKey]: 'text', value: 'hi' }
+      expect(Number().safeParse(textShape).success).toBe(false)
+    })
+
+    test('the legacy "number::v1" marker does not parse under any text control', () => {
+      const numberShape = { [ControlDataTypeKey]: 'number::v1', value: 42 }
+      expect(TextInput().safeParse(numberShape).success).toBe(false)
+      expect(TextArea().safeParse(numberShape).success).toBe(false)
+      expect(Code().safeParse(numberShape).success).toBe(false)
+    })
+
+    test('a raw string does not parse under Number', () => {
+      expect(Number().safeParse('hi').success).toBe(false)
+    })
+
+    test('a raw number does not parse under TextInput/TextArea/Code', () => {
+      expect(TextInput().safeParse(42).success).toBe(false)
+      expect(TextArea().safeParse(42).success).toBe(false)
+      expect(Code().safeParse(42).success).toBe(false)
+    })
+  })
+
+  describe('legacy @makeswift/prop-controllers upgrade path', () => {
+    test('legacy text-input data parses under modern TextInput/TextArea/Code', () => {
+      const legacy = {
+        [ControlDataTypeKey]: 'prop-controllers::text-input::v1',
+        value: 'persisted under legacy package',
+      }
+
+      expect(TextInput().fromData(legacy as never)).toBe(
+        'persisted under legacy package',
+      )
+      expect(TextArea().fromData(legacy as never)).toBe(
+        'persisted under legacy package',
+      )
+      expect(Code().fromData(legacy as never)).toBe(
+        'persisted under legacy package',
+      )
+    })
+
+    test('legacy text-area data parses under modern TextInput/TextArea/Code', () => {
+      const legacy = {
+        [ControlDataTypeKey]: 'prop-controllers::text-area::v1',
+        value: 'persisted under legacy package',
+      }
+
+      expect(TextInput().fromData(legacy as never)).toBe(
+        'persisted under legacy package',
+      )
+      expect(TextArea().fromData(legacy as never)).toBe(
+        'persisted under legacy package',
+      )
+      expect(Code().fromData(legacy as never)).toBe(
+        'persisted under legacy package',
+      )
+    })
+
+    test('legacy number data parses under modern Number', () => {
+      const legacy = {
+        [ControlDataTypeKey]: 'prop-controllers::number::v1',
+        value: 99,
+      }
+
+      expect(Number().fromData(legacy as never)).toBe(99)
+    })
+
+    test('next edit through a modern control rewrites the marker to the canonical text marker', () => {
+      expect(TextInput().toData('after edit')).toEqual({
+        [ControlDataTypeKey]: 'text',
+        value: 'after edit',
+      })
+    })
+
+    test('next edit through Number rewrites the marker to the canonical number marker', () => {
+      expect(Number().toData(7)).toEqual({
+        [ControlDataTypeKey]: 'number',
+        value: 7,
+      })
+    })
+
+    test('legacy text marker still does not parse under Number, and vice versa', () => {
+      const legacyText = {
+        [ControlDataTypeKey]: 'prop-controllers::text-input::v1',
+        value: 'hi',
+      }
+      const legacyNumber = {
+        [ControlDataTypeKey]: 'prop-controllers::number::v1',
+        value: 7,
+      }
+
+      expect(Number().safeParse(legacyText).success).toBe(false)
+      expect(TextInput().safeParse(legacyNumber).success).toBe(false)
+      expect(TextArea().safeParse(legacyNumber).success).toBe(false)
+      expect(Code().safeParse(legacyNumber).success).toBe(false)
+    })
+  })
+
+  describe('type smoke test', () => {
+    test('control factories yield the expected definition classes', () => {
+      expect(TextInput()).toBeInstanceOf(TextInputDefinition)
+      expect(TextArea()).toBeInstanceOf(TextAreaDefinition)
+      expect(Code()).toBeInstanceOf(CodeDefinition)
+      expect(Number()).toBeInstanceOf(NumberDefinition)
+    })
+  })
+})

--- a/packages/controls/src/controls/code/__snapshots__/code.test.ts.snap
+++ b/packages/controls/src/controls/code/__snapshots__/code.test.ts.snap
@@ -32,28 +32,28 @@ CodeDefinition {
 
 exports[`Code definition w/ config {"defaultValue":"console.log(\\"hi\\")","label":"visible"} toData returns v1 data for \`body { color: red; }\` when definition version is 1 1`] = `
 {
-  "@@makeswift/type": "code::v1",
+  "@@makeswift/type": "text",
   "value": "body { color: red; }",
 }
 `;
 
 exports[`Code definition w/ config {"defaultValue":"console.log(\\"hi\\")","label":"visible"} toData returns v1 data for \`const x = 1\` when definition version is 1 1`] = `
 {
-  "@@makeswift/type": "code::v1",
+  "@@makeswift/type": "text",
   "value": "const x = 1",
 }
 `;
 
 exports[`Code definition w/ config {"label":"Code"} toData returns v1 data for \`.class { margin: 0; }\` when definition version is 1 1`] = `
 {
-  "@@makeswift/type": "code::v1",
+  "@@makeswift/type": "text",
   "value": ".class { margin: 0; }",
 }
 `;
 
 exports[`Code definition w/ config {"label":"Code"} toData returns v1 data for \`<div>hello</div>\` when definition version is 1 1`] = `
 {
-  "@@makeswift/type": "code::v1",
+  "@@makeswift/type": "text",
   "value": "<div>hello</div>",
 }
 `;

--- a/packages/controls/src/controls/code/code.test.types.ts
+++ b/packages/controls/src/controls/code/code.test.types.ts
@@ -1,6 +1,6 @@
 import { expectTypeOf } from 'expect-type'
 
-import { ControlDataTypeKey } from '../../common'
+import { AcceptedTextDataTypes, ControlDataTypeKey } from '../../common'
 
 import {
   type DataType,
@@ -13,7 +13,7 @@ import { Code } from './code'
 type ExpectedCodeDataType =
   | string
   | {
-      [ControlDataTypeKey]: 'code::v1'
+      [ControlDataTypeKey]: (typeof AcceptedTextDataTypes)[number]
       value: string
     }
 

--- a/packages/controls/src/controls/code/code.ts
+++ b/packages/controls/src/controls/code/code.ts
@@ -1,9 +1,13 @@
-import { match } from 'ts-pattern'
+import { match, P } from 'ts-pattern'
 import { z } from 'zod'
 
 import { safeParse, type ParseResult } from '../../lib/zod'
 
-import { ControlDataTypeKey } from '../../common'
+import {
+  AcceptedTextDataTypes,
+  ControlDataTypeKey,
+  TextDataType,
+} from '../../common'
 import { type CopyContext } from '../../context'
 import { type DeserializedRecord } from '../../serialization'
 
@@ -42,7 +46,7 @@ class Definition<C extends Config> extends ControlDefinition<
   ValueType<C>,
   ResolvedValueType<C>
 > {
-  private static readonly v1DataType = 'code::v1' as const
+  private static readonly v1DataType = TextDataType
   private static readonly dataSignature = {
     v1: { [ControlDataTypeKey]: this.v1DataType },
   } as const
@@ -52,7 +56,7 @@ class Definition<C extends Config> extends ControlDefinition<
   static get schema() {
     const version = z.literal(1)
     const versionedData = z.object({
-      [ControlDataTypeKey]: z.literal(this.v1DataType),
+      [ControlDataTypeKey]: z.enum(AcceptedTextDataTypes),
       value: z.string(),
     })
 
@@ -147,7 +151,10 @@ class Definition<C extends Config> extends ControlDefinition<
   fromData(data: DataType<C> | undefined): ValueType<C> | undefined {
     const inputSchema = this.dataSchema.optional()
     return match(data satisfies z.infer<typeof inputSchema>)
-      .with(Definition.dataSignature.v1, ({ value }) => value)
+      .with(
+        { [ControlDataTypeKey]: P.union(...AcceptedTextDataTypes) },
+        ({ value }) => value,
+      )
       .otherwise((val) => val)
   }
 

--- a/packages/controls/src/controls/code/code.ts
+++ b/packages/controls/src/controls/code/code.ts
@@ -1,9 +1,10 @@
-import { match } from 'ts-pattern'
+import { match, P } from 'ts-pattern'
 import { z } from 'zod'
 
 import { safeParse, type ParseResult } from '../../lib/zod'
 
-import { ControlDataTypeKey } from '../../common'
+import { AcceptedTextDataTypes, ControlDataTypeKey } from '../../common'
+import { DataType } from '../../common/data-types'
 import { type CopyContext } from '../../context'
 import { type DeserializedRecord } from '../../serialization'
 
@@ -42,7 +43,7 @@ class Definition<C extends Config> extends ControlDefinition<
   ValueType<C>,
   ResolvedValueType<C>
 > {
-  private static readonly v1DataType = 'code::v1' as const
+  private static readonly v1DataType = DataType.Text
   private static readonly dataSignature = {
     v1: { [ControlDataTypeKey]: this.v1DataType },
   } as const
@@ -52,7 +53,7 @@ class Definition<C extends Config> extends ControlDefinition<
   static get schema() {
     const version = z.literal(1)
     const versionedData = z.object({
-      [ControlDataTypeKey]: z.literal(this.v1DataType),
+      [ControlDataTypeKey]: z.enum(AcceptedTextDataTypes),
       value: z.string(),
     })
 
@@ -147,7 +148,10 @@ class Definition<C extends Config> extends ControlDefinition<
   fromData(data: DataType<C> | undefined): ValueType<C> | undefined {
     const inputSchema = this.dataSchema.optional()
     return match(data satisfies z.infer<typeof inputSchema>)
-      .with(Definition.dataSignature.v1, ({ value }) => value)
+      .with(
+        { [ControlDataTypeKey]: P.union(...AcceptedTextDataTypes) },
+        ({ value }) => value,
+      )
       .otherwise((val) => val)
   }
 
@@ -171,9 +175,7 @@ class Definition<C extends Config> extends ControlDefinition<
   ): Resolvable<ResolvedValueType<C> | undefined> {
     const value = this.fromData(data) ?? this.config.defaultValue
     const resolved =
-      value === undefined
-        ? undefined
-        : ({ value } as ResolvedValueType<C>)
+      value === undefined ? undefined : ({ value } as ResolvedValueType<C>)
     return {
       name: Definition.type,
       readStable: () => resolved,
@@ -191,9 +193,7 @@ class Definition<C extends Config> extends ControlDefinition<
   }
 }
 
-export class CodeDefinition<
-  C extends Config = Config,
-> extends Definition<C> {}
+export class CodeDefinition<C extends Config = Config> extends Definition<C> {}
 
 type UserConfig<D extends Config['defaultValue']> = Config & {
   defaultValue?: D

--- a/packages/controls/src/controls/group/__snapshots__/group.test.ts.snap
+++ b/packages/controls/src/controls/group/__snapshots__/group.test.ts.snap
@@ -69,13 +69,13 @@ exports[`Group Group data gracefully handles missing/extra props toData 1`] = `
         "id": "xxxxxxxx-xxxx-xxxx-xxxx-100000000000",
         "type": "makeswift::controls::number",
         "value": {
-          "@@makeswift/type": "number::v1",
+          "@@makeswift/type": "number",
           "value": 17,
         },
       },
     ],
     "text": {
-      "@@makeswift/type": "text-area::v1",
+      "@@makeswift/type": "text",
       "value": "Hello world",
     },
   },
@@ -151,13 +151,13 @@ exports[`Group Group versioned data is gracefully handles missing/extra props to
         "id": "xxxxxxxx-xxxx-xxxx-xxxx-100000000001",
         "type": "makeswift::controls::number",
         "value": {
-          "@@makeswift/type": "number::v1",
+          "@@makeswift/type": "number",
           "value": 17,
         },
       },
     ],
     "text": {
-      "@@makeswift/type": "text-area::v1",
+      "@@makeswift/type": "text",
       "value": "Hello world",
     },
   },

--- a/packages/controls/src/controls/group/group.test.types.ts
+++ b/packages/controls/src/controls/group/group.test.types.ts
@@ -1,6 +1,6 @@
 import { expectTypeOf } from 'expect-type'
 
-import { ControlDataTypeKey } from '../../common'
+import { AcceptedNumberDataTypes, ControlDataTypeKey } from '../../common'
 
 import {
   type DataType,
@@ -25,7 +25,7 @@ type ExpectedPropsDataType = {
     value?:
       | number
       | {
-          [ControlDataTypeKey]: 'number::v1'
+          [ControlDataTypeKey]: (typeof AcceptedNumberDataTypes)[number]
           value: number
         }
   }[]

--- a/packages/controls/src/controls/number/__snapshots__/number.test.ts.snap
+++ b/packages/controls/src/controls/number/__snapshots__/number.test.ts.snap
@@ -32,28 +32,28 @@ NumberDefinition {
 
 exports[`Number definition w/ config {"defaultValue":17,"label":"visible"} toData returns v1 data for \`20\` when definition version is 1 1`] = `
 {
-  "@@makeswift/type": "number::v1",
+  "@@makeswift/type": "number",
   "value": 20,
 }
 `;
 
 exports[`Number definition w/ config {"defaultValue":17,"label":"visible"} toData returns v1 data for \`21\` when definition version is 1 1`] = `
 {
-  "@@makeswift/type": "number::v1",
+  "@@makeswift/type": "number",
   "value": 21,
 }
 `;
 
 exports[`Number definition w/ config {"label":"Number"} toData returns v1 data for \`50\` when definition version is 1 1`] = `
 {
-  "@@makeswift/type": "number::v1",
+  "@@makeswift/type": "number",
   "value": 50,
 }
 `;
 
 exports[`Number definition w/ config {"label":"Number"} toData returns v1 data for \`51\` when definition version is 1 1`] = `
 {
-  "@@makeswift/type": "number::v1",
+  "@@makeswift/type": "number",
   "value": 51,
 }
 `;

--- a/packages/controls/src/controls/number/number.test.types.ts
+++ b/packages/controls/src/controls/number/number.test.types.ts
@@ -1,6 +1,6 @@
 import { expectTypeOf } from 'expect-type'
 
-import { ControlDataTypeKey } from '../../common'
+import { AcceptedNumberDataTypes, ControlDataTypeKey } from '../../common'
 
 import {
   type DataType,
@@ -13,7 +13,7 @@ import { Number } from './number'
 type ExpectedNumberDataType =
   | number
   | {
-      [ControlDataTypeKey]: 'number::v1'
+      [ControlDataTypeKey]: (typeof AcceptedNumberDataTypes)[number]
       value: number
     }
 

--- a/packages/controls/src/controls/number/number.ts
+++ b/packages/controls/src/controls/number/number.ts
@@ -3,7 +3,11 @@ import { z } from 'zod'
 
 import { safeParse, type ParseResult } from '../../lib/zod'
 
-import { ControlDataTypeKey } from '../../common'
+import {
+  AcceptedNumberDataTypes,
+  ControlDataTypeKey,
+  NumberDataType,
+} from '../../common'
 import { type CopyContext } from '../../context'
 import { type DeserializedRecord } from '../../serialization'
 
@@ -42,7 +46,7 @@ class Definition<C extends Config> extends ControlDefinition<
   ValueType<C>,
   ResolvedValueType<C>
 > {
-  private static readonly v1DataType = 'number::v1' as const
+  private static readonly v1DataType = NumberDataType
   private static readonly dataSignature = {
     v1: { [ControlDataTypeKey]: this.v1DataType },
   } as const
@@ -53,7 +57,7 @@ class Definition<C extends Config> extends ControlDefinition<
     const version = z.literal(1).optional()
 
     const versionedData = z.object({
-      [ControlDataTypeKey]: z.literal(this.v1DataType),
+      [ControlDataTypeKey]: z.enum(AcceptedNumberDataTypes),
       value: z.number(),
     })
 
@@ -140,7 +144,10 @@ class Definition<C extends Config> extends ControlDefinition<
   fromData(data: DataType<C> | undefined): ValueType<C> | undefined {
     const inputSchema = this.dataSchema.optional()
     return match(data satisfies z.infer<typeof inputSchema>)
-      .with(Definition.dataSignature.v1, ({ value }) => value)
+      .with(
+        { [ControlDataTypeKey]: P.union(...AcceptedNumberDataTypes) },
+        ({ value }) => value,
+      )
       .otherwise((val) => val)
   }
 

--- a/packages/controls/src/controls/number/number.ts
+++ b/packages/controls/src/controls/number/number.ts
@@ -3,7 +3,8 @@ import { z } from 'zod'
 
 import { safeParse, type ParseResult } from '../../lib/zod'
 
-import { ControlDataTypeKey } from '../../common'
+import { AcceptedNumberDataTypes, ControlDataTypeKey } from '../../common'
+import { DataType } from '../../common/data-types'
 import { type CopyContext } from '../../context'
 import { type DeserializedRecord } from '../../serialization'
 
@@ -42,7 +43,7 @@ class Definition<C extends Config> extends ControlDefinition<
   ValueType<C>,
   ResolvedValueType<C>
 > {
-  private static readonly v1DataType = 'number::v1' as const
+  private static readonly v1DataType = DataType.Number
   private static readonly dataSignature = {
     v1: { [ControlDataTypeKey]: this.v1DataType },
   } as const
@@ -53,7 +54,7 @@ class Definition<C extends Config> extends ControlDefinition<
     const version = z.literal(1).optional()
 
     const versionedData = z.object({
-      [ControlDataTypeKey]: z.literal(this.v1DataType),
+      [ControlDataTypeKey]: z.enum(AcceptedNumberDataTypes),
       value: z.number(),
     })
 
@@ -140,7 +141,10 @@ class Definition<C extends Config> extends ControlDefinition<
   fromData(data: DataType<C> | undefined): ValueType<C> | undefined {
     const inputSchema = this.dataSchema.optional()
     return match(data satisfies z.infer<typeof inputSchema>)
-      .with(Definition.dataSignature.v1, ({ value }) => value)
+      .with(
+        { [ControlDataTypeKey]: P.union(...AcceptedNumberDataTypes) },
+        ({ value }) => value,
+      )
       .otherwise((val) => val)
   }
 

--- a/packages/controls/src/controls/shape/v1/__snapshots__/shape.test.ts.snap
+++ b/packages/controls/src/controls/shape/v1/__snapshots__/shape.test.ts.snap
@@ -83,13 +83,13 @@ exports[`Shape gracefully handles missing/extra props toData 1`] = `
       "id": "xxxxxxxx-xxxx-xxxx-xxxx-100000000000",
       "type": "makeswift::controls::number",
       "value": {
-        "@@makeswift/type": "number::v1",
+        "@@makeswift/type": "number",
         "value": 17,
       },
     },
   ],
   "text": {
-    "@@makeswift/type": "text-area::v1",
+    "@@makeswift/type": "text",
     "value": "Hello world",
   },
 }

--- a/packages/controls/src/controls/shape/v1/shape.test.types.ts
+++ b/packages/controls/src/controls/shape/v1/shape.test.types.ts
@@ -1,7 +1,6 @@
 import { expectTypeOf } from 'expect-type'
 
-import { ControlDataTypeKey } from '../../../common'
-
+import { AcceptedNumberDataTypes, ControlDataTypeKey } from '../../../common'
 import {
   type DataType,
   type ResolvedValueType,
@@ -51,7 +50,7 @@ describe('Shape Types', () => {
           value?:
             | number
             | {
-                [ControlDataTypeKey]: 'number::v1'
+                [ControlDataTypeKey]: (typeof AcceptedNumberDataTypes)[number]
                 value: number
               }
         }[]

--- a/packages/controls/src/controls/shape/v1/shape.test.types.ts
+++ b/packages/controls/src/controls/shape/v1/shape.test.types.ts
@@ -1,6 +1,6 @@
 import { expectTypeOf } from 'expect-type'
 
-import { ControlDataTypeKey } from '../../../common'
+import { AcceptedNumberDataTypes, ControlDataTypeKey } from '../../../common'
 
 import {
   type DataType,
@@ -51,7 +51,7 @@ describe('Shape Types', () => {
           value?:
             | number
             | {
-                [ControlDataTypeKey]: 'number::v1'
+                [ControlDataTypeKey]: (typeof AcceptedNumberDataTypes)[number]
                 value: number
               }
         }[]

--- a/packages/controls/src/controls/text-area/__snapshots__/text-area.test.ts.snap
+++ b/packages/controls/src/controls/text-area/__snapshots__/text-area.test.ts.snap
@@ -32,28 +32,28 @@ TextAreaDefinition {
 
 exports[`TextArea definition w/ config {"defaultValue":"Up","label":"visible"} toData returns v1 data for \`Monster's Inc.\` when definition version is 1 1`] = `
 {
-  "@@makeswift/type": "text-area::v1",
+  "@@makeswift/type": "text",
   "value": "Monster's Inc.",
 }
 `;
 
 exports[`TextArea definition w/ config {"defaultValue":"Up","label":"visible"} toData returns v1 data for \`Toy Story 3\` when definition version is 1 1`] = `
 {
-  "@@makeswift/type": "text-area::v1",
+  "@@makeswift/type": "text",
   "value": "Toy Story 3",
 }
 `;
 
 exports[`TextArea definition w/ config {"label":"TextArea"} toData returns v1 data for \`Ratatouille\` when definition version is 1 1`] = `
 {
-  "@@makeswift/type": "text-area::v1",
+  "@@makeswift/type": "text",
   "value": "Ratatouille",
 }
 `;
 
 exports[`TextArea definition w/ config {"label":"TextArea"} toData returns v1 data for \`WALL-E\` when definition version is 1 1`] = `
 {
-  "@@makeswift/type": "text-area::v1",
+  "@@makeswift/type": "text",
   "value": "WALL-E",
 }
 `;

--- a/packages/controls/src/controls/text-area/text-area.test.types.ts
+++ b/packages/controls/src/controls/text-area/text-area.test.types.ts
@@ -1,6 +1,6 @@
 import { expectTypeOf } from 'expect-type'
 
-import { ControlDataTypeKey } from '../../common'
+import { AcceptedTextDataTypes, ControlDataTypeKey } from '../../common'
 
 import {
   type DataType,
@@ -13,7 +13,7 @@ import { TextArea } from './text-area'
 type ExpectedTextAreaDataType =
   | string
   | {
-      [ControlDataTypeKey]: 'text-area::v1'
+      [ControlDataTypeKey]: (typeof AcceptedTextDataTypes)[number]
       value: string
     }
 

--- a/packages/controls/src/controls/text-area/text-area.ts
+++ b/packages/controls/src/controls/text-area/text-area.ts
@@ -3,7 +3,12 @@ import { z } from 'zod'
 
 import { safeParse, type ParseResult } from '../../lib/zod'
 
-import { ControlDataTypeKey, type Data } from '../../common'
+import {
+  AcceptedTextDataTypes,
+  ControlDataTypeKey,
+  TextDataType,
+  type Data,
+} from '../../common'
 import { type CopyContext } from '../../context'
 import { type DeserializedRecord } from '../../serialization'
 
@@ -42,7 +47,7 @@ class Definition<C extends Config> extends ControlDefinition<
   ValueType<C>,
   ResolvedValueType<C>
 > {
-  private static readonly v1DataType = 'text-area::v1' as const
+  private static readonly v1DataType = TextDataType
   private static readonly dataSignature = {
     v1: { [ControlDataTypeKey]: this.v1DataType },
   } as const
@@ -52,7 +57,7 @@ class Definition<C extends Config> extends ControlDefinition<
   static get schema() {
     const version = z.literal(1).optional()
     const versionedData = z.object({
-      [ControlDataTypeKey]: z.literal(this.v1DataType),
+      [ControlDataTypeKey]: z.enum(AcceptedTextDataTypes),
       value: z.string(),
     })
 
@@ -135,7 +140,10 @@ class Definition<C extends Config> extends ControlDefinition<
   fromData(data: DataType<C> | undefined): ValueType<C> | undefined {
     const inputSchema = this.dataSchema.optional()
     return match(data satisfies z.infer<typeof inputSchema>)
-      .with(Definition.dataSignature.v1, ({ value }) => value)
+      .with(
+        { [ControlDataTypeKey]: P.union(...AcceptedTextDataTypes) },
+        ({ value }) => value,
+      )
       .otherwise((val) => val)
   }
 

--- a/packages/controls/src/controls/text-area/text-area.ts
+++ b/packages/controls/src/controls/text-area/text-area.ts
@@ -3,7 +3,12 @@ import { z } from 'zod'
 
 import { safeParse, type ParseResult } from '../../lib/zod'
 
-import { ControlDataTypeKey, type Data } from '../../common'
+import {
+  AcceptedTextDataTypes,
+  ControlDataTypeKey,
+  type Data,
+} from '../../common'
+import { DataType } from '../../common/data-types'
 import { type CopyContext } from '../../context'
 import { type DeserializedRecord } from '../../serialization'
 
@@ -42,7 +47,7 @@ class Definition<C extends Config> extends ControlDefinition<
   ValueType<C>,
   ResolvedValueType<C>
 > {
-  private static readonly v1DataType = 'text-area::v1' as const
+  private static readonly v1DataType = DataType.Text
   private static readonly dataSignature = {
     v1: { [ControlDataTypeKey]: this.v1DataType },
   } as const
@@ -52,7 +57,7 @@ class Definition<C extends Config> extends ControlDefinition<
   static get schema() {
     const version = z.literal(1).optional()
     const versionedData = z.object({
-      [ControlDataTypeKey]: z.literal(this.v1DataType),
+      [ControlDataTypeKey]: z.enum(AcceptedTextDataTypes),
       value: z.string(),
     })
 
@@ -135,7 +140,10 @@ class Definition<C extends Config> extends ControlDefinition<
   fromData(data: DataType<C> | undefined): ValueType<C> | undefined {
     const inputSchema = this.dataSchema.optional()
     return match(data satisfies z.infer<typeof inputSchema>)
-      .with(Definition.dataSignature.v1, ({ value }) => value)
+      .with(
+        { [ControlDataTypeKey]: P.union(...AcceptedTextDataTypes) },
+        ({ value }) => value,
+      )
       .otherwise((val) => val)
   }
 

--- a/packages/controls/src/controls/text-input/__snapshots__/text-input.test.ts.snap
+++ b/packages/controls/src/controls/text-input/__snapshots__/text-input.test.ts.snap
@@ -32,28 +32,28 @@ TextInputDefinition {
 
 exports[`TextInput definition w/ config {"defaultValue":"elmo","label":"visible"} toData returns v1 data for \`bert\` when definition version is 1 1`] = `
 {
-  "@@makeswift/type": "text-input::v1",
+  "@@makeswift/type": "text",
   "value": "bert",
 }
 `;
 
 exports[`TextInput definition w/ config {"defaultValue":"elmo","label":"visible"} toData returns v1 data for \`ernie\` when definition version is 1 1`] = `
 {
-  "@@makeswift/type": "text-input::v1",
+  "@@makeswift/type": "text",
   "value": "ernie",
 }
 `;
 
 exports[`TextInput definition w/ config {"label":"TextInput"} toData returns v1 data for \`big bird\` when definition version is 1 1`] = `
 {
-  "@@makeswift/type": "text-input::v1",
+  "@@makeswift/type": "text",
   "value": "big bird",
 }
 `;
 
 exports[`TextInput definition w/ config {"label":"TextInput"} toData returns v1 data for \`cookie monster\` when definition version is 1 1`] = `
 {
-  "@@makeswift/type": "text-input::v1",
+  "@@makeswift/type": "text",
   "value": "cookie monster",
 }
 `;

--- a/packages/controls/src/controls/text-input/text-input.test.types.ts
+++ b/packages/controls/src/controls/text-input/text-input.test.types.ts
@@ -1,6 +1,6 @@
 import { expectTypeOf } from 'expect-type'
 
-import { ControlDataTypeKey } from '../../common'
+import { AcceptedTextDataTypes, ControlDataTypeKey } from '../../common'
 
 import {
   type DataType,
@@ -13,7 +13,7 @@ import { TextInput } from './text-input'
 type ExpectedTextInputDataType =
   | string
   | {
-      [ControlDataTypeKey]: 'text-input::v1'
+      [ControlDataTypeKey]: (typeof AcceptedTextDataTypes)[number]
       value: string
     }
 

--- a/packages/controls/src/controls/text-input/text-input.ts
+++ b/packages/controls/src/controls/text-input/text-input.ts
@@ -3,7 +3,12 @@ import { z } from 'zod'
 
 import { safeParse, type ParseResult } from '../../lib/zod'
 
-import { ControlDataTypeKey, type Data } from '../../common'
+import {
+  AcceptedTextDataTypes,
+  ControlDataTypeKey,
+  type Data,
+} from '../../common'
+import { DataType } from '../../common/data-types'
 import { type CopyContext } from '../../context'
 import { type DeserializedRecord } from '../../serialization'
 
@@ -42,7 +47,7 @@ class Definition<C extends Config> extends ControlDefinition<
   ValueType<C>,
   ResolvedValueType<C>
 > {
-  private static readonly v1DataType = 'text-input::v1' as const
+  private static readonly v1DataType = DataType.Text
   private static readonly dataSignature = {
     v1: { [ControlDataTypeKey]: this.v1DataType },
   } as const
@@ -52,7 +57,7 @@ class Definition<C extends Config> extends ControlDefinition<
   static get schema() {
     const version = z.literal(1).optional()
     const versionedData = z.object({
-      [ControlDataTypeKey]: z.literal(this.v1DataType),
+      [ControlDataTypeKey]: z.enum(AcceptedTextDataTypes),
       value: z.string(),
     })
 
@@ -135,7 +140,10 @@ class Definition<C extends Config> extends ControlDefinition<
   fromData(data: DataType<C> | undefined): ValueType<C> | undefined {
     const inputSchema = this.dataSchema.optional()
     return match(data satisfies z.infer<typeof inputSchema>)
-      .with(Definition.dataSignature.v1, ({ value }) => value)
+      .with(
+        { [ControlDataTypeKey]: P.union(...AcceptedTextDataTypes) },
+        ({ value }) => value,
+      )
       .otherwise((val) => val)
   }
 

--- a/packages/controls/src/controls/text-input/text-input.ts
+++ b/packages/controls/src/controls/text-input/text-input.ts
@@ -3,7 +3,12 @@ import { z } from 'zod'
 
 import { safeParse, type ParseResult } from '../../lib/zod'
 
-import { ControlDataTypeKey, type Data } from '../../common'
+import {
+  AcceptedTextDataTypes,
+  ControlDataTypeKey,
+  TextDataType,
+  type Data,
+} from '../../common'
 import { type CopyContext } from '../../context'
 import { type DeserializedRecord } from '../../serialization'
 
@@ -42,7 +47,7 @@ class Definition<C extends Config> extends ControlDefinition<
   ValueType<C>,
   ResolvedValueType<C>
 > {
-  private static readonly v1DataType = 'text-input::v1' as const
+  private static readonly v1DataType = TextDataType
   private static readonly dataSignature = {
     v1: { [ControlDataTypeKey]: this.v1DataType },
   } as const
@@ -52,7 +57,7 @@ class Definition<C extends Config> extends ControlDefinition<
   static get schema() {
     const version = z.literal(1).optional()
     const versionedData = z.object({
-      [ControlDataTypeKey]: z.literal(this.v1DataType),
+      [ControlDataTypeKey]: z.enum(AcceptedTextDataTypes),
       value: z.string(),
     })
 
@@ -135,7 +140,10 @@ class Definition<C extends Config> extends ControlDefinition<
   fromData(data: DataType<C> | undefined): ValueType<C> | undefined {
     const inputSchema = this.dataSchema.optional()
     return match(data satisfies z.infer<typeof inputSchema>)
-      .with(Definition.dataSignature.v1, ({ value }) => value)
+      .with(
+        { [ControlDataTypeKey]: P.union(...AcceptedTextDataTypes) },
+        ({ value }) => value,
+      )
       .otherwise((val) => val)
   }
 

--- a/packages/controls/src/testing/test-definition.ts
+++ b/packages/controls/src/testing/test-definition.ts
@@ -1,4 +1,4 @@
-import { ControlDataTypeKey } from '../common/types'
+import { ControlDataTypeKey } from '../common/data-types'
 import { type ValueType } from '../controls/associated-types'
 import { ControlDefinition } from '../controls/definition'
 

--- a/packages/prop-controllers/jest.config.json
+++ b/packages/prop-controllers/jest.config.json
@@ -1,5 +1,6 @@
 {
   "transform": {
     "^.+\\.(t|j)sx?$": "@swc/jest"
-  }
+  },
+  "testPathIgnorePatterns": ["/node_modules/", "/dist/"]
 }

--- a/packages/prop-controllers/src/__tests__/interop.test.ts
+++ b/packages/prop-controllers/src/__tests__/interop.test.ts
@@ -1,0 +1,200 @@
+import {
+  AcceptedNumberDataTypes,
+  AcceptedTextDataTypes,
+  Code,
+  ControlDataTypeKey,
+  Number as ModernNumber,
+  TextArea as ModernTextArea,
+  TextInput as ModernTextInput,
+} from '@makeswift/controls'
+
+import {
+  getNumberPropControllerDataNumber,
+  numberPropControllerDataSchema,
+} from '../number'
+import {
+  TextAreaPropControllerData,
+  getTextAreaPropControllerDataString,
+  textAreaPropControllerDataSchema,
+} from '../text-area/text-area'
+import {
+  TextInputPropControllerData,
+  getTextInputPropControllerDataString,
+  textInputPropControllerDataSchema,
+} from '../text-input/text-input'
+
+describe('@makeswift/controls -> @makeswift/prop-controllers interop', () => {
+  describe('text group', () => {
+    const modernTextWriters = {
+      TextInput: ModernTextInput(),
+      TextArea: ModernTextArea(),
+      Code: Code(),
+    } as const
+
+    describe.each(Object.entries(modernTextWriters))(
+      'data written by modern controls %s',
+      (writerName, writer) => {
+        const value = `hello from ${writerName}`
+        const written = writer.toData(value)
+
+        test(`textInputPropControllerDataSchema parses it`, () => {
+          expect(
+            textInputPropControllerDataSchema.safeParse(written).success,
+          ).toBe(true)
+        })
+
+        test(`textAreaPropControllerDataSchema parses it`, () => {
+          expect(
+            textAreaPropControllerDataSchema.safeParse(written).success,
+          ).toBe(true)
+        })
+
+        test(`getTextInputPropControllerDataString returns the inner value`, () => {
+          expect(
+            getTextInputPropControllerDataString(
+              written as TextInputPropControllerData,
+            ),
+          ).toBe(value)
+        })
+
+        test(`getTextAreaPropControllerDataString returns the inner value`, () => {
+          expect(
+            getTextAreaPropControllerDataString(
+              written as TextAreaPropControllerData,
+            ),
+          ).toBe(value)
+        })
+      },
+    )
+
+    describe('backward compatibility: every accepted modern text marker is parsable', () => {
+      describe.each(AcceptedTextDataTypes)('marker %s', (marker) => {
+        const data = {
+          [ControlDataTypeKey]: marker,
+          value: 'legacy value',
+        }
+
+        test('textInputPropControllerDataSchema parses', () => {
+          expect(
+            textInputPropControllerDataSchema.safeParse(data).success,
+          ).toBe(true)
+        })
+
+        test('textAreaPropControllerDataSchema parses', () => {
+          expect(textAreaPropControllerDataSchema.safeParse(data).success).toBe(
+            true,
+          )
+        })
+
+        test('getTextInputPropControllerDataString returns the inner value', () => {
+          expect(
+            getTextInputPropControllerDataString(
+              data as TextInputPropControllerData,
+            ),
+          ).toBe('legacy value')
+        })
+
+        test('getTextAreaPropControllerDataString returns the inner value', () => {
+          expect(
+            getTextAreaPropControllerDataString(
+              data as TextAreaPropControllerData,
+            ),
+          ).toBe('legacy value')
+        })
+      })
+    })
+
+    test('override-then-revert round-trip preserves text value', () => {
+      // 1. Built-in (prop-controllers) writes legacy v1 data
+      const persisted = {
+        [ControlDataTypeKey]: 'prop-controllers::text-input::v1' as const,
+        value: 'Shop now',
+      }
+
+      // 2. Host overrides with custom component using modern controls; on next
+      //    edit, modern toData rewrites the marker to canonical 'text'.
+      const afterModernRead = ModernTextInput().fromData(persisted as never)
+      const afterModernEdit = ModernTextInput().toData(afterModernRead!)
+
+      expect(afterModernEdit).toEqual({
+        [ControlDataTypeKey]: 'text',
+        value: 'Shop now',
+      })
+
+      // 3. Host removes the override; built-in must still read the value.
+      expect(
+        getTextInputPropControllerDataString(
+          afterModernEdit as TextInputPropControllerData,
+        ),
+      ).toBe('Shop now')
+    })
+  })
+
+  describe('number group', () => {
+    const writer = ModernNumber()
+    const value = 42
+    const written = writer.toData(value)
+
+    test('numberPropControllerDataSchema parses modern-written data', () => {
+      expect(numberPropControllerDataSchema.safeParse(written).success).toBe(
+        true,
+      )
+    })
+
+    test('getNumberPropControllerDataNumber returns the inner value', () => {
+      expect(getNumberPropControllerDataNumber(written as never)).toBe(value)
+    })
+
+    describe('backward compatibility: every accepted modern number marker is parsable', () => {
+      describe.each(AcceptedNumberDataTypes)('marker %s', (marker) => {
+        const data = { [ControlDataTypeKey]: marker, value: 7 }
+
+        test('numberPropControllerDataSchema parses', () => {
+          expect(numberPropControllerDataSchema.safeParse(data).success).toBe(
+            true,
+          )
+        })
+
+        test('getNumberPropControllerDataNumber returns the inner value', () => {
+          expect(getNumberPropControllerDataNumber(data as never)).toBe(7)
+        })
+      })
+    })
+
+    test('override-then-revert round-trip preserves number value', () => {
+      const persisted = {
+        [ControlDataTypeKey]: 'prop-controllers::number::v1' as const,
+        value: 99,
+      }
+
+      const afterModernRead = ModernNumber().fromData(persisted as never)
+      const afterModernEdit = ModernNumber().toData(afterModernRead!)
+
+      expect(afterModernEdit).toEqual({
+        [ControlDataTypeKey]: 'number',
+        value: 99,
+      })
+
+      expect(getNumberPropControllerDataNumber(afterModernEdit as never)).toBe(
+        99,
+      )
+    })
+  })
+
+  describe('cross-group rejection', () => {
+    test('a text marker does not parse under numberPropControllerDataSchema', () => {
+      const data = { [ControlDataTypeKey]: 'text', value: 'hi' }
+      expect(numberPropControllerDataSchema.safeParse(data).success).toBe(false)
+    })
+
+    test('a number marker does not parse under text schemas', () => {
+      const data = { [ControlDataTypeKey]: 'number', value: 42 }
+      expect(textInputPropControllerDataSchema.safeParse(data).success).toBe(
+        false,
+      )
+      expect(textAreaPropControllerDataSchema.safeParse(data).success).toBe(
+        false,
+      )
+    })
+  })
+})

--- a/packages/prop-controllers/src/number.ts
+++ b/packages/prop-controllers/src/number.ts
@@ -1,3 +1,4 @@
+import { AcceptedNumberDataTypes } from '@makeswift/controls'
 import { z } from 'zod'
 import { ControlDataTypeKey, Options, Types } from './prop-controllers'
 import { P, match } from 'ts-pattern'
@@ -19,9 +20,15 @@ type NumberPropControllerDataV1 = z.infer<
   typeof numberPropControllerDataV1Schema
 >
 
+const numberInteropDataSchema = z.object({
+  [ControlDataTypeKey]: z.enum(AcceptedNumberDataTypes),
+  value: z.number(),
+})
+
 export const numberPropControllerDataSchema = z.union([
   numberPropControllerDataV0Schema,
   numberPropControllerDataV1Schema,
+  numberInteropDataSchema,
 ])
 
 export type NumberPropControllerData = z.infer<
@@ -70,8 +77,8 @@ export function getNumberPropControllerDataNumber(
 ): number {
   return match(data)
     .with(
-      { [ControlDataTypeKey]: NumberPropControllerDataV1Type },
-      (v1) => v1.value,
+      { [ControlDataTypeKey]: P.union(...AcceptedNumberDataTypes) },
+      (versioned) => versioned.value,
     )
     .otherwise((v0) => v0)
 }
@@ -88,7 +95,7 @@ export function createNumberPropControllerDataFromNumber(
         ({
           [ControlDataTypeKey]: NumberPropControllerDataV1Type,
           value,
-        } as const),
+        }) as const,
     )
     .otherwise(() => value)
 }

--- a/packages/prop-controllers/src/text-area/text-area.ts
+++ b/packages/prop-controllers/src/text-area/text-area.ts
@@ -1,6 +1,7 @@
+import { AcceptedTextDataTypes } from '@makeswift/controls'
 import { z } from 'zod'
 import { ControlDataTypeKey, Options, Types } from '../prop-controllers'
-import { match } from 'ts-pattern'
+import { P, match } from 'ts-pattern'
 
 const textAreaPropControllerDataV0Schema = z.string()
 
@@ -20,9 +21,15 @@ export type TextAreaPropControllerDataV1 = z.infer<
   typeof textAreaPropControllerDataV1Schema
 >
 
+const textAreaInteropDataSchema = z.object({
+  [ControlDataTypeKey]: z.enum(AcceptedTextDataTypes),
+  value: z.string(),
+})
+
 export const textAreaPropControllerDataSchema = z.union([
   textAreaPropControllerDataV0Schema,
   textAreaPropControllerDataV1Schema,
+  textAreaInteropDataSchema,
 ])
 
 export type TextAreaPropControllerData = z.infer<
@@ -69,8 +76,8 @@ export function getTextAreaPropControllerDataString(
 ): string | undefined {
   return match(data)
     .with(
-      { [ControlDataTypeKey]: TextAreaPropControllerDataV1Type },
-      (v1) => v1.value,
+      { [ControlDataTypeKey]: P.union(...AcceptedTextDataTypes) },
+      (versioned) => versioned.value,
     )
     .otherwise((v0) => v0)
 }
@@ -86,7 +93,7 @@ export function createTextAreaPropControllerDataFromString(
         ({
           [ControlDataTypeKey]: TextAreaPropControllerDataV1Type,
           value,
-        } as const),
+        }) as const,
     )
     .otherwise(() => value)
 }

--- a/packages/prop-controllers/src/text-input/text-input.ts
+++ b/packages/prop-controllers/src/text-input/text-input.ts
@@ -1,6 +1,7 @@
+import { AcceptedTextDataTypes } from '@makeswift/controls'
 import { z } from 'zod'
 import { ControlDataTypeKey, Options, Types } from '../prop-controllers'
-import { match } from 'ts-pattern'
+import { P, match } from 'ts-pattern'
 
 const textInputPropControllerDataV0Schema = z.string()
 
@@ -20,9 +21,15 @@ export type TextInputPropControllerDataV1 = z.infer<
   typeof textInputPropControllerDataV1Schema
 >
 
+const textInputInteropDataSchema = z.object({
+  [ControlDataTypeKey]: z.enum(AcceptedTextDataTypes),
+  value: z.string(),
+})
+
 export const textInputPropControllerDataSchema = z.union([
   textInputPropControllerDataV0Schema,
   textInputPropControllerDataV1Schema,
+  textInputInteropDataSchema,
 ])
 
 export type TextInputPropControllerData = z.infer<
@@ -71,8 +78,8 @@ export function getTextInputPropControllerDataString(
 ): string | undefined {
   return match(data)
     .with(
-      { [ControlDataTypeKey]: TextInputPropControllerDataV1Type },
-      (v1) => v1.value,
+      { [ControlDataTypeKey]: P.union(...AcceptedTextDataTypes) },
+      (versioned) => versioned.value,
     )
     .otherwise((v0) => v0)
 }
@@ -88,7 +95,7 @@ export function createTextInputPropControllerDataFromString(
         ({
           [ControlDataTypeKey]: TextInputPropControllerDataV1Type,
           value,
-        } as const),
+        }) as const,
     )
     .otherwise(() => value)
 }

--- a/packages/runtime/src/next/components/tests/controls/__snapshots__/code-control.test.tsx.snap
+++ b/packages/runtime/src/next/components/tests/controls/__snapshots__/code-control.test.tsx.snap
@@ -202,7 +202,7 @@ exports[`Page Code control data v1 when value is <div>hi</div>: snapshot 1`] = `
               "key": "11111111-1111-1111-1111-111111111111",
               "props": {
                 "propKey": {
-                  "@@makeswift/type": "code::v1",
+                  "@@makeswift/type": "text",
                   "value": "<div>hi</div>",
                 },
               },
@@ -262,7 +262,7 @@ exports[`Page Code control data v1 when value is console.log("hello"): snapshot 
               "key": "11111111-1111-1111-1111-111111111111",
               "props": {
                 "propKey": {
-                  "@@makeswift/type": "code::v1",
+                  "@@makeswift/type": "text",
                   "value": "console.log("hello")",
                 },
               },

--- a/packages/runtime/src/next/components/tests/controls/__snapshots__/number-control.test.tsx.snap
+++ b/packages/runtime/src/next/components/tests/controls/__snapshots__/number-control.test.tsx.snap
@@ -137,7 +137,7 @@ exports[`Page Number control data v1 when value is 42: snapshot 1`] = `
               "key": "11111111-1111-1111-1111-111111111111",
               "props": {
                 "propKey": {
-                  "@@makeswift/type": "number::v1",
+                  "@@makeswift/type": "number",
                   "value": 42,
                 },
               },

--- a/packages/runtime/src/next/components/tests/controls/__snapshots__/text-area-control.test.tsx.snap
+++ b/packages/runtime/src/next/components/tests/controls/__snapshots__/text-area-control.test.tsx.snap
@@ -137,7 +137,7 @@ exports[`Page TextArea control data v1 when value is The Prizoner of Azkaban: sn
               "key": "11111111-1111-1111-1111-111111111111",
               "props": {
                 "propKey": {
-                  "@@makeswift/type": "text-area::v1",
+                  "@@makeswift/type": "text",
                   "value": "The Prizoner of Azkaban",
                 },
               },

--- a/packages/runtime/src/next/components/tests/controls/__snapshots__/text-input-control.test.tsx.snap
+++ b/packages/runtime/src/next/components/tests/controls/__snapshots__/text-input-control.test.tsx.snap
@@ -137,7 +137,7 @@ exports[`Page TextInput control data v1 when value is The Blueprint: snapshot 1`
               "key": "11111111-1111-1111-1111-111111111111",
               "props": {
                 "propKey": {
-                  "@@makeswift/type": "text-input::v1",
+                  "@@makeswift/type": "text",
                   "value": "The Blueprint",
                 },
               },


### PR DESCRIPTION
## Summary

Swapping one primitive-typed control for another (e.g. `TextInput` → `TextArea`, `Number` → `Slider (wip)`) no longer drops the saved value.

Each primitive group now shares a `[@@makeswift/type]` marker — `'text'` for `TextInput`/`TextArea`/`Code`, `'number'` for `Number` — and every control accepts the full set of legacy markers (`text-input::v1`, `text-area::v1`, `code::v1`, `number::v1`) on read. Rewrite to the shared marker is lazy on next edit; no DB migration.

## Test

https://github.com/user-attachments/assets/d85a76b2-f901-4aa1-9935-98f12f8bade3


https://github.com/user-attachments/assets/3b94503e-2f1c-4186-b886-224b35fa5863


https://github.com/user-attachments/assets/4a108aca-eea9-4eca-817a-eac23b0ff413


- [x] `pnpm --filter @makeswift/controls test` — 871 tests pass (incl. 65 new interop assertions)
- [x] `pnpm --filter @makeswift/runtime test` — 788 tests pass
- [x] In cosmos: swap a `TextInput` prop to `TextArea` (and `Code`); value persists. Repeat `Number` ↔ `Slider`.
- [x] Open a page saved before this PR; legacy marker still parses, no warning.
- [x] Negative: swap `TextInput` → `Number` falls back to `defaultValue`.