### PR TITLE
chore: downgrade Color control defaultValue changeset to patch

### DIFF
--- a/.changeset/color-default-opacity.md
+++ b/.changeset/color-default-opacity.md
@@ -1,5 +1,5 @@
 ---
-"@makeswift/controls": minor
+"@makeswift/controls": patch
 ---
 
 Support object form `{ color, opacity }` for Color control defaultValue


### PR DESCRIPTION
Changes the `@makeswift/controls` changeset in `.changeset/color-default-opacity.md` from `minor` to `patch`.

Since `@makeswift/controls` is pre-1.0 (`0.1.18`), this additive change is fine as a patch.