### PR TITLE
fix: force cache all client fetches on live requests

### DIFF
--- a/.changeset/rotten-dolls-tie.md
+++ b/.changeset/rotten-dolls-tie.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+Force cache Makeswift client requests on live page visits

--- a/packages/runtime/src/client/index.ts
+++ b/packages/runtime/src/client/index.ts
@@ -401,7 +401,7 @@ export class MakeswiftClient {
     const response = await fetch(requestUrl.toString(), {
       ...init,
       headers: requestHeaders,
-      ...(siteVersion != null ? { cache: 'no-store' } : {}),
+      cache: siteVersion != null ? 'no-cache' : 'force-cache',
       ...this.fetchOptions(siteVersion),
     })
 


### PR DESCRIPTION
Note: this does not cache unsuccessful responses from the API (4XXs, 5XXs)