### PR TITLE
feat(runtime): allow configuring the default breakpoint viewport and label

### DIFF
--- a/.changeset/default-breakpoint-config.md
+++ b/.changeset/default-breakpoint-config.md
@@ -1,0 +1,22 @@
+---
+"@makeswift/runtime": minor
+---
+
+Add support for configuring the default breakpoint's viewport and label
+
+The `breakpoints` configuration now accepts a `default` key that allows customizing the base breakpoint:
+
+```ts
+export const runtime = new ReactRuntime({
+  breakpoints: {
+    default: { viewport: 780, label: 'Tablet' },
+  },
+})
+```
+
+This is useful for tablet-focused or single-device experiences where the builder should open at a specific preview width and display a custom label instead of "Desktop".
+
+- `viewport`: Sets the preview width for the default breakpoint in the builder
+- `label`: Customizes the display name of the default breakpoint (e.g., "Tablet" instead of "Desktop")
+
+When only `default` is specified with no other breakpoints, the runtime uses just the single base breakpoint. When combined with other breakpoints, the default's viewport and label are applied to the base breakpoint while other breakpoints function as before.

--- a/packages/runtime/src/state/modules/breakpoints.test.ts
+++ b/packages/runtime/src/state/modules/breakpoints.test.ts
@@ -1,6 +1,100 @@
 import { parseBreakpointsInput } from './breakpoints'
 
 describe('parseBreakpointsInput', () => {
+  describe('default breakpoint configuration', () => {
+    test('accepts only a default breakpoint with viewport and label', async () => {
+      // Arrange
+      const input = {
+        default: { viewport: 780, label: 'Tablet' },
+      }
+
+      // Act
+      const result = parseBreakpointsInput(input)
+
+      // Assert
+      expect(result).toEqual([{ id: 'desktop', label: 'Tablet', viewportWidth: 780 }])
+    })
+
+    test('accepts only a default breakpoint with just viewport', async () => {
+      // Arrange
+      const input = {
+        default: { viewport: 780 },
+      }
+
+      // Act
+      const result = parseBreakpointsInput(input)
+
+      // Assert
+      expect(result).toEqual([{ id: 'desktop', label: 'Desktop', viewportWidth: 780 }])
+    })
+
+    test('accepts only a default breakpoint with just label', async () => {
+      // Arrange
+      const input = {
+        default: { label: 'Tablet' },
+      }
+
+      // Act
+      const result = parseBreakpointsInput(input)
+
+      // Assert
+      expect(result).toEqual([{ id: 'desktop', label: 'Tablet' }])
+    })
+
+    test('accepts default with other breakpoints', async () => {
+      // Arrange
+      const input = {
+        default: { viewport: 1200, label: 'Large' },
+        tablet: { width: 768 },
+        mobile: { width: 575 },
+      }
+
+      // Act
+      const result = parseBreakpointsInput(input)
+
+      // Assert
+      expect(result).toEqual([
+        { id: 'desktop', label: 'Large', minWidth: 769, viewportWidth: 1200 },
+        { id: 'tablet', minWidth: 576, maxWidth: 768, viewportWidth: 768 },
+        { id: 'mobile', maxWidth: 575, viewportWidth: 575 },
+      ])
+    })
+
+    test('default label overrides the base breakpoint label', async () => {
+      // Arrange
+      const input = {
+        default: { label: 'Custom Base' },
+        tablet: { width: 768 },
+      }
+
+      // Act
+      const result = parseBreakpointsInput(input)
+
+      // Assert
+      expect(result).toEqual([
+        { id: 'desktop', label: 'Custom Base', minWidth: 769 },
+        { id: 'tablet', maxWidth: 768, viewportWidth: 768 },
+      ])
+    })
+
+    test('default viewport sets the base breakpoint viewportWidth', async () => {
+      // Arrange
+      const input = {
+        default: { viewport: 1024 },
+        tablet: { width: 768 },
+      }
+
+      // Act
+      const result = parseBreakpointsInput(input)
+
+      // Assert
+      expect(result).toEqual([
+        { id: 'desktop', label: 'Desktop', minWidth: 769, viewportWidth: 1024 },
+        { id: 'tablet', maxWidth: 768, viewportWidth: 768 },
+      ])
+    })
+  })
+
   test('adds the base breakpoint', async () => {
     // Arrange
     const input = {
@@ -105,7 +199,7 @@ describe('parseBreakpointsInput', () => {
 
     // Act
     // Assert
-    expect(() => parseBreakpointsInput(input)).toThrowError(/base breakpoint/)
+    expect(() => parseBreakpointsInput(input)).toThrowError(/Use "default" instead/)
   })
 
   test('throws an error if the the input is an empty object', async () => {

--- a/packages/runtime/src/state/modules/breakpoints.ts
+++ b/packages/runtime/src/state/modules/breakpoints.ts
@@ -128,14 +128,50 @@ export function reducer(state: State = getInitialState(), action: Action | Unkno
   }
 }
 
-export type BreakpointsInput = Record<string, { width: number; label?: string; viewport?: number }>
+export type DefaultBreakpointConfig = {
+  viewport?: number
+  label?: string
+}
+
+export type BreakpointConfig = {
+  width: number
+  label?: string
+  viewport?: number
+}
+
+export type BreakpointsInput = {
+  default?: DefaultBreakpointConfig
+  [key: string]: BreakpointConfig | DefaultBreakpointConfig | undefined
+}
+
+const DEFAULT_BREAKPOINT_KEY = 'default'
 
 export function parseBreakpointsInput(input: BreakpointsInput): Breakpoints {
   validateBreakpointsInput(input)
 
-  const sorted = Object.entries(input)
-    .map(([id, value]) => ({ ...value, id }))
+  const { [DEFAULT_BREAKPOINT_KEY]: defaultConfig, ...otherBreakpoints } = input
+
+  const hasOtherBreakpoints = Object.keys(otherBreakpoints).length > 0
+
+  if (!hasOtherBreakpoints) {
+    const baseBreakpoint: Breakpoint = {
+      id: DefaultBreakpointID.Desktop,
+      label: defaultConfig?.label ?? 'Desktop',
+      ...(defaultConfig?.viewport != null && { viewportWidth: defaultConfig.viewport }),
+    }
+    return [baseBreakpoint]
+  }
+
+  const sorted = Object.entries(otherBreakpoints)
+    .map(([id, value]) => ({ ...(value as BreakpointConfig), id }))
     .sort((a, b) => b.width - a.width) // Sort by width in descending order
+
+  const baseBreakpoint: Breakpoint = {
+    id: DefaultBreakpointID.Desktop,
+    label: defaultConfig?.label ?? 'Desktop',
+    minWidth: sorted[0].width + 1,
+    ...(defaultConfig?.viewport != null && { viewportWidth: defaultConfig.viewport }),
+  }
 
   const transformed = sorted.reduce(
     (prev, curr, index, array) => {
@@ -152,9 +188,7 @@ export function parseBreakpointsInput(input: BreakpointsInput): Breakpoints {
 
       return [...prev, breakpoint]
     },
-    [
-      { id: DefaultBreakpointID.Desktop, label: 'Desktop', minWidth: sorted[0].width + 1 },
-    ] as Breakpoints,
+    [baseBreakpoint] as Breakpoints,
   )
 
   return transformed
@@ -163,16 +197,25 @@ export function parseBreakpointsInput(input: BreakpointsInput): Breakpoints {
 function validateBreakpointsInput(input: BreakpointsInput) {
   if (DefaultBreakpointID.Desktop in input) {
     throw new Error(
-      `Cannot change the base breakpoint. "${DefaultBreakpointID.Desktop}" is reserved as the base breakpoint.`,
+      `Cannot use "${DefaultBreakpointID.Desktop}" as a breakpoint key. Use "default" instead to configure the base breakpoint.`,
     )
   }
 
-  if (Object.keys(input).length === 0) {
+  const { [DEFAULT_BREAKPOINT_KEY]: defaultConfig, ...otherBreakpoints } = input
+
+  const hasDefaultConfig = defaultConfig !== undefined
+  const hasOtherBreakpoints = Object.keys(otherBreakpoints).length > 0
+
+  if (!hasDefaultConfig && !hasOtherBreakpoints) {
     throw new Error(`Breakpoints cannot be empty. You must provide at least one breakpoint.`)
   }
 
-  const sorted = Object.entries(input)
-    .map(([id, value]) => ({ ...value, id }))
+  if (!hasOtherBreakpoints) {
+    return
+  }
+
+  const sorted = Object.entries(otherBreakpoints)
+    .map(([id, value]) => ({ ...(value as BreakpointConfig), id }))
     .sort((a, b) => b.width - a.width) // Sort by width in descending order
 
   sorted.forEach(({ id, width, viewport }, index, array) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR implements the runtime side of MSFT-11197, allowing customers to configure the default breakpoint's viewport and label.

### Changes

**New API support in `breakpoints` configuration:**

```ts
export const runtime = new ReactRuntime({
  breakpoints: {
    default: { viewport: 780, label: 'Tablet' },
  },
})
```

The `default` key accepts:
- `viewport?: number` - Sets the preview width for the default breakpoint in the builder
- `label?: string` - Customizes the display name of the default breakpoint (e.g., "Tablet" instead of "Desktop")

### Behavior

1. **Single default breakpoint only**: When only `default` is specified with no other breakpoints, the runtime uses just the single base breakpoint with the configured viewport and label.

2. **Default with other breakpoints**: When combined with other breakpoints, the default's viewport and label are applied to the base breakpoint while other breakpoints function as before.

3. **Backward compatibility**: 
   - The base breakpoint id remains `desktop` for backward compatibility with stored responsive values
   - Existing apps without `default` configuration continue to get the current full-width Desktop behavior

### Technical Details

- Updated `BreakpointsInput` type to support the `default` key with `DefaultBreakpointConfig` type
- Updated `parseBreakpointsInput` to handle the default breakpoint configuration
- Updated validation to provide a helpful error message suggesting `default` instead of `desktop`
- Added comprehensive tests covering all new functionality

### Testing

- All 806 existing tests pass
- Added 6 new tests specifically for the default breakpoint configuration

### Related

- Resolves MSFT-11197
- The cosmos/Leo side changes were completed separately (builder header width display fix)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MSFT-11197](https://linear.app/commerce/issue/MSFT-11197/allow-configuring-the-default-viewport-size-in-makeswift)

<div><a href="https://cursor.com/agents/bc-91762e6c-8895-4c70-ac88-830c7e2c097b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91762e6c-8895-4c70-ac88-830c7e2c097b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

