### PR TITLE
feat: support default opacity value in Color control

### DIFF
--- a/.changeset/color-default-opacity.md
+++ b/.changeset/color-default-opacity.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/controls": minor
+---
+
+Support object form `{ color, opacity }` for Color control defaultValue

--- a/apps/nextjs-app-router/src/components/code-demo/code-demo.makeswift.ts
+++ b/apps/nextjs-app-router/src/components/code-demo/code-demo.makeswift.ts
@@ -1,7 +1,7 @@
 import { runtime } from '@/makeswift/runtime'
 import { lazy } from 'react'
 
-import { Style, Code } from '@makeswift/runtime/controls'
+import { Style, Code, Color } from '@makeswift/runtime/controls'
 
 runtime.registerComponent(
   lazy(() => import('./code-demo')),
@@ -10,6 +10,7 @@ runtime.registerComponent(
     label: 'Custom / Code Control Demo',
     props: {
       className: Style(),
+      color: Color({ label: 'Color', defaultValue: '#4f46e5' }),
       htmlCode: Code({
         label: 'HTML',
         defaultValue: `<article class="card">

--- a/apps/nextjs-app-router/src/components/code-demo/code-demo.tsx
+++ b/apps/nextjs-app-router/src/components/code-demo/code-demo.tsx
@@ -8,6 +8,7 @@ type Props = {
   cssCode?: CodeProp
   tsCode?: CodeProp
   bashCode?: CodeProp
+  color?: string
 }
 
 function Section({ title, code }: { title: string; code: CodeProp }) {
@@ -22,13 +23,14 @@ function Section({ title, code }: { title: string; code: CodeProp }) {
 }
 
 export const CodeDemo = forwardRef(function CodeDemo(
-  { className, htmlCode, cssCode, tsCode, bashCode }: Props,
+  { className, htmlCode, cssCode, tsCode, bashCode, color }: Props,
   ref: Ref<HTMLDivElement>,
 ) {
   return (
     <div
       className={`flex flex-col gap-4 p-4 w-full ${className ?? ''}`}
       ref={ref}
+       style={{ backgroundColor: color }}
     >
       <Section title="HTML" code={htmlCode} />
       <Section title="CSS" code={cssCode} />

--- a/packages/controls/src/controls/color/__snapshots__/color.test.ts.snap
+++ b/packages/controls/src/controls/color/__snapshots__/color.test.ts.snap
@@ -13,6 +13,7 @@ ColorDefinition {
 exports[`Color constructor call with default value \`undefined\` returns versioned definition 1`] = `
 ColorDefinition {
   "config": {
+    "defaultValue": undefined,
     "label": "color",
   },
   "version": 1,

--- a/packages/controls/src/controls/color/__snapshots__/color.test.ts.snap
+++ b/packages/controls/src/controls/color/__snapshots__/color.test.ts.snap
@@ -13,14 +13,13 @@ ColorDefinition {
 exports[`Color constructor call with default value \`undefined\` returns versioned definition 1`] = `
 ColorDefinition {
   "config": {
-    "defaultValue": undefined,
     "label": "color",
   },
   "version": 1,
 }
 `;
 
-exports[`Color definition w/ config {"defaultValue":"red","label":"visible"} toData returns v1 data for \`{ swatchId: '[swatch-id-1]', alpha: 1 }\` when definition version is 1 1`] = `
+exports[`Color definition w/ config {"label":"visible","defaultValue":"red"} toData returns v1 data for \`{ swatchId: '[swatch-id-1]', alpha: 1 }\` when definition version is 1 1`] = `
 {
   "@@makeswift/type": "color::v1",
   "alpha": 1,
@@ -28,7 +27,7 @@ exports[`Color definition w/ config {"defaultValue":"red","label":"visible"} toD
 }
 `;
 
-exports[`Color definition w/ config {"defaultValue":"red","label":"visible"} toData returns v1 data for \`{ swatchId: '[swatch-id-2]', alpha: 0.5 }\` when definition version is 1 1`] = `
+exports[`Color definition w/ config {"label":"visible","defaultValue":"red"} toData returns v1 data for \`{ swatchId: '[swatch-id-2]', alpha: 0.5 }\` when definition version is 1 1`] = `
 {
   "@@makeswift/type": "color::v1",
   "alpha": 0.5,

--- a/packages/controls/src/controls/color/color.test.ts
+++ b/packages/controls/src/controls/color/color.test.ts
@@ -132,6 +132,7 @@ describe('Color', () => {
     function assignTest(_def: ColorDefinition) {}
     assignTest(Color({ label: 'background' }))
     assignTest(Color({ defaultValue: 'red' }))
+    assignTest(Color({ defaultValue: { color: '#4f46e5', opacity: 0.25 } }))
     assignTest(Color({ label: 'background', labelOrientation: 'horizontal' }))
     assignTest(
       Color({
@@ -176,6 +177,25 @@ describe('Color', () => {
           .resolveValue(data, colorResolver)
           .readStable(),
       ).toBe('rgba(0, 0, 0, 0.5)')
+    })
+
+    test('resolves object defaultValue with opacity when no data', () => {
+      expect(
+        Color({
+          label: 'Color',
+          defaultValue: { color: '#4f46e5', opacity: 0.25 },
+        })
+          .resolveValue(undefined, noOpResourceResolver)
+          .readStable(),
+      ).toBe('rgba(79, 70, 229, 0.25)')
+    })
+
+    test('resolves string defaultValue when no data', () => {
+      expect(
+        Color({ label: 'Color', defaultValue: '#4f46e5' })
+          .resolveValue(undefined, noOpResourceResolver)
+          .readStable(),
+      ).toBe('rgb(79, 70, 229)')
     })
   })
 

--- a/packages/controls/src/controls/color/color.test.types.ts
+++ b/packages/controls/src/controls/color/color.test.types.ts
@@ -63,5 +63,34 @@ describe('Color Types', () => {
       type Resolved = ResolvedValueType<typeof def>
       expectTypeOf<Resolved>().toEqualTypeOf<string>()
     })
+
+    test('with default opacity', () => {
+      const def = Color({
+        defaultValue: { color: 'red', opacity: 0.25 },
+        label: 'color',
+      })
+
+      type ConfigType = typeof def.config
+      expectTypeOf<ConfigType>().toEqualTypeOf<{
+        defaultValue: string
+        description?: string
+        label?: string
+        labelOrientation?: 'vertical' | 'horizontal'
+        hideAlpha?: boolean
+      }>()
+
+      type Data = DataType<typeof def>
+      expectTypeOf<Data>().toEqualTypeOf<{
+        swatchId: string
+        alpha: number
+        [ControlDataTypeKey]?: 'color::v1' | undefined
+      }>()
+
+      type Value = ValueType<typeof def>
+      expectTypeOf<Value>().toEqualTypeOf<{ swatchId: string; alpha: number }>()
+
+      type Resolved = ResolvedValueType<typeof def>
+      expectTypeOf<Resolved>().toEqualTypeOf<string>()
+    })
   })
 })

--- a/packages/controls/src/controls/color/color.ts
+++ b/packages/controls/src/controls/color/color.ts
@@ -269,38 +269,48 @@ class Definition<C extends Config> extends ControlDefinition<
 
 export class ColorDefinition<C extends Config = Config> extends Definition<C> {}
 
-type ColorDefaultValueInput = string | { color: string; opacity: number }
+type ColorDefaultValueInput =
+  | string
+  | { color: string; opacity: number }
+  | undefined
 
-type NormalizedDefaultValue<D extends ColorDefaultValueInput | undefined> =
-  D extends undefined ? undefined : string
-
-type UserConfig = Omit<Config, 'defaultValue'> & {
-  defaultValue?: ColorDefaultValueInput
+type UserConfig<D extends ColorDefaultValueInput = undefined> = Omit<
+  Config,
+  'defaultValue'
+> & {
+  defaultValue?: D
 }
 
-type NormedConfig<D extends ColorDefaultValueInput | undefined> = z.infer<
+type NormalizedDefaultValue<D extends ColorDefaultValueInput> =
+  D extends undefined ? undefined : string
+
+type NormedConfig<D extends ColorDefaultValueInput> = z.infer<
   SchemaByDefaultValue<NormalizedDefaultValue<D>>['config']
 >
 
 function normalizeDefaultValue(
-  defaultValue: ColorDefaultValueInput | undefined,
-): string | undefined {
-  if (defaultValue == null) return undefined
-  if (typeof defaultValue === 'string') return defaultValue
+  defaultValue: ColorDefaultValueInput,
+): Config['defaultValue'] {
+  if (defaultValue == null || typeof defaultValue === 'string')
+    return defaultValue
+
   return safeColorString(defaultValue.color, defaultValue.opacity)
 }
 
-export function Color<D extends ColorDefaultValueInput | undefined = undefined>(
-  config?: UserConfig & { defaultValue?: D },
-): ColorDefinition<NormedConfig<D>> {
-  if (!config) {
-    return new ColorDefinition<NormedConfig<D>>({} as any, 1)
-  }
-
+function normalizeConfig<D extends ColorDefaultValueInput>(
+  config: UserConfig<D>,
+) {
   const { defaultValue, ...rest } = config
-  const normalized = normalizeDefaultValue(defaultValue)
-  const normalizedConfig =
-    normalized !== undefined ? { ...rest, defaultValue: normalized } : rest
+  return defaultValue == null
+    ? config
+    : { ...rest, defaultValue: normalizeDefaultValue(defaultValue) }
+}
 
-  return new ColorDefinition<NormedConfig<D>>(normalizedConfig as any, 1)
+export function Color<D extends ColorDefaultValueInput = undefined>(
+  config?: UserConfig<D>,
+): ColorDefinition<NormedConfig<D>> {
+  return new ColorDefinition<NormedConfig<D>>(
+    config ? normalizeConfig(config) : {},
+    1,
+  )
 }

--- a/packages/controls/src/controls/color/color.ts
+++ b/packages/controls/src/controls/color/color.ts
@@ -23,7 +23,7 @@ import {
 import { DefaultControlInstance, type SendMessage } from '../instance'
 import { ControlDefinitionVisitor } from '../visitor'
 
-import { swatchToColorString } from './conversion'
+import { safeColorString, swatchToColorString } from './conversion'
 
 type Config = z.infer<typeof Definition.schema.relaxed.config>
 
@@ -269,16 +269,38 @@ class Definition<C extends Config> extends ControlDefinition<
 
 export class ColorDefinition<C extends Config = Config> extends Definition<C> {}
 
-type UserConfig<D extends Config['defaultValue']> = Config & {
-  defaultValue?: D
+type ColorDefaultValueInput = string | { color: string; opacity: number }
+
+type NormalizedDefaultValue<D extends ColorDefaultValueInput | undefined> =
+  D extends undefined ? undefined : string
+
+type UserConfig = Omit<Config, 'defaultValue'> & {
+  defaultValue?: ColorDefaultValueInput
 }
 
-type NormedConfig<D extends Config['defaultValue']> = z.infer<
-  SchemaByDefaultValue<D>['config']
+type NormedConfig<D extends ColorDefaultValueInput | undefined> = z.infer<
+  SchemaByDefaultValue<NormalizedDefaultValue<D>>['config']
 >
 
-export function Color<D extends Config['defaultValue']>(
-  config?: UserConfig<D>,
+function normalizeDefaultValue(
+  defaultValue: ColorDefaultValueInput | undefined,
+): string | undefined {
+  if (defaultValue == null) return undefined
+  if (typeof defaultValue === 'string') return defaultValue
+  return safeColorString(defaultValue.color, defaultValue.opacity)
+}
+
+export function Color<D extends ColorDefaultValueInput | undefined = undefined>(
+  config?: UserConfig & { defaultValue?: D },
 ): ColorDefinition<NormedConfig<D>> {
-  return new ColorDefinition<NormedConfig<D>>(config ?? {}, 1)
+  if (!config) {
+    return new ColorDefinition<NormedConfig<D>>({} as any, 1)
+  }
+
+  const { defaultValue, ...rest } = config
+  const normalized = normalizeDefaultValue(defaultValue)
+  const normalizedConfig =
+    normalized !== undefined ? { ...rest, defaultValue: normalized } : rest
+
+  return new ColorDefinition<NormedConfig<D>>(normalizedConfig as any, 1)
 }

--- a/packages/controls/src/controls/color/conversion.ts
+++ b/packages/controls/src/controls/color/conversion.ts
@@ -23,6 +23,10 @@ export function swatchToColorString(
     .string()
 }
 
+export function safeColorString(color: string, opacity: number): string {
+  return safeParseColor(color).alpha(opacity).rgb().string()
+}
+
 function safeParseColor(value: string) {
   try {
     return parseColor(value)


### PR DESCRIPTION
This update allows users to set a default color opacity value along with the default color value. With changes included in `cosmos`, this default opacity value will also be displayed in the Color control.

https://github.com/user-attachments/assets/caa3daef-5c00-4e7e-a106-11309192755d

