### PR TITLE
refactor: switch `MakeswiftClient` to using `runtime.fetch`

### DIFF
--- a/packages/runtime/src/client/index.ts
+++ b/packages/runtime/src/client/index.ts
@@ -398,7 +398,7 @@ export class MakeswiftClient {
       })
     }
 
-    const response = await fetch(requestUrl.toString(), {
+    const response = await this.runtime.fetch(requestUrl.toString(), {
       ...init,
       headers: requestHeaders,
       ...(siteVersion != null ? { cache: 'no-store' } : {}),

--- a/packages/runtime/src/next/client.ts
+++ b/packages/runtime/src/next/client.ts
@@ -4,7 +4,6 @@ import { z } from 'zod'
 import { deserializeSiteVersion, type SiteVersion } from '../api/site-version'
 
 import { MakeswiftClient } from '../client'
-import { MAKESWIFT_CACHE_TAG } from './cache'
 
 const previewDataSchema = z.object({
   siteVersion: z.string(),
@@ -23,10 +22,6 @@ export class Makeswift extends MakeswiftClient {
   }
 
   fetchOptions(_siteVersion: SiteVersion): Record<string, unknown> {
-    return {
-      next: {
-        tags: [MAKESWIFT_CACHE_TAG],
-      },
-    }
+    return {}
   }
 }


### PR DESCRIPTION
Following up on https://github.com/makeswift/makeswift/pull/1219, where we moved `fetch` parameterization from the framework context to the runtime instance, but didn't unify it with `MakeswiftClient`'s usage.