### PR TITLE
fix: receive 200 response from element tree API

### DIFF
--- a/.changeset/eleven-windows-fetch.md
+++ b/.changeset/eleven-windows-fetch.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+Return 200 response from Makeswift API for missing element trees

--- a/packages/runtime/src/client/index.ts
+++ b/packages/runtime/src/client/index.ts
@@ -153,6 +153,11 @@ const makeswiftComponentDocumentSchema = z.object({
 
 export type MakeswiftComponentDocument = z.infer<typeof makeswiftComponentDocumentSchema>
 
+// When the `unstable_enforceSuccess` query string param is set, the element
+// tree endpoint responds with this body and a 200 status instead of a 404 when
+// the tree can't be found.
+const elementTreeNotFoundSchema = z.object({ notFound: z.literal(true) })
+
 const makeswiftComponentDocumentFallbackSchema = z.object({
   id: z.string(),
   locale: z.string().nullable(),
@@ -1050,57 +1055,78 @@ export class MakeswiftClient {
       allowLocaleFallback?: boolean
     },
   ): Promise<MakeswiftComponentSnapshot> {
-    const searchParams = new URLSearchParams()
-    if (locale) searchParams.set('locale', locale)
-
     const siteVersion = await siteVersionPromise
     const key = deterministicUUID({ id, locale, seed: this.apiKey.split('-').at(0) })
     const baseLocaleWasRequested = locale == null
     const canAttemptLocaleFallback = !baseLocaleWasRequested && allowLocaleFallback
 
-    let response
-    const responseForRequestedLocale = await this.fetch(
-      `v2/element-trees/${encodeURIComponent(id)}?${searchParams.toString()}`,
-      siteVersion,
-    )
+    const requestElementTree = (includeLocale: boolean) => {
+      const searchParams = new URLSearchParams()
+      if (includeLocale && locale) searchParams.set('locale', locale)
+      // Opt into the behavior where a missing element tree is returned as a 200
+      // with a `{ notFound: true }` body instead of a 404, so the response can
+      // be cached like any other successful request.
+      searchParams.set('unstable_enforceSuccess', 'true')
 
-    if (responseForRequestedLocale.status === 404 && canAttemptLocaleFallback) {
-      await failedResponseBody(responseForRequestedLocale)
-      response = await this.fetch(`v2/element-trees/${encodeURIComponent(id)}`, siteVersion)
-    } else {
-      response = responseForRequestedLocale
+      return this.fetch(
+        `v2/element-trees/${encodeURIComponent(id)}?${searchParams.toString()}`,
+        siteVersion,
+      )
     }
 
-    if (!response.ok) {
-      // See comment on `failedResponseBody` for why we always consume the
-      // response body of failed responses.
-      const failedBody = await failedResponseBody(response)
+    // Resolves a response into the parsed document, or `null` when the element
+    // tree wasn't found. "Not found" is signaled either by the
+    // `{ notFound: true }` body (when `unstable_enforceSuccess` is honored) or
+    // by a legacy 404 status (in case the endpoint doesn't honor the param).
+    const parseElementTreeResponse = async (
+      response: Response,
+    ): Promise<MakeswiftComponentDocument | null> => {
       if (response.status === 404) {
-        return {
-          document: {
-            id,
-            locale: locale ?? null,
-            data: null,
-          },
-          key,
-          cacheData: CacheData.empty(),
-          meta: {
-            allowLocaleFallback,
-            requestedLocale: locale ?? null,
-          },
-        }
+        // See comment on `failedResponseBody` for why we always consume the
+        // response body of failed responses.
+        await failedResponseBody(response)
+        return null
       }
 
-      console.error(`Failed to get component snapshot for '${id}':`, {
-        response: failedBody,
-        siteVersion,
-        locale,
-      })
+      if (!response.ok) {
+        const failedBody = await failedResponseBody(response)
+        console.error(`Failed to get component snapshot for '${id}':`, {
+          response: failedBody,
+          siteVersion,
+          locale,
+        })
 
-      throw new Error(`Failed to get component snapshot for '${id}': ${responseError(response)}`)
+        throw new Error(`Failed to get component snapshot for '${id}': ${responseError(response)}`)
+      }
+
+      const json = await response.json()
+      if (elementTreeNotFoundSchema.safeParse(json).success) return null
+
+      return makeswiftComponentDocumentSchema.parse(json)
     }
 
-    const document = makeswiftComponentDocumentSchema.parse(await response.json())
+    let document = await parseElementTreeResponse(await requestElementTree(true))
+
+    if (document == null && canAttemptLocaleFallback) {
+      document = await parseElementTreeResponse(await requestElementTree(false))
+    }
+
+    if (document == null) {
+      return {
+        document: {
+          id,
+          locale: locale ?? null,
+          data: null,
+        },
+        key,
+        cacheData: CacheData.empty(),
+        meta: {
+          allowLocaleFallback,
+          requestedLocale: locale ?? null,
+        },
+      }
+    }
+
     const cacheData = await this.introspect(document.data, siteVersion, locale ?? null)
 
     return {

--- a/packages/runtime/src/client/tests/client.get-component-snapshot.test.ts
+++ b/packages/runtime/src/client/tests/client.get-component-snapshot.test.ts
@@ -44,6 +44,96 @@ describe('getComponentSnapshot using v2 element tree endpoint', () => {
     expect(result.document.data).toBeNull()
   })
 
+  test('passes the unstable_enforceSuccess query string param', async () => {
+    // Arrange
+    const client = createTestClient()
+    const treeId = 'myTree'
+    const httpHandler = jest.fn(({ request }) => {
+      void request
+      return HttpResponse.json({ notFound: true }, { status: 200 })
+    })
+    server.use(http.get(`${baseUrl}/${treeId}`, httpHandler, { once: true }))
+
+    // Act
+    await client.getComponentSnapshot(treeId, {
+      siteVersion: TestWorkingSiteVersion,
+    })
+
+    // Assert
+    const requestUrl = new URL(httpHandler.mock.calls[0][0].request.url)
+    expect(requestUrl.searchParams.get('unstable_enforceSuccess')).toBe('true')
+  })
+
+  test('returns null document data on a { notFound: true } response', async () => {
+    // Arrange
+    const client = createTestClient()
+    const treeId = 'myTree'
+    server.use(
+      http.get(`${baseUrl}/${treeId}`, () => HttpResponse.json({ notFound: true }, { status: 200 }), {
+        once: true,
+      }),
+    )
+
+    // Act
+    const result = await client.getComponentSnapshot(treeId, {
+      siteVersion: TestWorkingSiteVersion,
+    })
+
+    // Assert
+    expect(result.document).not.toBeNull()
+    expect(result.document.id).toBe(treeId)
+    expect(result.document.data).toBeNull()
+  })
+
+  test('performs locale fallback after a { notFound: true } response for a locale variant tree', async () => {
+    // Arrange
+    const client = createTestClient()
+    const localeToTest = 'fr-FR'
+    const treeId = 'myTree123'
+    const elementTreeKey = 'abc123'
+    const document: MakeswiftComponentDocument = {
+      id: treeId,
+      name: 'myElementTree',
+      data: {
+        type: 'myType',
+        key: elementTreeKey,
+        props: {},
+      },
+      locale: null,
+      siteId: 'mySiteId',
+      inheritsFromParent: false,
+    }
+
+    const httpHandler = jest.fn(({ request }) => {
+      const { searchParams } = new URL(request.url)
+      if (searchParams.get('locale') === localeToTest) {
+        return HttpResponse.json({ notFound: true }, { status: 200 })
+      }
+
+      return HttpResponse.json(document, { status: 200 })
+    })
+
+    server.use(
+      http.get(`${baseUrl}/${encodeURIComponent(treeId)}`, httpHandler),
+      graphql.operation(() => HttpResponse.json({})),
+    )
+
+    // Act
+    const result = await client.getComponentSnapshot(treeId, {
+      siteVersion: TestWorkingSiteVersion,
+      locale: localeToTest,
+    })
+
+    // Assert
+    expect(result.document.data).not.toBeNull()
+    expect(result.document.data?.key).toBe(elementTreeKey)
+    expect(result.document.locale).toBeNull()
+
+    expect(httpHandler).toHaveBeenCalledTimes(2)
+    expect(httpHandler.mock.calls[0][0].request.url).toContain(`locale=${localeToTest}`)
+    expect(httpHandler.mock.calls[1][0].request.url).not.toContain('locale=')
+  })
+
   test('throws on errors other than 404', async () => {
     // Arrange
     const client = createTestClient()

--- a/packages/runtime/src/next/client.ts
+++ b/packages/runtime/src/next/client.ts
@@ -22,8 +22,9 @@ export class Makeswift extends MakeswiftClient {
     return this.getSiteVersion(previewData) != null
   }
 
-  fetchOptions(_siteVersion: SiteVersion): Record<string, unknown> {
+  fetchOptions(siteVersion: SiteVersion): Record<string, unknown> {
     return {
+      cache: siteVersion ? 'no-store' : 'force-cache',
       next: {
         tags: [MAKESWIFT_CACHE_TAG],
       },


### PR DESCRIPTION
Updates the getComponentSnapshot to pass a QSP that forces the endpoint to return a 200 response when the element tree is not found.

Will make it easier for certain clients to cache responses.