### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# Agents
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+This is the **Makeswift** monorepo — an open-source visual page builder SDK for React/Next.js. It is a pure frontend/SDK project (no Docker, databases, or backend services). The product consists of npm packages that integrate with the hosted Makeswift builder at `app.makeswift.com`.
+
+### Monorepo structure
+
+- **Package manager:** pnpm 9.15.4 with workspaces (see `pnpm-workspace.yaml`)
+- **Build orchestration:** Turborepo (`turbo.json`)
+- **Workspace packages:** `packages/*` (runtime, controls, prop-controllers, makeswift CLI, next-plugin, express-react, hono-react, react-router)
+- **Test apps:** `apps/nextjs-app-router`, `apps/nextjs-pages-router`
+- **Examples:** `examples/*` (not part of the pnpm workspace — have their own `package.json` and separate dependency trees)
+
+### Key commands
+
+| Task | Command | Notes |
+|------|---------|-------|
+| Install deps | `pnpm install` | Run from workspace root |
+| Build all packages | `pnpm run build` | Turborepo handles dependency ordering |
+| Run all tests | `pnpm run test` | Jest tests across packages |
+| Format check | `npx prettier --check "packages/**" "apps/**"` | Root `pnpm format` uses `--write` |
+| Lint (app-router) | `pnpm --filter nextjs-app-router lint` | ESLint via Next.js |
+| Dev watch (runtime) | `pnpm --filter @makeswift/runtime dev` | Concurrent tsc + tsup watch |
+| Dev server (app-router) | `pnpm --filter nextjs-app-router dev` | Next.js on port 3000 |
+| Dev server (pages-router) | `pnpm --filter nextjs-pages-router dev` | Next.js on different port |
+
+### Important caveats
+
+- The test apps (`apps/*`) require a `MAKESWIFT_SITE_API_KEY` environment variable to render pages. Without it, pages return HTTP 500 but the dev server still compiles and serves static assets correctly. Unit tests run without any API key.
+- The root `prettier --check .` will fail with a missing `@trivago/prettier-plugin-sort-imports` error because `examples/` directories reference that plugin but aren't part of the workspace. Run prettier against `packages/` and `apps/` only.
+- Build order matters: packages depend on each other via `workspace:*`. Always use `pnpm run build` (turborepo) rather than building individual packages unless you know the dependency graph.
+- The `@makeswift/runtime` package is the core library; most tests live there (133 test suites).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents working on this repository.

### What's included

- Monorepo structure overview (packages, apps, examples)
- Key commands table (install, build, test, lint, dev servers)
- Important caveats about `MAKESWIFT_SITE_API_KEY` requirement, prettier plugin issue with examples, and build ordering

### Verified

- `pnpm install` - all 1727 packages installed
- `pnpm run build` - all 7 workspace packages built successfully  
- `pnpm run test` - 133 test suites, 800 tests passed
- `prettier --check` and ESLint - working correctly
- Next.js dev servers start, compile, and render pages with `MAKESWIFT_SITE_API_KEY`
- Full end-to-end navigation through the app (hardcoded page, main page, features page)

### Demo

[makeswift_app_demo.mp4](https://cursor.com/agents/bc-807bf5c9-fa05-4775-a67b-c022ba5eb639/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmakeswift_app_demo.mp4)

[Makeswift main page rendering](https://cursor.com/agents/bc-807bf5c9-fa05-4775-a67b-c022ba5eb639/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmakeswift_main_page.webp)
[Features page after navigation](https://cursor.com/agents/bc-807bf5c9-fa05-4775-a67b-c022ba5eb639/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffeatures_page.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-807bf5c9-fa05-4775-a67b-c022ba5eb639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-807bf5c9-fa05-4775-a67b-c022ba5eb639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

