### PR TITLE
refactor(runtime): move GraphQL ops into a separate client

### DIFF
--- a/.changeset/many-worlds-return.md
+++ b/.changeset/many-worlds-return.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+refactor: move GraphQL ops into a separate client

--- a/packages/runtime/src/api/client.ts
+++ b/packages/runtime/src/api/client.ts
@@ -13,13 +13,6 @@ import {
   APIResourceType,
 } from './types'
 
-import { GraphQLClient } from './graphql/client'
-import { CreateTableRecordMutation } from './graphql/documents'
-import {
-  CreateTableRecordMutationResult,
-  CreateTableRecordMutationVariables,
-} from './graphql/generated/types'
-
 import { ApiResourcesClient } from './api-resources-client'
 
 export { CacheData } from './api-resources-client'
@@ -44,15 +37,12 @@ export { CacheData } from './api-resources-client'
  * snapshot for use in the builder, not the lives pages.
  */
 export class MakeswiftHostApiClient extends ApiResourcesClient {
-  readonly graphqlClient: GraphQLClient
   readonly fetch: HttpFetch
 
   constructor({
-    uri,
     fetch,
     preloadedState,
   }: {
-    uri: string
     fetch: HttpFetch
     preloadedState: Partial<ApiClientState>
   }) {
@@ -60,7 +50,6 @@ export class MakeswiftHostApiClient extends ApiResourcesClient {
       store: configureClientStore({ preloadedState }),
     })
 
-    this.graphqlClient = new GraphQLClient(uri)
     this.fetch = fetch
   }
 
@@ -110,12 +99,5 @@ export class MakeswiftHostApiClient extends ApiResourcesClient {
 
   async fetchTable(tableId: string): Promise<Table | null> {
     return await this.store.dispatch(fetchAPIResource(APIResourceType.Table, tableId, this.fetch))
-  }
-
-  async createTableRecord(tableId: string, columns: any): Promise<void> {
-    await this.graphqlClient.request<
-      CreateTableRecordMutationResult,
-      CreateTableRecordMutationVariables
-    >(CreateTableRecordMutation, { input: { data: { tableId, columns } } })
   }
 }

--- a/packages/runtime/src/api/graphql-api-client.ts
+++ b/packages/runtime/src/api/graphql-api-client.ts
@@ -1,0 +1,21 @@
+import { GraphQLClient } from './graphql/client'
+import { CreateTableRecordMutation } from './graphql/documents'
+import {
+  CreateTableRecordMutationResult,
+  CreateTableRecordMutationVariables,
+} from './graphql/generated/types'
+
+export class MakeswiftGraphQLApiClient {
+  readonly graphqlClient: GraphQLClient
+
+  constructor({ endpoint }: { endpoint: string }) {
+    this.graphqlClient = new GraphQLClient(endpoint)
+  }
+
+  async createTableRecord(tableId: string, columns: any): Promise<void> {
+    await this.graphqlClient.request<
+      CreateTableRecordMutationResult,
+      CreateTableRecordMutationVariables
+    >(CreateTableRecordMutation, { input: { data: { tableId, columns } } })
+  }
+}

--- a/packages/runtime/src/components/builtin/Form/Form.tsx
+++ b/packages/runtime/src/components/builtin/Form/Form.tsx
@@ -40,7 +40,7 @@ import { cx } from '@emotion/css'
 import { useResponsiveGridItem, useResponsiveStyle } from '../../utils/responsive-style'
 import { type ResponsiveColor } from '../../utils/types'
 
