### PR TITLE
fix: fully await revalidation in pages router

### DIFF
--- a/.changeset/eighty-grapes-repeat.md
+++ b/.changeset/eighty-grapes-repeat.md
@@ -1,0 +1,5 @@
+---
+"@makeswift/runtime": patch
+---
+
+fix: await Next.js revalidation within Pages Router revalidation handler.

--- a/packages/runtime/src/next/api-handler/config/pages-router.ts
+++ b/packages/runtime/src/next/api-handler/config/pages-router.ts
@@ -32,7 +32,7 @@ export async function config({
 
     revalidationHandler: async (path?: string): Promise<void> => {
       if (path != null) {
-        res.revalidate(path)
+        await res.revalidate(path)
       } else {
         // No-op, Pages Router does not support tag-based revalidation
       }


### PR DESCRIPTION
Updates the Pages Router revalidation handler to fully await page revalidation.