### PR TITLE
feat: support auto for width

### DIFF
--- a/.changeset/auto-width-support.md
+++ b/.changeset/auto-width-support.md
@@ -1,0 +1,7 @@
+---
+'@makeswift/runtime': minor
+'@makeswift/controls': minor
+'@makeswift/prop-controllers': minor
+---
+
+Add auto width support across width controls.

--- a/packages/controls/src/controls/style/v1/schema.ts
+++ b/packages/controls/src/controls/style/v1/schema.ts
@@ -166,7 +166,9 @@ export const textStyle = z
  * `'100px'`.
  */
 
-export const width = z.union([pixelLength, percentageLength])
+export const autoLength = z.literal('auto')
+
+export const width = z.union([pixelLength, percentageLength, autoLength])
 
 const marginValue = z
   .union([pixelLength, z.literal('auto')])

--- a/packages/controls/src/controls/style/v1/style.test.types.ts
+++ b/packages/controls/src/controls/style/v1/style.test.types.ts
@@ -28,17 +28,12 @@ describe('Style Types', () => {
 
     type Data = DataType<typeof def>
 
-    expectTypeOf<Data['width']>().toEqualTypeOf<
+    expectTypeOf<Data['width']>().branded.toEqualTypeOf<
       | {
           value:
-            | {
-                value: number
-                unit: 'px'
-              }
-            | {
-                value: number
-                unit: '%'
-              }
+            | { value: number; unit: 'px' }
+            | { value: number; unit: '%' }
+            | 'auto'
           deviceId: string
         }[]
       | undefined

--- a/packages/prop-controllers/src/data.ts
+++ b/packages/prop-controllers/src/data.ts
@@ -15,6 +15,13 @@ export const lengthDataSchema = z.object({
 
 export type LengthData = z.infer<typeof lengthDataSchema>
 
+export const widthLengthDataSchema = z.union([
+  z.object({ value: z.number(), unit: z.enum(['px', '%']) }),
+  z.literal('auto'),
+])
+
+export type WidthLengthData = z.infer<typeof widthLengthDataSchema>
+
 export const gapDataSchema = z.object({
   value: z.number(),
   unit: z.literal('px'),

--- a/packages/prop-controllers/src/index.ts
+++ b/packages/prop-controllers/src/index.ts
@@ -348,6 +348,7 @@ export {
 } from './width'
 export type {
   ResolveWidthPropControllerValue,
+  ResponsiveWidthLengthData,
   WidthDescriptor,
   WidthPropControllerData,
 } from './width'

--- a/packages/prop-controllers/src/responsive-length.ts
+++ b/packages/prop-controllers/src/responsive-length.ts
@@ -37,8 +37,8 @@ export type ResponsiveLengthPropControllerData = z.infer<
 >
 
 export type LengthOption =
-  | { value: 'px'; label: 'Pixels'; icon: 'Px16' }
-  | { value: '%'; label: 'Percentage'; icon: 'Percent16' }
+  | { value: 'px'; label: string }
+  | { value: '%'; label: string }
 
 export type ResponsiveLengthOptions = Options<{
   preset?: ResponsiveLengthPropControllerData

--- a/packages/prop-controllers/src/width/width.test.ts
+++ b/packages/prop-controllers/src/width/width.test.ts
@@ -1,6 +1,7 @@
 import { ControlDataTypeKey, Types } from '../prop-controllers'
 import { ResponsiveLengthData } from '../responsive-length'
 import {
+  ResponsiveWidthLengthData,
   WidthDescriptor,
   WidthPropControllerDataV0,
   WidthPropControllerDataV1,
@@ -115,6 +116,56 @@ describe('WidthPropController', () => {
 
       // Assert
       expect(result).toBe(data)
+    })
+  })
+
+  describe('auto unit support', () => {
+    test('parses width data with auto in V1 format', () => {
+      // Arrange
+      const data: WidthPropControllerDataV1 = {
+        [ControlDataTypeKey]: WidthPropControllerDataV1Type,
+        value: [
+          {
+            deviceId: 'desktop',
+            value: 'auto',
+          },
+        ],
+      }
+
+      // Act
+      const result = getWidthPropControllerDataResponsiveLengthData(data)
+
+      // Assert
+      expect(result).toEqual([
+        { deviceId: 'desktop', value: 'auto' },
+      ])
+    })
+
+    test('creates V1 data with auto', () => {
+      // Arrange
+      const data: ResponsiveWidthLengthData = [
+        {
+          deviceId: 'desktop',
+          value: 'auto',
+        },
+      ]
+      const definition: WidthDescriptor = {
+        type: Types.Width,
+        version: 1,
+        options: {},
+      }
+
+      // Act
+      const result = createWidthPropControllerDataFromResponsiveLengthData(
+        data,
+        definition,
+      )
+
+      // Assert
+      expect(result).toEqual({
+        [ControlDataTypeKey]: WidthPropControllerDataV1Type,
+        value: data,
+      })
     })
   })
 })

--- a/packages/prop-controllers/src/width/width.ts
+++ b/packages/prop-controllers/src/width/width.ts
@@ -1,13 +1,13 @@
 import { P, match } from 'ts-pattern'
-import { ControlDataTypeKey, ResolveOptions, Types } from '../prop-controllers'
+import { ControlDataTypeKey, ResolveOptions, Types, Schema } from '../prop-controllers'
 import { z } from 'zod'
-import { LengthData } from '../data'
-import {
-  ResponsiveLengthData,
-  responsiveLengthDataSchema,
-} from '../responsive-length'
+import { WidthLengthData, widthLengthDataSchema } from '../data'
 
-const widthPropControllerDataV0Schema = responsiveLengthDataSchema
+const responsiveWidthLengthDataSchema = Schema.responsiveValue(widthLengthDataSchema)
+
+export type ResponsiveWidthLengthData = z.infer<typeof responsiveWidthLengthDataSchema>
+
+const widthPropControllerDataV0Schema = responsiveWidthLengthDataSchema
 
 export type WidthPropControllerDataV0 = z.infer<
   typeof widthPropControllerDataV0Schema
@@ -17,7 +17,7 @@ export const WidthPropControllerDataV1Type = 'prop-controllers::width::v1'
 
 const widthPropControllerDataV1Schema = z.object({
   [ControlDataTypeKey]: z.literal(WidthPropControllerDataV1Type),
-  value: responsiveLengthDataSchema,
+  value: responsiveWidthLengthDataSchema,
 })
 
 export type WidthPropControllerDataV1 = z.infer<
@@ -44,8 +44,9 @@ export type WidthPropControllerFormat =
 
 type WidthOptions = {
   preset?: WidthPropControllerData
-  defaultValue?: LengthData
+  defaultValue?: WidthLengthData
   format?: WidthPropControllerFormat
+  minWidth?: number
 }
 
 type WidthDescriptorV0<
@@ -73,16 +74,16 @@ export type WidthDescriptor<
 export type ResolveWidthPropControllerValue<T extends WidthDescriptor> =
   T extends WidthDescriptor
     ? undefined extends ResolveOptions<T['options']>['format']
-      ? ResponsiveLengthData | undefined
+      ? ResponsiveWidthLengthData | undefined
       : ResolveOptions<
-            T['options']
-          >['format'] extends typeof WidthPropControllerFormat.ClassName
-        ? string
-        : ResolveOptions<
-              T['options']
-            >['format'] extends typeof WidthPropControllerFormat.ResponsiveValue
-          ? ResponsiveLengthData | undefined
-          : never
+          T['options']
+        >['format'] extends typeof WidthPropControllerFormat.ClassName
+      ? string
+      : ResolveOptions<
+          T['options']
+        >['format'] extends typeof WidthPropControllerFormat.ResponsiveValue
+      ? ResponsiveWidthLengthData | undefined
+      : never
     : never
 
 /**
@@ -99,7 +100,7 @@ Width.Format = WidthPropControllerFormat
 
 export function getWidthPropControllerDataResponsiveLengthData(
   data: WidthPropControllerData | undefined,
-): ResponsiveLengthData | undefined {
+): ResponsiveWidthLengthData | undefined {
   return match(data)
     .with(
       { [ControlDataTypeKey]: WidthPropControllerDataV1Type },
@@ -109,7 +110,7 @@ export function getWidthPropControllerDataResponsiveLengthData(
 }
 
 export function createWidthPropControllerDataFromResponsiveLengthData(
-  responsiveLengthData: ResponsiveLengthData,
+  responsiveLengthData: ResponsiveWidthLengthData,
   definition?: WidthDescriptor,
 ): WidthPropControllerData {
   return match(definition)

--- a/packages/runtime/src/api-handler/handlers/manifest.ts
+++ b/packages/runtime/src/api-handler/handlers/manifest.ts
@@ -16,6 +16,7 @@ export type Manifest = {
   localizedPageSSR: boolean
   webhook: boolean
   localizedPagesOnlineByDefault: boolean
+  styleWidthAuto: boolean
 }
 
 export async function manifestHandler(
@@ -40,6 +41,8 @@ export async function manifestHandler(
     webhook: true,
     localizedPagesOnlineByDefault: true,
     previewToken: true,
+    styleWidthAuto: true,
     ...(manifest ?? {}),
   })
 }
+

--- a/packages/runtime/src/components/builtin/Box/Box.tsx
+++ b/packages/runtime/src/components/builtin/Box/Box.tsx
@@ -22,7 +22,7 @@ import {
   type BoxModelHandle,
 } from '../../../state/modules/read-write/box-models'
 import BackgroundsContainer from '../../shared/BackgroundsContainer'
-import { useResponsiveStyle } from '../../utils/responsive-style'
+import { useResponsiveStyle, useResponsiveWidth } from '../../utils/responsive-style'
 import { GridItem } from '../../shared/grid-item'
 import { useStyle } from '../../../runtimes/react/use-style'
 import {
@@ -30,12 +30,13 @@ import {
   type ResponsiveBackgroundsData,
   type ResponsiveGapData,
   type ResponsiveIconRadioGroupValue,
+  type ResponsiveWidthLengthData,
 } from '@makeswift/prop-controllers'
 
 type Props = {
   id?: string
   backgrounds?: ResponsiveBackgroundsData
-  width?: string
+  width?: ResponsiveWidthLengthData
   height?: ResponsiveIconRadioGroupValue<'auto' | 'stretch'>
   verticalAlign?: ResponsiveIconRadioGroupValue<
     'flex-start' | 'center' | 'flex-end' | 'space-between'
@@ -165,7 +166,7 @@ const Box = forwardRef(function Box(
       ref={boxElementCallbackRef}
       id={id}
       className={cx(
-        width,
+        useStyle(useResponsiveWidth(width, { defaultValue: { value: 100, unit: '%' } })),
         margin,
         borderRadius,
         useStyle({ display: 'flex' }),
@@ -181,7 +182,23 @@ const Box = forwardRef(function Box(
           padding,
           boxShadow,
           border,
-          useStyle({ display: 'flex', flexWrap: 'wrap', width: '100%' }),
+          useStyle(
+            useResponsiveStyle(
+              [width, children?.columns] as const,
+              ([width, grid = { spans: [[12]], count: 12 }]) => {
+                const isSingleColumn = grid.spans.every(row => row.length === 1)
+
+                return width === 'auto' && isSingleColumn
+                  ? {
+                      display: 'flex',
+                      flexDirection: 'column',
+                      flexWrap: 'nowrap',
+                      width: '100%',
+                    }
+                  : { display: 'flex', flexDirection: 'row', flexWrap: 'wrap', width: '100%' }
+              },
+            ),
+          ),
           useStyle(
             useResponsiveStyle([verticalAlign], ([alignContent = 'flex-start']) => ({
               alignContent,

--- a/packages/runtime/src/components/builtin/Box/register.ts
+++ b/packages/runtime/src/components/builtin/Box/register.ts
@@ -57,7 +57,6 @@ export function registerComponent(runtime: ReactRuntimeCore) {
         id: ElementID(),
         backgrounds: Backgrounds(),
         width: Width({
-          format: Width.Format.ClassName,
           defaultValue: { value: 100, unit: '%' },
         }),
         height: ResponsiveIconRadioGroup({

--- a/packages/runtime/src/components/builtin/Button/Button.tsx
+++ b/packages/runtime/src/components/builtin/Button/Button.tsx
@@ -21,10 +21,10 @@ import {
 import { cx } from '@emotion/css'
 import {
   type LinkData,
-  type ResponsiveLengthData,
   type ResponsiveTextStyleData,
   type ResponsiveSelectValue,
   type ResponsiveIconRadioGroupValue,
+  type ResponsiveWidthLengthData,
 } from '@makeswift/prop-controllers'
 
 type BaseProps<T extends ElementType> = {
@@ -38,7 +38,7 @@ type BaseProps<T extends ElementType> = {
   color?: ResponsiveColor | null
   textColor?: ResponsiveColor | null
   textStyle?: ResponsiveTextStyleData
-  width?: ResponsiveLengthData
+  width?: ResponsiveWidthLengthData
   margin?: string
 }
 
@@ -83,7 +83,7 @@ const Button = forwardRef(function Button<T extends ElementType = 'button'>(
           textDecoration: 'none',
           textAlign: 'center',
         }),
-        useStyle(useResponsiveWidth(width, 'auto')),
+        useStyle(useResponsiveWidth(width, { defaultValue: 'auto', autoWidth: 'fit-content' })),
         margin,
         useStyle(
           useResponsiveStyle(

--- a/packages/runtime/src/components/builtin/Button/register.ts
+++ b/packages/runtime/src/components/builtin/Button/register.ts
@@ -82,7 +82,7 @@ export function registerComponent(runtime: ReactRuntimeCore) {
           placeholder: 'white',
         }),
         textStyle: TextStyle(),
-        width: Width(),
+        width: Width({ defaultValue: 'auto' }),
         margin: Margin({ format: Margin.Format.ClassName }),
       },
     },

--- a/packages/runtime/src/components/builtin/Divider/register.ts
+++ b/packages/runtime/src/components/builtin/Divider/register.ts
@@ -34,7 +34,7 @@ export function registerComponent(runtime: ReactRuntimeCore) {
         thickness: ResponsiveLength({
           label: 'Height',
           defaultValue: { value: 1, unit: 'px' },
-          options: [{ value: 'px', label: 'Pixels', icon: 'Px16' }],
+          options: [{ value: 'px', label: 'px' }],
         }),
         color: ResponsiveColor({ placeholder: 'black' }),
         width: Width({

--- a/packages/runtime/src/components/builtin/Image/Image.tsx
+++ b/packages/runtime/src/components/builtin/Image/Image.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, Ref, forwardRef } from 'react'
 
 import {
   LinkData,
-  ResponsiveLengthData,
+  ResponsiveWidthLengthData,
   ImageData,
   ResponsiveOpacityValue,
 } from '@makeswift/prop-controllers'
@@ -25,7 +25,7 @@ type Props = {
   file?: ImageData
   altText?: string
   link?: LinkData
-  width?: ResponsiveLengthData
+  width?: ResponsiveWidthLengthData
   margin?: string
   padding?: string
   border?: string
@@ -47,24 +47,43 @@ function loadImage(src: string): Promise<HTMLImageElement> {
   })
 }
 
-function imageSizes(breakpoints: Breakpoints, width?: Props['width']): string {
+function imageSizes(breakpoints: Breakpoints, width?: Props['width'], intrinsicWidth?: number): string {
   const baseDevice = breakpoints.find(breakpoint => breakpoint.maxWidth == null)
   const baseWidth = baseDevice && width && findBreakpointOverride(breakpoints, width, baseDevice.id)
   const baseWidthSize =
-    baseWidth == null || baseWidth.value.unit !== 'px' ? '100vw' : `${baseWidth.value.value}px`
+    baseWidth == null
+      ? '100vw'
+      : baseWidth.value === 'auto'
+        ? intrinsicWidth != null
+          ? `${intrinsicWidth}px`
+          : '100vw'
+        : baseWidth.value.unit === 'px'
+          ? `${baseWidth.value.value}px`
+          : '100vw'
 
   return breakpoints
     .map(breakpoint => {
       const override = findBreakpointOverride(breakpoints, width, breakpoint.id)
 
-      if (override == null || breakpoint.maxWidth == null || override.value.unit !== 'px') {
+      if (override == null || breakpoint.maxWidth == null) {
         return null
       }
 
-      return `(max-width: ${breakpoint.maxWidth}px) ${Math.min(
-        breakpoint.maxWidth,
-        override.value.value,
-      )}px`
+      if (override.value === 'auto' && intrinsicWidth != null) {
+        return `(max-width: ${breakpoint.maxWidth}px) ${Math.min(
+          breakpoint.maxWidth,
+          intrinsicWidth,
+        )}px`
+      }
+
+      if (typeof override.value === 'object' && override.value.unit === 'px') {
+        return `(max-width: ${breakpoint.maxWidth}px) ${Math.min(
+          breakpoint.maxWidth,
+          override.value.value,
+        )}px`
+      }
+
+      return null
     })
     .filter((size): size is NonNullable<typeof size> => size != null)
     .reduce((sourceSizes, sourceSize) => `${sourceSize}, ${sourceSizes}`, baseWidthSize)
@@ -136,7 +155,7 @@ const ImageComponent = forwardRef(function Image(
   const Container = link ? Link : 'div'
   const containerClassName = cx(
     useStyle({ lineHeight: 0, overflow: 'hidden' }),
-    useStyle(useResponsiveWidth(width, dimensions?.width)),
+    useStyle(useResponsiveWidth(width, { defaultValue: dimensions?.width, autoWidth: dimensions?.width })),
     useStyle(useResponsiveStyle([opacity] as const, ([opacity = 1]) => ({ opacity }))),
     margin,
     padding,
@@ -155,7 +174,7 @@ const ImageComponent = forwardRef(function Image(
       <Image
         src={imageSrc}
         priority={priority}
-        sizes={imageSizes(breakpoints, width)}
+        sizes={imageSizes(breakpoints, width, dimensions?.width)}
         alt={altText ?? ''}
         width={dimensions.width}
         height={dimensions.height}

--- a/packages/runtime/src/components/builtin/Image/register.ts
+++ b/packages/runtime/src/components/builtin/Image/register.ts
@@ -27,7 +27,7 @@ export function registerComponent(runtime: ReactRuntimeCore) {
         file: Image(),
         altText: TextInput({ label: 'Alt text' }),
         link: Link({ label: 'On click' }),
-        width: Width(),
+        width: Width({ defaultValue: 'auto' }),
         margin: Margin({ format: Margin.Format.ClassName }),
         padding: Padding({ format: Padding.Format.ClassName }),
         border: Border({ format: Border.Format.ClassName }),

--- a/packages/runtime/src/components/builtin/Navigation/register.ts
+++ b/packages/runtime/src/components/builtin/Navigation/register.ts
@@ -78,7 +78,7 @@ export function registerComponent(runtime: ReactRuntimeCore) {
           min: 0,
           max: 1000,
           // TODO: This is hardcoded value, import it from LengthInputOptions
-          options: [{ value: 'px', label: 'Pixels', icon: 'Px16' }],
+          options: [{ value: 'px', label: 'px' }],
           hidden:
             getCheckboxPropControllerDataBoolean(
               checkboxPropControllerDataSchema.optional().catch(undefined).parse(props.showLogo),

--- a/packages/runtime/src/components/builtin/Video/register.ts
+++ b/packages/runtime/src/components/builtin/Video/register.ts
@@ -17,6 +17,7 @@ export function registerComponent(runtime: ReactRuntimeCore) {
         width: Width({
           format: Width.Format.ClassName,
           defaultValue: { value: 560, unit: 'px' },
+          minWidth: 300,
         }),
         margin: Margin({ format: Margin.Format.ClassName }),
         borderRadius: BorderRadius({ format: BorderRadius.Format.ClassName }),

--- a/packages/runtime/src/components/utils/responsive-style.test.ts
+++ b/packages/runtime/src/components/utils/responsive-style.test.ts
@@ -1,0 +1,100 @@
+import { responsiveWidth } from './responsive-style'
+
+const breakpoints = [
+  { id: 'desktop', label: 'Desktop', viewportWidth: 1280 },
+]
+
+const MEDIA_QUERY = '@media only screen'
+
+describe('responsiveWidth', () => {
+  test('emits pixel width for px unit', () => {
+    const widthData = [{ deviceId: 'desktop', value: { value: 200, unit: 'px' as const } }]
+
+    const result = responsiveWidth(breakpoints, widthData)
+
+    expect(result).toMatchObject({
+      maxWidth: '100%',
+      [MEDIA_QUERY]: { width: '200px' },
+    })
+  })
+
+  test('emits percentage width for % unit', () => {
+    const widthData = [{ deviceId: 'desktop', value: { value: 50, unit: '%' as const } }]
+
+    const result = responsiveWidth(breakpoints, widthData)
+
+    expect(result).toMatchObject({
+      maxWidth: '100%',
+      [MEDIA_QUERY]: { width: '50%' },
+    })
+  })
+
+  test('emits fit-content for auto when autoWidth is not provided', () => {
+    const widthData = [{ deviceId: 'desktop', value: 'auto' as const }]
+
+    const result = responsiveWidth(breakpoints, widthData)
+
+    expect(result).toMatchObject({
+      maxWidth: '100%',
+      [MEDIA_QUERY]: { width: 'fit-content', minWidth: 20 },
+    })
+  })
+
+  test('emits pixel width for auto with numeric autoWidth (image intrinsic)', () => {
+    const widthData = [{ deviceId: 'desktop', value: 'auto' as const }]
+
+    const result = responsiveWidth(breakpoints, widthData, { autoWidth: 800 })
+
+    expect(result).toMatchObject({
+      maxWidth: '100%',
+      [MEDIA_QUERY]: { width: '800px' },
+    })
+  })
+
+  test('uses default value when no data provided', () => {
+    const result = responsiveWidth(breakpoints, undefined)
+
+    expect(result).toMatchObject({ maxWidth: '100%' })
+  })
+
+  test('uses custom string default when no data provided', () => {
+    const result = responsiveWidth(breakpoints, undefined, { defaultValue: 'auto' })
+
+    expect(result).toMatchObject({ maxWidth: '100%' })
+  })
+
+  test('falls back to autoWidth when no data and defaultValue is auto (button)', () => {
+    const result = responsiveWidth(breakpoints, undefined, {
+      defaultValue: 'auto',
+      autoWidth: 'fit-content',
+    })
+
+    expect(result).toMatchObject({
+      maxWidth: '100%',
+      [MEDIA_QUERY]: { width: 'fit-content', minWidth: 20 },
+    })
+  })
+
+  test('falls back to intrinsic pixel width when no data (image)', () => {
+    const result = responsiveWidth(breakpoints, undefined, {
+      defaultValue: 800,
+      autoWidth: 800,
+    })
+
+    expect(result).toMatchObject({
+      maxWidth: '100%',
+      [MEDIA_QUERY]: { width: 800 },
+    })
+  })
+
+  test('uses default minWidth when minWidth is explicitly undefined', () => {
+    const widthData = [{ deviceId: 'desktop', value: 'auto' as const }]
+
+    const result = responsiveWidth(breakpoints, widthData, { minWidth: undefined })
+
+    expect(result).toMatchObject({
+      maxWidth: '100%',
+      [MEDIA_QUERY]: { width: 'fit-content', minWidth: 20 },
+    })
+  })
+})

--- a/packages/runtime/src/components/utils/responsive-style.ts
+++ b/packages/runtime/src/components/utils/responsive-style.ts
@@ -9,8 +9,9 @@ import type {
   ResponsiveMarginData,
   ResponsivePaddingData,
   ResponsiveValue,
-  ResponsiveLengthData,
   ResponsiveTextStyleData,
+  ResponsiveWidthLengthData,
+  WidthLengthData,
 } from '@makeswift/prop-controllers'
 
 import {
@@ -69,14 +70,32 @@ export function useResponsiveStyle<
 
 export function responsiveWidth(
   breakpoints: Breakpoints,
-  widthData: ResponsiveLengthData | undefined,
-  defaultValue: LengthData | WidthProperty<string | number> = '100%',
+  widthData: ResponsiveWidthLengthData | undefined,
+  {
+    defaultValue = '100%',
+    minWidth = 20,
+    autoWidth = 'fit-content',
+  }: {
+    defaultValue?: WidthLengthData | WidthProperty<string | number>
+    minWidth?: number
+    autoWidth?: WidthProperty<string | number>
+  } = {},
 ): CSSObject {
+  const resolvedAutoWidth = typeof autoWidth === 'number' ? `${autoWidth}px` : autoWidth
+
   return {
     maxWidth: '100%',
-    ...responsiveStyle(breakpoints, [widthData], ([width = defaultValue]) => ({
-      width: typeof width === 'object' ? `${width.value}${width.unit}` : width,
-    })),
+    ...responsiveStyle(breakpoints, [widthData], ([width = defaultValue]) => {
+      const isAuto = width === 'auto'
+      return {
+        width: isAuto
+          ? resolvedAutoWidth
+          : typeof width === 'object'
+            ? `${width.value}${width.unit}`
+            : width,
+        ...(isAuto && resolvedAutoWidth === 'fit-content' && { minWidth }),
+      }
+    }),
   }
 }
 
@@ -210,8 +229,7 @@ export function responsiveGridItem(
         const excessWidth = `${Number(firstCol) + Number(lastCol)} * ${columnGap.value}${
           columnGap.unit
         } / 2`
-        const iePrecisionError = '0.01px'
-        const flexBasis = `calc(${width} - ${excessWidth} - ${iePrecisionError})`
+        const flexBasis = `calc(${width} - ${excessWidth})`
         const firstRow = rowIndex === 0
         const lastRow = rowIndex === spans.length - 1
 
@@ -220,9 +238,6 @@ export function responsiveGridItem(
           : {
               flexBasis,
               minWidth: flexBasis,
-              // NOTE: IE11 width breaks without max width
-              // https://github.com/philipwalton/flexbugs/issues/3
-              maxWidth: flexBasis,
               paddingLeft: firstCol ? 0 : `${columnGap.value / 2}${columnGap.unit}`,
               paddingRight: lastCol ? 0 : `${columnGap.value / 2}${columnGap.unit}`,
               paddingTop: firstRow ? 0 : `${rowGap.value / 2}${rowGap.unit}`,

--- a/packages/runtime/src/next/components/tests/components/__snapshots__/box-component-rendering.test.tsx.snap
+++ b/packages/runtime/src/next/components/tests/components/__snapshots__/box-component-rendering.test.tsx.snap
@@ -212,13 +212,46 @@ exports[`correctly renders box component with background image 1`] = `
   }
 }
 
-.emotion-11 {
-  display: flex;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  width: 100%;
+@media only screen and (min-width: 769px) {
+  .emotion-11 {
+    display: flex;
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+    -webkit-box-flex-wrap: wrap;
+    -webkit-flex-wrap: wrap;
+    -ms-flex-wrap: wrap;
+    flex-wrap: wrap;
+    width: 100%;
+  }
+}
+
+@media only screen and (min-width: 576px) and (max-width: 768px) {
+  .emotion-11 {
+    display: flex;
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+    -webkit-box-flex-wrap: wrap;
+    -webkit-flex-wrap: wrap;
+    -ms-flex-wrap: wrap;
+    flex-wrap: wrap;
+    width: 100%;
+  }
+}
+
+@media only screen and (max-width: 575px) {
+  .emotion-11 {
+    display: flex;
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+    -webkit-box-flex-wrap: wrap;
+    -webkit-flex-wrap: wrap;
+    -ms-flex-wrap: wrap;
+    flex-wrap: wrap;
+    width: 100%;
+  }
 }
 
 @media only screen and (min-width: 769px) {

--- a/packages/runtime/src/next/components/tests/components/__snapshots__/button-component-rendering.test.tsx.snap
+++ b/packages/runtime/src/next/components/tests/components/__snapshots__/button-component-rendering.test.tsx.snap
@@ -200,19 +200,22 @@ exports[`correctly renders button component with link 1`] = `
 
 @media only screen and (min-width: 769px) {
   .emotion-1 {
-    width: auto;
+    width: fit-content;
+    min-width: 20px;
   }
 }
 
 @media only screen and (min-width: 576px) and (max-width: 768px) {
   .emotion-1 {
-    width: auto;
+    width: fit-content;
+    min-width: 20px;
   }
 }
 
 @media only screen and (max-width: 575px) {
   .emotion-1 {
-    width: auto;
+    width: fit-content;
+    min-width: 20px;
   }
 }
 

--- a/packages/runtime/src/next/tests/server.api-handler-manifest.test.ts
+++ b/packages/runtime/src/next/tests/server.api-handler-manifest.test.ts
@@ -51,6 +51,7 @@ describe('MakeswiftApiHandler', () => {
         webhook: true,
         localizedPagesOnlineByDefault: true,
         previewToken: true,
+        styleWidthAuto: true,
       })
     })
   })

--- a/packages/runtime/src/runtimes/react/controls/style.ts
+++ b/packages/runtime/src/runtimes/react/controls/style.ts
@@ -50,9 +50,12 @@ export function styleV1Css(
         style?.borderRadius,
         style?.textStyle,
       ] as const,
-      ([width, margin, padding, border, borderRadius, textStyle]) => ({
+      ([width, margin, padding, border, borderRadius, textStyle]) => {
+        const widthStr = widthToString(width)
+        return {
         ...(properties.includes(Style.Width) && {
-          width: widthToString(width) ?? '100%',
+          width: widthStr ?? '100%',
+          ...(widthStr === 'fit-content' && { minWidth: '20px' }),
         }),
         ...(properties.includes(Style.Margin) &&
           marginPropertyDataToStyle(margin ?? defaultMargin, defaultMargin)),
@@ -82,12 +85,14 @@ export function styleV1Css(
           textTransform: textStyle?.textTransform ?? [],
           fontStyle: textStyle?.fontStyle ?? [],
         }),
-      }),
+      }},
     ),
   }
 
   function widthToString(widthProperty: WidthPropertyData | undefined): string | null {
     if (widthProperty == null) return null
+
+    if (widthProperty === 'auto') return 'fit-content'
 
     return lengthPercentageDataToString(widthProperty)
   }

--- a/packages/runtime/src/runtimes/react/legacy-controls.tsx
+++ b/packages/runtime/src/runtimes/react/legacy-controls.tsx
@@ -78,7 +78,12 @@ function useWidthStyle(
 ): string {
   const value = getWidthPropControllerDataResponsiveLengthData(data)
 
-  return useStyle(useResponsiveWidth(value, descriptor.options.defaultValue))
+  return useStyle(
+    useResponsiveWidth(value, {
+      defaultValue: descriptor.options.defaultValue,
+      minWidth: descriptor.options.minWidth,
+    }),
+  )
 }
 
 function usePaddingStyle(data: PaddingPropControllerData | undefined): string {

--- a/packages/runtime/src/state/__tests__/fixtures/serialized-descriptors-from-builder.ts
+++ b/packages/runtime/src/state/__tests__/fixtures/serialized-descriptors-from-builder.ts
@@ -892,7 +892,7 @@ export const getMockedSerializedDescriptorsFromBuilder: (
       type: 'ResponsiveLength',
       options: {
         label: 'Height',
-        options: [{ icon: 'Px16', label: 'Pixels', value: 'px' }],
+        options: [{ label: 'px', value: 'px' }],
         defaultValue: { unit: 'px', value: 1 },
       },
       version: 1,


### PR DESCRIPTION
Introduces support for an "auto" unit for width controls across the codebase, allowing components to use a width that maps to CSS `fit-content`, while images use their intrinsic width for "auto". Images and Buttons will have "allowAuto" on by default, which will match how they've always been displayed in the canvas when dropped in.


https://github.com/user-attachments/assets/5a4cad10-95bd-445b-8ef3-8d5250fbca45

