### PR TITLE
chore: add changeset for Slider control

### DIFF
--- a/.changeset/add-slider-control.md
+++ b/.changeset/add-slider-control.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/controls': patch
+---
+
+Introduce `Slider` control, a numeric input with `min`/`max`/`step` and an optional `defaultValue`, rendered as a slider in the builder property panels.


### PR DESCRIPTION
## Summary
- Adds a minor changeset for `@makeswift/controls` covering the new `Slider` control introduced on `drewpledger/arr-539-runtime-updates`.