### PR TITLE
fix(hono-react): remove `MAKESWIFT_SITE_API_KEY` binding from hono env

### DIFF
--- a/.changeset/metal-cups-crash.md
+++ b/.changeset/metal-cups-crash.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/hono-react": patch
+---
+
+fix: remove `MAKESWIFT_SITE_API_KEY` binding requirement from Hono env

--- a/packages/hono-react/src/server/env.ts
+++ b/packages/hono-react/src/server/env.ts
@@ -1,6 +1,1 @@
-export type Env = {
-  Bindings: {
-    MAKESWIFT_SITE_API_KEY: string
-  }
-  Variables: {}
-}
+export { type Env } from 'hono'


### PR DESCRIPTION
Catching up with our evolved approach of making it the user's responsibility to derive the key from the execution environment. This removes the need for TypeScript error suppression [here](https://github.com/bigcommerce/makeswift-stencil-worker/blob/73b24dcc1cd9f617023f1cc98c178f12f3269edf/src/app.ts#L33) and [here](https://github.com/bigcommerce/makeswift-stencil-worker/blob/73b24dcc1cd9f617023f1cc98c178f12f3269edf/src/app.ts#L40).