### PR TITLE
refactor(runtime): factor out `resolvedStyleToCss` util for server use

### DIFF
--- a/packages/runtime/src/runtimes/react/hooks/use-stylesheet-factory.ts
+++ b/packages/runtime/src/runtimes/react/hooks/use-stylesheet-factory.ts
@@ -1,5 +1,5 @@
 import { useMemo, useEffect, useRef } from 'react'
-import { type CSSObject, serializeStyles } from '@emotion/serialize'
+import { serializeStyles } from '@emotion/serialize'
 import { type EmotionCache } from '@emotion/cache'
 import { type SerializedStyles } from '@emotion/utils'
 
@@ -8,16 +8,11 @@ import {
   type Breakpoints,
   type Stylesheet,
   type ResolvedStyle,
-  type ResolvedStyleV2,
-  type ResolvedTypographyStyle,
   isNotNil,
-  getBaseBreakpoint,
-  getBreakpointMediaQuery,
 } from '@makeswift/controls'
 
 import { useCache } from '../root-style-registry'
-import { styleV1Css } from '../controls/style'
-import { typographyCss } from '../controls/typography'
+import { resolvedStyleToCss } from '../lib/resolved-style-to-css'
 
 import { useBreakpoints } from './use-breakpoints'
 import { useCssId } from './use-css-id'
@@ -35,7 +30,9 @@ export function useStylesheetFactory(): StylesheetFactory {
   const componentUid = useCssId()
 
   const computedStyles = useRef<Record<string, SerializedStyles>>({}).current
-  const boxModelCallbacks = useRef<Record<string, (boxModel: BoxDisplayModel | null) => void>>({}).current
+  const boxModelCallbacks = useRef<Record<string, (boxModel: BoxDisplayModel | null) => void>>(
+    {},
+  ).current
 
   return useMemo(() => {
     const getStylesheet = (styleSheetId: string): Stylesheet => ({
@@ -88,40 +85,6 @@ export function useStylesheetFactory(): StylesheetFactory {
       },
     }
   }, [breakpoints, cache, componentUid])
-}
-
-function isTypographyStyle(style: ResolvedStyle): style is ResolvedTypographyStyle {
-  return Array.isArray(style)
-}
-
-function isStyleV2(style: ResolvedStyle): style is ResolvedStyleV2 {
-  return typeof style === 'object' && 'getStyle' in style && typeof style.getStyle === 'function'
-}
-
-function styleV2Css(breakpoints: Breakpoints, style: ResolvedStyleV2<CSSObject>): CSSObject {
-  return {
-    ...style.getStyle(getBaseBreakpoint(breakpoints)),
-    ...breakpoints.reduce(
-      (styles, breakpoint) => ({
-        ...styles,
-        [getBreakpointMediaQuery(breakpoint)]: style.getStyle(breakpoint),
-      }),
-      {},
-    ),
-  }
-}
-
-function resolvedStyleToCss(breakpoints: Breakpoints, style: ResolvedStyle) {
-  if (isTypographyStyle(style)) {
-    return typographyCss(breakpoints, style)
-  }
-
-  if (isStyleV2(style)) {
-    return styleV2Css(breakpoints, style as ResolvedStyleV2<CSSObject>)
-  }
-
-  const { properties, styleData } = style
-  return styleV1Css(breakpoints, styleData, properties)
 }
 
 function serializeStyle(

--- a/packages/runtime/src/runtimes/react/lib/resolved-style-to-css.ts
+++ b/packages/runtime/src/runtimes/react/lib/resolved-style-to-css.ts
@@ -1,0 +1,47 @@
+import { type CSSObject } from '@emotion/serialize'
+
+import {
+  type Breakpoints,
+  type ResolvedStyle,
+  type ResolvedStyleV2,
+  type ResolvedTypographyStyle,
+  getBaseBreakpoint,
+  getBreakpointMediaQuery,
+} from '@makeswift/controls'
+
+import { styleV1Css } from '../controls/style'
+import { typographyCss } from '../controls/typography'
+
+function isTypographyStyle(style: ResolvedStyle): style is ResolvedTypographyStyle {
+  return Array.isArray(style)
+}
+
+function isStyleV2(style: ResolvedStyle): style is ResolvedStyleV2 {
+  return typeof style === 'object' && 'getStyle' in style && typeof style.getStyle === 'function'
+}
+
+function styleV2Css(breakpoints: Breakpoints, style: ResolvedStyleV2<CSSObject>): CSSObject {
+  return {
+    ...style.getStyle(getBaseBreakpoint(breakpoints)),
+    ...breakpoints.reduce(
+      (styles, breakpoint) => ({
+        ...styles,
+        [getBreakpointMediaQuery(breakpoint)]: style.getStyle(breakpoint),
+      }),
+      {},
+    ),
+  }
+}
+
+export function resolvedStyleToCss(breakpoints: Breakpoints, style: ResolvedStyle): CSSObject {
+  if (isTypographyStyle(style)) {
+    return typographyCss(breakpoints, style)
+  }
+
+  if (isStyleV2(style)) {
+    return styleV2Css(breakpoints, style as ResolvedStyleV2<CSSObject>)
+  }
+
+  const { properties, styleData } = style
+  return styleV1Css(breakpoints, styleData, properties)
+}


### PR DESCRIPTION
Factored out `resolvedStyleToCss` utility from a hook into a standalone module for server use. No semantic changes.