-import { useMakeswiftHostApiClient } from '../../../runtimes/react/host-api-client'
+import { useMakeswiftGraphQLApiClient } from '../../../runtimes/react/hooks/use-graphql-api-client'
 import { useStyle } from '../../../runtimes/react/use-style'
 import { useTable } from '../../../runtimes/react/hooks/makeswift-api'
 import {
@@ -276,7 +276,7 @@ const Form = forwardRef(function Form(
   const fields = useMemo(() => fieldsProp?.fields ?? [], [fieldsProp])
   const grid = useMemo(() => fieldsProp?.grid ?? [], [fieldsProp])
   const table = useTable(tableId ?? null)
-  const client = useMakeswiftHostApiClient()
+  const client = useMakeswiftGraphQLApiClient()
   const [refEl, setRefEl] = useState<HTMLElement | null>(null)
   const [propControllers, setPropControllers] =
     useState<DescriptorsPropControllers<Descriptors> | null>(null)

--- a/packages/runtime/src/runtimes/react/components/GoogleFontLink.tsx
+++ b/packages/runtime/src/runtimes/react/components/GoogleFontLink.tsx
@@ -5,7 +5,7 @@ import { useMemo, useSyncExternalStore } from 'react'
 import { type Font } from '../../../client'
 import { type Site } from '../../../api'
 import { useIsInBuilder } from '../hooks/use-is-in-builder'
-import { useMakeswiftHostApiClient } from '../host-api-client'
+import { useApiResourcesClient } from '../hooks/use-api-resources-client'
 
 import {
   getGoogleFontsParamFromFonts,
@@ -21,7 +21,7 @@ type Props = {
 
 /**
  * This is experimental, and some of the logic here is duplicated in the `PageHead` component.
- * 
+ *
  * For now we want to avoid putting this on the critical path for rendering Makeswift pages, so we haven't
  * deduplicated the two.
  */
@@ -42,13 +42,11 @@ export function GoogleFontLink({ fonts, siteId }: Props) {
     return null
   }
 
-  return (
-    <PageLink precedence="medium" rel="stylesheet" href={url} />
-  )
+  return <PageLink precedence="medium" rel="stylesheet" href={url} />
 }
 
 function useCachedSite(siteId: string | null): Site | null {
-  const client = useMakeswiftHostApiClient()
+  const client = useApiResourcesClient()
   const getSnapshot = () => (siteId == null ? null : client.readSite(siteId))
 
   return useSyncExternalStore(client.subscribe, getSnapshot, getSnapshot)

--- a/packages/runtime/src/runtimes/react/components/hooks/use-page-snippets.ts
+++ b/packages/runtime/src/runtimes/react/components/hooks/use-page-snippets.ts
@@ -6,7 +6,7 @@ import { type Page as PageType } from '../../../../api'
 import deepEqual from '../../../../utils/deepEqual'
 
 import { useIsInBuilder } from '../../hooks/use-is-in-builder'
-import { useMakeswiftHostApiClient } from '../../host-api-client'
+import { useApiResourcesClient } from '../../hooks/use-api-resources-client'
 
 const filterUsedSnippetProperties = ({
   code,
@@ -61,7 +61,7 @@ export function usePageSnippets({ page }: { page: MakeswiftPageDocument }) {
 }
 
 function useCachedPage(pageId: string | null): PageType | null {
-  const client = useMakeswiftHostApiClient()
+  const client = useApiResourcesClient()
   const getSnapshot = () => (pageId == null ? null : client.readPage(pageId))
 
   const page = useSyncExternalStore(client.subscribe, getSnapshot, getSnapshot)

--- a/packages/runtime/src/runtimes/react/components/page/PageHead.tsx
+++ b/packages/runtime/src/runtimes/react/components/page/PageHead.tsx
@@ -3,8 +3,7 @@ import { useMemo, useSyncExternalStore, ReactNode } from 'react'
 import { type MakeswiftPageDocument } from '../../../../client'
 import { type Site } from '../../../../api'
 
-import { useMakeswiftHostApiClient } from '../../host-api-client'
-
+import { useApiResourcesClient } from '../../hooks/use-api-resources-client'
 import { useFrameworkContext } from '../hooks/use-framework-context'
 import { useIsInBuilder } from '../../hooks/use-is-in-builder'
 import { usePageSnippets } from '../hooks/use-page-snippets'
@@ -130,7 +129,7 @@ export function PageHead({ document: page, metadata = {} }: Props): ReactNode {
 }
 
 function useCachedSite(siteId: string | null): Site | null {
-  const client = useMakeswiftHostApiClient()
+  const client = useApiResourcesClient()
   const getSnapshot = () => (siteId == null ? null : client.readSite(siteId))
 
   const site = useSyncExternalStore(client.subscribe, getSnapshot, getSnapshot)

--- a/packages/runtime/src/runtimes/react/hooks/makeswift-api.ts
+++ b/packages/runtime/src/runtimes/react/hooks/makeswift-api.ts
@@ -11,11 +11,11 @@ import {
   Typography,
 } from '../../../api'
 
-import { useMakeswiftHostApiClient } from '../host-api-client'
+import { useApiResourcesClient } from './use-api-resources-client'
 import { useDocumentLocale } from './use-document-context'
 
 export function useSwatch(swatchId: string | null): Swatch | null {
-  const client = useMakeswiftHostApiClient()
+  const client = useApiResourcesClient()
   const readSwatch = () => (swatchId == null ? null : client.readSwatch(swatchId))
   const swatch = useSyncExternalStore(client.subscribe, readSwatch, readSwatch)
 
@@ -27,7 +27,7 @@ export function useSwatch(swatchId: string | null): Swatch | null {
 }
 
 export function useSwatches(swatchIds: string[]): (Swatch | null)[] {
-  const client = useMakeswiftHostApiClient()
+  const client = useApiResourcesClient()
   const lastSnapshot = useRef<(Swatch | null)[] | null>(null)
 
   function getSnapshot() {
@@ -54,7 +54,7 @@ export function useSwatches(swatchIds: string[]): (Swatch | null)[] {
 }
 
 export function useFile(fileId: string | null): File | null {
-  const client = useMakeswiftHostApiClient()
+  const client = useApiResourcesClient()
   const readFile = () => (fileId == null ? null : client.readFile(fileId))
   const file = useSyncExternalStore(client.subscribe, readFile, readFile)
 
@@ -66,7 +66,7 @@ export function useFile(fileId: string | null): File | null {
 }
 
 export function useFiles(fileIds: string[]): (File | null)[] {
-  const client = useMakeswiftHostApiClient()
+  const client = useApiResourcesClient()
   const lastSnapshot = useRef<(File | null)[] | null>(null)
 
   function getSnapshot() {
@@ -93,7 +93,7 @@ export function useFiles(fileIds: string[]): (File | null)[] {
 }
 
 export function useTypography(typographyId: string | null): Typography | null {
-  const client = useMakeswiftHostApiClient()
+  const client = useApiResourcesClient()
   const readTypography = () => (typographyId == null ? null : client.readTypography(typographyId))
   const typography = useSyncExternalStore(client.subscribe, readTypography, readTypography)
 
@@ -105,7 +105,7 @@ export function useTypography(typographyId: string | null): Typography | null {
 }
 
 export function useGlobalElement(globalElementId: string | null): GlobalElement | null {
-  const client = useMakeswiftHostApiClient()
+  const client = useApiResourcesClient()
   const readGlobalElement = () =>
     globalElementId == null ? null : client.readGlobalElement(globalElementId)
   const globalElement = useSyncExternalStore(client.subscribe, readGlobalElement, readGlobalElement)
@@ -121,7 +121,7 @@ export function useLocalizedGlobalElement(
   locale: string | null,
   globalElementId: string | null,
 ): LocalizedGlobalElement | null {
-  const client = useMakeswiftHostApiClient()
+  const client = useApiResourcesClient()
   const readLocalizedGlobalElement = () =>
     locale == null || globalElementId == null
       ? null
@@ -143,7 +143,7 @@ export function useLocalizedGlobalElement(
 }
 
 export function usePagePathnameSlice(pageId: string | null): PagePathnameSlice | null {
-  const client = useMakeswiftHostApiClient()
+  const client = useApiResourcesClient()
   const locale = useDocumentLocale()
 
   const readPagePathnameSlice = () =>
@@ -163,7 +163,7 @@ export function usePagePathnameSlice(pageId: string | null): PagePathnameSlice |
 }
 
 export function useTable(tableId: string | null): Table | null {
-  const client = useMakeswiftHostApiClient()
+  const client = useApiResourcesClient()
   const readTable = () => (tableId == null ? null : client.readTable(tableId))
   const table = useSyncExternalStore(client.subscribe, readTable, readTable)
 

--- a/packages/runtime/src/runtimes/react/hooks/use-api-resources-client.tsx
+++ b/packages/runtime/src/runtimes/react/hooks/use-api-resources-client.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+import { ApiResourcesClient } from '../../../api/api-resources-client'
+
+import { useStore } from './use-store'
+
+export function useApiResourcesClient(): ApiResourcesClient {
+  return useStore().apiResourcesClient
+}

--- a/packages/runtime/src/runtimes/react/hooks/use-cache-data.ts
+++ b/packages/runtime/src/runtimes/react/hooks/use-cache-data.ts
@@ -2,10 +2,10 @@ import { useMemo } from 'react'
 import { type CacheData } from '../../../api/client'
 import { updateAPIClientCache } from '../../../state/actions/internal/read-write-actions'
 
-import { useMakeswiftHostApiClient } from '../host-api-client'
+import { useApiResourcesClient } from './use-api-resources-client'
 
 export function useCacheData(cacheData: CacheData) {
-  const { store: apiStore } = useMakeswiftHostApiClient()
+  const { store: apiStore } = useApiResourcesClient()
 
   // We perform cache hydration immediately on render - this is safe to do per
   // render because updating the API cache is idempotent. For precedence, see:

--- a/packages/runtime/src/runtimes/react/hooks/use-graphql-api-client.tsx
+++ b/packages/runtime/src/runtimes/react/hooks/use-graphql-api-client.tsx
@@ -1,0 +1,10 @@
+'use client'
+
+import { MakeswiftGraphQLApiClient } from '../../../api/graphql-api-client'
+
+import { useReactRuntime } from './use-react-runtime'
+
+export function useMakeswiftGraphQLApiClient(): MakeswiftGraphQLApiClient {
+  const runtime = useReactRuntime()
+  return new MakeswiftGraphQLApiClient({ endpoint: runtime.graphqlApiEndpoint })
+}

--- a/packages/runtime/src/runtimes/react/hooks/use-resource-resolver.ts
+++ b/packages/runtime/src/runtimes/react/hooks/use-resource-resolver.ts
@@ -1,15 +1,15 @@
 import { useMemo } from 'react'
 import { type ResourceResolver } from '@makeswift/controls'
 
-import { useMakeswiftHostApiClient } from '../host-api-client'
 import { createResourceResolver } from '../resource-resolver'
 
-import { useStore } from './use-store'
+import { useApiResourcesClient } from './use-api-resources-client'
 import { useDocumentKey, useDocumentLocale } from './use-document-context'
+import { useStore } from './use-store'
 
 export function useResourceResolver(): ResourceResolver {
   const store = useStore()
-  const apiClient = useMakeswiftHostApiClient()
+  const apiClient = useApiResourcesClient()
 
   const documentKey = useDocumentKey()
   const locale = useDocumentLocale()

--- a/packages/runtime/src/runtimes/react/host-api-client.tsx
+++ b/packages/runtime/src/runtimes/react/host-api-client.tsx
@@ -1,9 +1,0 @@
-'use client'
-
-import { MakeswiftHostApiClient } from '../../api/client'
-
-import { useStore } from './hooks/use-store'
-
-export function useMakeswiftHostApiClient(): MakeswiftHostApiClient {
-  return useStore().hostApiClient
-}

--- a/packages/runtime/src/runtimes/react/runtime-core.ts
+++ b/packages/runtime/src/runtimes/react/runtime-core.ts
@@ -77,12 +77,8 @@ export class RuntimeCore {
     const key = storeCacheKey({ siteVersion, locale })
 
     const createStore = () => {
-      // host API client includes an in-memory cache of the site's resources and thus also has to be versioned
-      const hostApiClient = new MakeswiftHostApiClient({
-        uri: new URL('graphql', this.apiOrigin).href,
-        fetch: this.fetch,
-        preloadedState: { siteVersion, locale },
-      })
+      // API resources client includes an in-memory cache of the site's resources and thus also has to be versioned
+      const apiResourcesClient = this.createApiResourcesClient({ siteVersion, locale })
 
       // TODO: we need to decouple editability from the site version; specifically, previewing
       // a draft version of the site should not lead to switching to the read-write state
@@ -91,7 +87,7 @@ export class RuntimeCore {
       return configureReadWriteStore({
         name: `Runtime read-write store (site version: ${key})`,
         appOrigin: this.appOrigin,
-        hostApiClient,
+        apiResourcesClient,
         preloadedState: { ...this.protoStore.getState(), siteVersion, isReadOnly, locale },
       })
     }
@@ -143,6 +139,20 @@ export class RuntimeCore {
 
   getBreakpoints(): Breakpoints {
     return getBreakpoints(this.protoStore.getState())
+  }
+
+  get graphqlApiEndpoint(): string {
+    return new URL('graphql', this.apiOrigin).href
+  }
+
+  private createApiResourcesClient(preloadedState: {
+    siteVersion: SiteVersion | null
+    locale: string | undefined
+  }) {
+    return new MakeswiftHostApiClient({
+      fetch: this.fetch,
+      preloadedState,
+    })
   }
 
   private shouldUsePersistentStore(key: string): boolean {

--- a/packages/runtime/src/state/__tests__/store.read-write-state.test.ts
+++ b/packages/runtime/src/state/__tests__/store.read-write-state.test.ts
@@ -35,8 +35,8 @@ const createStore = ({
   configureReadWriteStore({
     name: 'test-store',
     appOrigin: TestOrigins.appOrigin,
-    hostApiClient: {
-      makeswiftApiClient: {
+    apiResourcesClient: {
+      store: {
         dispatch: jest.fn(),
       },
     } as any,

--- a/packages/runtime/src/state/middleware/makeswift-api-client-sync.ts
+++ b/packages/runtime/src/state/middleware/makeswift-api-client-sync.ts
@@ -1,13 +1,13 @@
 import { type Middleware } from '@reduxjs/toolkit'
 
-import { MakeswiftHostApiClient } from '../../api/client'
+import { ApiResourcesClient } from '../../api/api-resources-client'
 
 import { type Action } from '../actions'
 import { actionMiddleware } from '../toolkit'
 import { type State, type Dispatch } from '../unified-state'
 
 export function makeswiftApiClientSyncMiddleware(
-  client: MakeswiftHostApiClient,
+  client: ApiResourcesClient,
 ): Middleware<Dispatch, State, Dispatch> {
   return actionMiddleware(() => next => {
     return (action: Action) => {

--- a/packages/runtime/src/state/store.ts
+++ b/packages/runtime/src/state/store.ts
@@ -8,7 +8,7 @@ import {
   compose,
 } from '@reduxjs/toolkit'
 
-import { MakeswiftHostApiClient } from '../api/client'
+import { ApiResourcesClient } from '../api/api-resources-client'
 
 import { actionMiddleware, middlewareOptions, devToolsConfig } from './toolkit'
 import { BuilderActionTypes } from './builder-api/actions'
@@ -157,7 +157,7 @@ export function conditionalReadWriteMiddleware(
 }
 
 export interface ReadWriteStateMixin {
-  readonly hostApiClient: MakeswiftHostApiClient
+  readonly apiResourcesClient: ApiResourcesClient
 
   loadReadWriteStateIfNeeded(): Promise<() => void>
 }
@@ -172,12 +172,12 @@ function withMixin<M extends {}>(mixin: M): StoreEnhancer<M> {
 export function configureReadWriteStore({
   name,
   appOrigin,
-  hostApiClient,
+  apiResourcesClient,
   preloadedState,
 }: {
   name: string
   appOrigin: string
-  hostApiClient: MakeswiftHostApiClient
+  apiResourcesClient: ApiResourcesClient
   preloadedState: Partial<State>
 }) {
   const readWriteMiddlewareRef: ReadWriteMiddlewareRef = {
@@ -240,7 +240,7 @@ export function configureReadWriteStore({
     preloadedState,
 
     middleware: () => [
-      makeswiftApiClientSyncMiddleware(hostApiClient),
+      makeswiftApiClientSyncMiddleware(apiResourcesClient),
       conditionalReadWriteMiddleware(readWriteMiddlewareRef),
     ],
 
@@ -255,7 +255,7 @@ export function configureReadWriteStore({
         ),
 
         withMixin<ReadWriteStateMixin>({
-          hostApiClient,
+          apiResourcesClient,
           loadReadWriteStateIfNeeded: async () => {
             const { isReadOnly } = store.getState()
 


### PR DESCRIPTION
Decouple `MakeswiftHostApiClient`'s API resource caching/fetching from a GraphQL mutation used in form submissions. 

Form submissions smoke test:

https://github.com/user-attachments/assets/a86ab6c3-6fba-4028-b416-522caec61809


