### PR TITLE
fix(hono-react): move `renderHtml` to a separate entry point

### DIFF
--- a/.changeset/pretty-oranges-type.md
+++ b/.changeset/pretty-oranges-type.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/hono-react': minor
+---
+
+fix: move `renderHtml` to a separate entry point so `hono-react/server` can be imported in environments where `react-dom/server` does not provide `renderToReadableStream`.

--- a/packages/hono-react/package.json
+++ b/packages/hono-react/package.json
@@ -24,6 +24,11 @@
       "require": "./dist/cjs/server/index.js",
       "import": "./dist/esm/server/index.js",
       "types": "./dist/types/server/index.d.ts"
+    },
+    "./server/render": {
+      "require": "./dist/cjs/server/render.js",
+      "import": "./dist/esm/server/render.js",
+      "types": "./dist/types/server/render.d.ts"
     }
   },
   "scripts": {

--- a/packages/hono-react/src/server/index.ts
+++ b/packages/hono-react/src/server/index.ts
@@ -1,4 +1,3 @@
 export { createApiHandler } from './api-handler'
 export { createPreviewMiddleware } from './preview'
-export { renderHtml } from './render'
 export { getSiteVersion } from './site-version'


### PR DESCRIPTION
Move `renderHtml` to a separate entry point so `hono-react/server` can be imported in environments where `react-dom/server` does not provide `renderToReadableStream` (e.g. Node.js). Breaking change.