### PR TITLE
refactor(runtime): `api/client` -> `api/host-api-resouces-client`

### DIFF
--- a/packages/runtime/src/api/host-api-resources-client.ts
+++ b/packages/runtime/src/api/host-api-resources-client.ts
@@ -36,7 +36,7 @@ export { CacheData } from './api-resources-client'
  * client of the host's API, not Makeswift's, intended to build and continuously maintain a realtime
  * snapshot for use in the builder, not the lives pages.
  */
-export class MakeswiftHostApiClient extends ApiResourcesClient {
+export class HostApiResourcesClient extends ApiResourcesClient {
   readonly fetch: HttpFetch
 
   constructor({

--- a/packages/runtime/src/client/index.ts
+++ b/packages/runtime/src/client/index.ts
@@ -21,7 +21,7 @@ import {
   TableQueryVariables,
 } from '../api/graphql/generated/types'
 
-import { CacheData } from '../api/client'
+import { CacheData } from '../api/api-resources-client'
 import { Descriptor as PropControllerDescriptor } from '../prop-controllers/descriptors'
 import {
   getElementChildren,

--- a/packages/runtime/src/client/tests/client.get-component-snapshots.test.ts
+++ b/packages/runtime/src/client/tests/client.get-component-snapshots.test.ts
@@ -5,7 +5,7 @@ import { createReactRuntime } from '../../runtimes/react/testing/react-runtime'
 
 import { server } from '../../mocks/server'
 import { TestWorkingSiteVersion } from '../../testing/fixtures'
-import { CacheData } from '../../api/client'
+import { CacheData } from '../../api/api-resources-client'
 
 const TEST_API_KEY = 'myApiKey'
 const runtime = createReactRuntime()
@@ -134,7 +134,11 @@ describe('unstable_getComponentSnapshots', () => {
         baseUrl,
         () =>
           HttpResponse.json(
-            { object: 'error', code: 'not_found', message: 'Element trees for requested version not found' },
+            {
+              object: 'error',
+              code: 'not_found',
+              message: 'Element trees for requested version not found',
+            },
             { status: 404 },
           ),
         { once: true },
@@ -161,7 +165,11 @@ describe('unstable_getComponentSnapshots', () => {
 
     const httpHandler = jest.fn(() =>
       HttpResponse.json(
-        { object: 'error', code: 'not_found', message: 'Element trees for requested version not found' },
+        {
+          object: 'error',
+          code: 'not_found',
+          message: 'Element trees for requested version not found',
+        },
         { status: 404 },
       ),
     )

--- a/packages/runtime/src/next/components/tests/controls/color-control/fixtures.ts
+++ b/packages/runtime/src/next/components/tests/controls/color-control/fixtures.ts
@@ -2,7 +2,7 @@ import { type ValueType } from '@makeswift/controls'
 import { ColorDefinition } from '@makeswift/controls'
 
 import { APIResourceType, type Swatch } from '../../../../../api'
-import { type CacheData } from '../../../../../api/client'
+import { type CacheData } from '../../../../../api/api-resources-client'
 
 type SwatchData = Omit<Swatch, 'id'>
 

--- a/packages/runtime/src/next/components/tests/controls/page-control-prop-rendering.tsx
+++ b/packages/runtime/src/next/components/tests/controls/page-control-prop-rendering.tsx
@@ -7,7 +7,7 @@ import { ServerInsertedHTMLContext } from 'next/navigation'
 
 import { type Data, type ValueType, type DataType, ControlDefinition } from '@makeswift/controls'
 
-import { type CacheData } from '../../../../api/client'
+import { type CacheData } from '../../../../api/api-resources-client'
 import { ElementData } from '../../../../state/read-only-state'
 import { setIsInBuilder } from '../../../../state/actions/internal/read-only-actions'
 import { ReactRuntime } from '../../../../runtimes/react/react-runtime'

--- a/packages/runtime/src/next/components/tests/controls/rich-text-v2-control/fixtures.tsx
+++ b/packages/runtime/src/next/components/tests/controls/rich-text-v2-control/fixtures.tsx
@@ -1,7 +1,7 @@
 import { APIResourceType, type Swatch, type Typography } from '../../../../../api'
 
 import * as Fixture from '../fixtures/rich-text-v2'
-import { type CacheData } from '../../../../../api/client'
+import { type CacheData } from '../../../../../api/api-resources-client'
 
 const swatchId = 'U3dhdGNoOmJkODYxMWM5LTNiZjItNDM3MS1iMmU4LTBmMmNlMDZjNDE1OA=='
 const swatch: Swatch = {

--- a/packages/runtime/src/next/testing/element-data.ts
+++ b/packages/runtime/src/next/testing/element-data.ts
@@ -5,7 +5,7 @@ import {
   type MakeswiftPageDocument,
   type MakeswiftComponentSnapshot,
 } from '../../client'
-import { CacheData } from '../../api/client'
+import { CacheData } from '../../api/api-resources-client'
 import { type ElementData } from '../../state/read-only-state'
 import { MakeswiftComponentType } from '../../components/builtin/constants'
 

--- a/packages/runtime/src/runtimes/react/hooks/use-cache-data.ts
+++ b/packages/runtime/src/runtimes/react/hooks/use-cache-data.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { type CacheData } from '../../../api/client'
+import { type CacheData } from '../../../api/api-resources-client'
 import { updateAPIClientCache } from '../../../state/actions/internal/read-write-actions'
 
 import { useApiResourcesClient } from './use-api-resources-client'

--- a/packages/runtime/src/runtimes/react/runtime-core.ts
+++ b/packages/runtime/src/runtimes/react/runtime-core.ts
@@ -1,6 +1,6 @@
 import { type SerializableReplacementContext } from '@makeswift/controls'
 
-import { MakeswiftHostApiClient } from '../../api/client'
+import { HostApiResourcesClient } from '../../api/host-api-resources-client'
 import { type HttpFetch } from '../../state/api-client/fetch-api-resource'
 import { type SiteVersion } from '../../api/site-version'
 
@@ -149,7 +149,7 @@ export class RuntimeCore {
     siteVersion: SiteVersion | null
     locale: string | undefined
   }) {
-    return new MakeswiftHostApiClient({
+    return new HostApiResourcesClient({
       fetch: this.fetch,
       preloadedState,
     })


### PR DESCRIPTION
Improve file & class naming + related cleanup; following up https://github.com/makeswift/makeswift/pull/1327. No semantic changes.