### PR TITLE
chore: stop exposing internal actions/state/reducer to the builder

### DIFF
--- a/.changeset/grumpy-poets-compare.md
+++ b/.changeset/grumpy-poets-compare.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+chore: stop exposing internal actions/state/reducer to the builder

--- a/packages/runtime/src/builder/breakpoints/index.ts
+++ b/packages/runtime/src/builder/breakpoints/index.ts
@@ -1,8 +1,6 @@
 export {
-  reducer,
   DefaultBreakpointID,
   DEFAULT_BREAKPOINTS,
-  type State,
   type BreakpointId,
   type Breakpoint,
   type Breakpoints,

--- a/packages/runtime/src/builder/host-api.ts
+++ b/packages/runtime/src/builder/host-api.ts
@@ -1,11 +1,4 @@
-export {
-  type SetBreakpointsAction,
-  makeswiftConnectionInit,
-  registerDocument,
-  unregisterDocument,
-  setBreakpoints,
-  setLocale,
-} from '../state/shared-api'
+export { makeswiftConnectionInit, registerDocument, unregisterDocument } from '../state/shared-api'
 
 export {
   changeDocument,

--- a/packages/runtime/src/next/hooks/use-router-locale-sync.ts
+++ b/packages/runtime/src/next/hooks/use-router-locale-sync.ts
@@ -2,7 +2,7 @@ import { useRouter as usePagesRouter } from 'next/router'
 import { P, match } from 'ts-pattern'
 import { useEffect } from 'react'
 
-import { setLocale } from '../../state/shared-api'
+import { setLocale } from '../../state/builder-api/actions'
 import { useDispatch } from '../../runtimes/react/hooks/use-dispatch'
 
 function useRouter() {

--- a/packages/runtime/src/state/actions/internal/read-only-actions.ts
+++ b/packages/runtime/src/state/actions/internal/read-only-actions.ts
@@ -7,11 +7,13 @@ import { ElementImperativeHandle } from '../../../runtimes/react/element-imperat
 import { type APIResource, APIResourceType, APIResourceLocale } from '../../../api/types'
 import { type Descriptor as PropControllerDescriptor } from '../../../prop-controllers/descriptors'
 
+import { type Breakpoints } from '../../modules/breakpoints'
 import { type ComponentMeta } from '../../modules/components-meta'
 import { type PropControllersHandle } from '../../modules/prop-controller-handles'
 import { type ComponentType } from '../../modules/react-components'
 import { type DescriptorsByComponentType } from '../../modules/prop-controllers'
 
+import { type LocaleString, localeStringSchema } from '../../../locale'
 import { type DocumentPayload } from '../../shared-api'
 
 export const ReadOnlyActionTypes = {
@@ -35,7 +37,10 @@ export const ReadOnlyActionTypes = {
   REGISTER_REACT_COMPONENT: 'REGISTER_REACT_COMPONENT',
   UNREGISTER_REACT_COMPONENT: 'UNREGISTER_REACT_COMPONENT',
 
+  SET_BREAKPOINTS: 'SET_BREAKPOINTS',
   UPDATE_CLIENT_BREAKPOINT: 'UPDATE_CLIENT_BREAKPOINT',
+
+  SET_LOCALE: 'SET_LOCALE',
 
   SET_IS_IN_BUILDER: 'SET_IS_IN_BUILDER',
   SET_IS_READ_ONLY: 'SET_IS_READ_ONLY',
@@ -119,8 +124,18 @@ type UnregisterReactComponentAction = {
   payload: { type: string }
 }
 
+export type SetBreakpointsAction = {
+  type: typeof ReadOnlyActionTypes.SET_BREAKPOINTS
+  payload: { breakpoints: Breakpoints }
+}
+
 type UpdateClientBreakpointAction = {
   type: typeof ReadOnlyActionTypes.UPDATE_CLIENT_BREAKPOINT
+}
+
+export type SetLocaleAction = {
+  type: typeof ReadOnlyActionTypes.SET_LOCALE
+  payload: { locale: LocaleString; pathname?: string }
 }
 
 type SetIsInBuilderAction = {
@@ -147,7 +162,9 @@ export type ReadOnlyAction =
   | UnregisterPropControllersAction
   | RegisterReactComponentAction
   | UnregisterReactComponentAction
+  | SetBreakpointsAction
   | UpdateClientBreakpointAction
+  | SetLocaleAction
   | SetIsInBuilderAction
   | SetIsReadOnlyAction
 
@@ -308,8 +325,19 @@ export function registerReactComponentEffect(
   }
 }
 
+export function setBreakpoints(breakpoints: Breakpoints): SetBreakpointsAction {
+  return { type: ReadOnlyActionTypes.SET_BREAKPOINTS, payload: { breakpoints } }
+}
+
 export function updateClientBreakpoint(): UpdateClientBreakpointAction {
   return { type: ReadOnlyActionTypes.UPDATE_CLIENT_BREAKPOINT }
+}
+
+export function setLocale(locale: Intl.Locale, pathname?: string): SetLocaleAction {
+  return {
+    type: ReadOnlyActionTypes.SET_LOCALE,
+    payload: { locale: localeStringSchema.parse(locale.toString()), pathname },
+  }
 }
 
 export function setIsInBuilder(isInBuilder: boolean): SetIsInBuilderAction {

--- a/packages/runtime/src/state/builder-api/actions.ts
+++ b/packages/runtime/src/state/builder-api/actions.ts
@@ -11,15 +11,24 @@ import { type ElementSize } from '../middleware/read-write/builder-api/element-s
 import { type DocumentPayload, type SharedAction, SharedActionTypes } from '../shared-api'
 
 import { type HostNavigationEvent } from './api'
+import {
+  type SetBreakpointsAction,
+  type SetLocaleAction,
+  ReadOnlyActionTypes,
+} from '../actions/internal/read-only-actions'
 
 export * from '../shared-api'
+export { setBreakpoints } from '../actions/internal/read-only-actions'
+export { setLocale } from '../actions/internal/read-only-actions'
 
 // actions dispatched by the host to the builder ("Builder API")
-// note that some of these actions, in addition to being dispatched to the builder,
-// might also be internally intercepted by the host as a part of maintaining the
-// runtime's "read-write" state
+// note that some of these actions (SET_BREAKPOINTS, SET_LOCALE), in addition to
+// being dispatched to the builder, are also internally intercepted by the host
+// as a part of maintaining the runtime's own state
 export const BuilderActionTypes = {
   ...SharedActionTypes,
+  SET_BREAKPOINTS: ReadOnlyActionTypes.SET_BREAKPOINTS,
+  SET_LOCALE: ReadOnlyActionTypes.SET_LOCALE,
 
   MAKESWIFT_CONNECTION_CHECK: 'MAKESWIFT_CONNECTION_CHECK',
 
@@ -124,6 +133,8 @@ type HandleHostNavigateAction = {
 
 export type BuilderAction =
   | SharedAction
+  | SetBreakpointsAction
+  | SetLocaleAction
   | MakeswiftConnectionCheckAction
   | MountComponentAction
   | UnmountComponentAction

--- a/packages/runtime/src/state/modules/locale.ts
+++ b/packages/runtime/src/state/modules/locale.ts
@@ -1,5 +1,5 @@
 import { type Action, type UnknownAction, isKnownAction } from '../actions'
-import { SharedActionTypes } from '../shared-api'
+import { ReadOnlyActionTypes } from '../actions/internal/read-only-actions'
 
 export type State = string | null
 
@@ -15,7 +15,7 @@ export function reducer(state = getInitialState(), action: Action | UnknownActio
   if (!isKnownAction(action)) return state
 
   switch (action.type) {
-    case SharedActionTypes.SET_LOCALE:
+    case ReadOnlyActionTypes.SET_LOCALE:
       return action.payload.locale
 
     default:

--- a/packages/runtime/src/state/shared-api.ts
+++ b/packages/runtime/src/state/shared-api.ts
@@ -1,8 +1,5 @@
 import { type ThunkAction } from '@reduxjs/toolkit'
 
-import { type LocaleString, localeStringSchema } from '../locale'
-
-import { type Breakpoints } from './modules/breakpoints'
 import { type Element, type Document, EMBEDDED_DOCUMENT_TYPE } from './modules/read-only-documents'
 
 type DocumentPayloadBaseDocument = {
@@ -30,9 +27,6 @@ export const SharedActionTypes = {
 
   REGISTER_DOCUMENT: 'REGISTER_DOCUMENT',
   UNREGISTER_DOCUMENT: 'UNREGISTER_DOCUMENT',
-
-  SET_BREAKPOINTS: 'SET_BREAKPOINTS',
-  SET_LOCALE: 'SET_LOCALE',
 } as const
 
 type MakeswiftConnectionInitAction = { type: typeof SharedActionTypes.MAKESWIFT_CONNECTION_INIT }
@@ -47,22 +41,10 @@ type UnregisterDocumentAction = {
   payload: { documentKey: string }
 }
 
-export type SetBreakpointsAction = {
-  type: typeof SharedActionTypes.SET_BREAKPOINTS
-  payload: { breakpoints: Breakpoints }
-}
-
-type SetLocaleAction = {
-  type: typeof SharedActionTypes.SET_LOCALE
-  payload: { locale: LocaleString; pathname?: string }
-}
-
 export type SharedAction =
   | MakeswiftConnectionInitAction
   | RegisterDocumentAction
   | UnregisterDocumentAction
-  | SetBreakpointsAction
-  | SetLocaleAction
 
 export function makeswiftConnectionInit(): MakeswiftConnectionInitAction {
   return {
@@ -90,16 +72,5 @@ export function registerDocumentsEffect(
     return () => {
       documents.forEach(document => dispatch(unregisterDocument(document.key)))
     }
-  }
-}
-
-export function setBreakpoints(breakpoints: Breakpoints): SetBreakpointsAction {
-  return { type: SharedActionTypes.SET_BREAKPOINTS, payload: { breakpoints } }
-}
-
-export function setLocale(locale: Intl.Locale, pathname?: string): SetLocaleAction {
-  return {
-    type: SharedActionTypes.SET_LOCALE,
-    payload: { locale: localeStringSchema.parse(locale.toString()), pathname },
   }
 }


### PR DESCRIPTION
See inline comments.