### PR TITLE
refactor(runtime): extract resources fetching etc into a REST API client

### DIFF
--- a/.changeset/sunny-monkeys-sing.md
+++ b/.changeset/sunny-monkeys-sing.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+refactor: extract resources fetching etc into a REST API client; removed two undocumented internal exports from the `@makeswift/runtime/client` entrypoint

--- a/packages/runtime/src/api/__tests__/rest-api-client.error-handling.test.ts
+++ b/packages/runtime/src/api/__tests__/rest-api-client.error-handling.test.ts
@@ -1,5 +1,5 @@
 import { HttpResponse } from 'msw'
-import { failedResponseBody } from '../../client'
+import { failedResponseBody } from '../rest-api-client'
 
 describe('failedResponseBody', () => {
   test('returns JSON for JSON responses', async () => {

--- a/packages/runtime/src/api/__tests__/rest-api-client.get-resources.test.ts
+++ b/packages/runtime/src/api/__tests__/rest-api-client.get-resources.test.ts
@@ -1,17 +1,17 @@
-import { MakeswiftClient } from '../../client'
+import { MakeswiftRestAPIClient } from '../rest-api-client'
 import { http, HttpResponse } from 'msw'
 
-import { createReactRuntime } from '../../runtimes/react/testing/react-runtime'
-
 import { server } from '../../mocks/server'
-import { TestWorkingSiteVersion } from '../../testing/fixtures'
+import { TestOrigins, TestWorkingSiteVersion } from '../../testing/fixtures'
 
 const TEST_API_KEY = 'xxx'
-const runtime = createReactRuntime()
-const baseUrl = `${runtime.apiOrigin}/v3`
+const baseUrl = `${TestOrigins.apiOrigin}/v3`
 
 function createTestClient() {
-  return new MakeswiftClient(TEST_API_KEY, { runtime })
+  return new MakeswiftRestAPIClient({
+    apiKey: TEST_API_KEY,
+    apiOrigin: TestOrigins.apiOrigin,
+  })
 }
 
 let consoleErrorSpy: jest.SpyInstance

--- a/packages/runtime/src/api/rest-api-client.ts
+++ b/packages/runtime/src/api/rest-api-client.ts
@@ -1,0 +1,231 @@
+import {
+  type GlobalElement,
+  type LocalizedGlobalElement,
+  type PagePathnameSlice,
+  type Swatch,
+  type Typography,
+} from './types'
+
+import { type SiteVersion } from './site-version'
+import * as Schema from './schema'
+
+export class MakeswiftRestAPIClient {
+  readonly apiKey: string
+  readonly apiOrigin: string
+
+  constructor({ apiKey, apiOrigin }: { apiKey: string; apiOrigin: string }) {
+    this.apiKey = apiKey
+    this.apiOrigin = apiOrigin
+  }
+
+  async getSwatch(swatchId: string, siteVersion: SiteVersion | null): Promise<Swatch | null> {
+    const response = await this.fetch(`v3/swatches/${swatchId}`, siteVersion)
+
+    if (!response.ok) {
+      const failedBody = await failedResponseBody(response)
+      if (response.status !== 404) {
+        console.error(`Failed to get swatch '${swatchId}'`, {
+          response: failedBody,
+          siteVersion,
+        })
+      }
+
+      return null
+    }
+
+    const swatch = await response.json()
+
+    return swatch
+  }
+
+  async getTypography(
+    typographyId: string,
+    siteVersion: SiteVersion | null,
+  ): Promise<Typography | null> {
+    const response = await this.fetch(`v3/typographies/${typographyId}`, siteVersion)
+
+    if (!response.ok) {
+      const failedBody = await failedResponseBody(response)
+      if (response.status !== 404) {
+        console.error(`Failed to get typography '${typographyId}'`, {
+          response: failedBody,
+          siteVersion,
+        })
+      }
+
+      return null
+    }
+
+    const typography = await response.json()
+
+    return typography
+  }
+
+  async getGlobalElement(
+    globalElementId: string,
+    siteVersion: SiteVersion | null,
+  ): Promise<GlobalElement | null> {
+    const response = await this.fetch(`v3/global-elements/${globalElementId}`, siteVersion)
+
+    if (!response.ok) {
+      const failedBody = await failedResponseBody(response)
+      if (response.status !== 404) {
+        console.error(`Failed to get global element '${globalElementId}'`, {
+          response: failedBody,
+          siteVersion,
+        })
+      }
+
+      return null
+    }
+
+    const globalElement = await response.json()
+
+    return globalElement
+  }
+
+  async getLocalizedGlobalElement(
+    globalElementId: string,
+    locale: string,
+    siteVersion: SiteVersion | null,
+  ): Promise<LocalizedGlobalElement | null> {
+    const response = await this.fetch(
+      `v3/localized-global-elements/${globalElementId}?locale=${locale}`,
+      siteVersion,
+    )
+
+    if (!response.ok) {
+      const failedBody = await failedResponseBody(response)
+      if (response.status !== 404) {
+        console.error(`Failed to get localized global element '${globalElementId}'`, {
+          response: failedBody,
+          siteVersion,
+          locale,
+        })
+      }
+
+      return null
+    }
+
+    const localizedGlobalElement = await response.json()
+
+    return localizedGlobalElement
+  }
+
+  async getPagePathnameSlices(
+    pageIds: string[],
+    siteVersion: SiteVersion | null,
+    { locale }: { locale?: string | null },
+  ): Promise<(PagePathnameSlice | null)[]> {
+    if (pageIds.length === 0) return []
+
+    const url = new URL(`v3/page-pathname-slices/bulk`, this.apiOrigin)
+
+    pageIds.forEach(id => url.searchParams.append('ids', id))
+    if (locale != null) url.searchParams.set('locale', locale)
+
+    const response = await this.fetch(url.pathname + url.search, siteVersion)
+
+    if (!response.ok) {
+      console.error(`Failed to get page pathname slice(s) for ${pageIds.join(', ')}`, {
+        response: await failedResponseBody(response),
+        siteVersion,
+        locale,
+      })
+
+      return []
+    }
+
+    const json = await response.json()
+
+    const pagePathnameSlices = Schema.pagePathnameSlices.parse(json)
+
+    // We're mapping the basePageId to be the id, because we're still using the GraphQL
+    // fragment as our APIResource. The id on the APIResource needs to match the pageId
+    // so that we can find the corresponding page pathname slice when we call getPagePathnameSlice(pageId).
+    // TODO: Update this once we move away from the GraphQL fragments.
+    return pagePathnameSlices.map(pagePathnameSlice => {
+      if (pagePathnameSlice == null) return null
+
+      return {
+        ...pagePathnameSlice,
+        id: pagePathnameSlice.basePageId,
+        localizedPathname: pagePathnameSlice.localizedPathname ?? null,
+      }
+    })
+  }
+
+  async getPagePathnameSlice(
+    pageId: string,
+    siteVersion: SiteVersion | null,
+    { locale }: { locale?: string } = {},
+  ): Promise<PagePathnameSlice | null> {
+    const pagePathnameSlices = await this.getPagePathnameSlices([pageId], siteVersion, { locale })
+
+    return pagePathnameSlices.at(0) ?? null
+  }
+
+  protected async fetch(
+    path: string,
+    siteVersion: SiteVersion | null,
+    init?: RequestInit,
+  ): Promise<Response> {
+    const requestUrl = new URL(path, this.apiOrigin)
+
+    const requestHeaders = new Headers({
+      'x-api-key': this.apiKey,
+      'makeswift-site-api-key': this.apiKey,
+      'makeswift-runtime-version': PACKAGE_VERSION,
+    })
+
+    if (siteVersion?.token) {
+      requestUrl.searchParams.set('version', siteVersion.version)
+      requestHeaders.set('makeswift-preview-token', siteVersion.token)
+    }
+
+    if (init?.headers) {
+      new Headers(init.headers).forEach((value, key) => {
+        requestHeaders.set(key, value)
+      })
+    }
+
+    const response = await fetch(requestUrl.toString(), {
+      ...init,
+      headers: requestHeaders,
+      ...(siteVersion != null ? { cache: 'no-store' } : {}),
+      ...this.fetchOptions(siteVersion),
+    })
+
+    return response
+  }
+
+  /**
+   * Override this method to provide additional fetch options, e.g. revalidation, cache tags, etc.
+   */
+  protected fetchOptions(_siteVersion: SiteVersion | null): Record<string, unknown> {
+    return {}
+  }
+}
+
+// This function attempts to consume the response body of a failed response, and
+// returns either the parsed JSON or raw text. This is useful for logging more
+// detailed error information when an API request fails.
+//
+// Cloudflare Worker Note: The Cloudflare Worker runtime has automatic deadlock
+// prevention (in the form of auto-cancelling responses) that triggers when too
+// many response bodies are unconsumed. This applies for error responses as
+// well. As such, in this client we use this function to consume the response
+// body whenever the request fails, even if we don't end up logging the body
+// itself, to avoid hitting the deadlock prevention.
+export async function failedResponseBody(response: Response): Promise<unknown> {
+  try {
+    const text = await response.text()
+    try {
+      return JSON.parse(text)
+    } catch {
+      return text
+    }
+  } catch (e) {
+    return `Failed to extract response body: ${e}`
+  }
+}

--- a/packages/runtime/src/api/schema/index.ts
+++ b/packages/runtime/src/api/schema/index.ts
@@ -1,0 +1,1 @@
+export * from './page-pathname-slice'

--- a/packages/runtime/src/api/schema/page-pathname-slice.ts
+++ b/packages/runtime/src/api/schema/page-pathname-slice.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod'
+
+export const pagePathnameSlices = z.array(
+  z
+    .object({
+      id: z.string(),
+      basePageId: z.string(),
+      pathname: z.string(),
+      localizedPathname: z.string().optional(),
+      __typename: z.literal('PagePathnameSlice'),
+    })
+    .nullable(),
+)

--- a/packages/runtime/src/client/component-snapshot.ts
+++ b/packages/runtime/src/client/component-snapshot.ts
@@ -1,0 +1,68 @@
+import { z } from 'zod'
+
+import { type CacheData } from '../api/api-resources-client'
+
+import { EMBEDDED_DOCUMENT_TYPE, type EmbeddedDocument } from '../state/modules/read-only-documents'
+
+import { deterministicUUID } from '../utils/deterministic-uuid'
+
+import * as Schema from './schema/component-document'
+
+export type MakeswiftComponentDocument = z.infer<typeof Schema.componentDocument>
+export type MakeswiftComponentDocumentFallback = z.infer<typeof Schema.componentDocumentFallback>
+
+export type MakeswiftComponentMetadata = {
+  allowLocaleFallback: boolean
+  requestedLocale: string | null
+}
+
+export function componentDocumentToRootEmbeddedDocument({
+  document,
+  documentKey,
+  name,
+  type,
+  description,
+  meta,
+}: {
+  document: MakeswiftComponentDocument | MakeswiftComponentDocumentFallback
+  documentKey: string
+  name: string
+  type: string
+  description?: string
+  meta: MakeswiftComponentMetadata
+}): EmbeddedDocument {
+  const { data: rootElement, locale, id } = document
+
+  if (rootElement != null && rootElement.type !== type) {
+    throw new Error(
+      `Type "${rootElement.type}" does not match the expected type "${type}" from the snapshot`,
+    )
+  }
+
+  const rootDocument: EmbeddedDocument = {
+    key: documentKey,
+    rootElement: rootElement ?? {
+      // Fallback rootElement
+      // Create a stable uuid so two different clients will have the same empty element data.
+      // This is needed to make presence feature work for an element that is not yet created.
+      key: deterministicUUID({ id, locale, seed: documentKey }),
+      type,
+      props: {},
+    },
+    locale,
+    id,
+    type,
+    name,
+    meta: { ...meta, description },
+    __type: EMBEDDED_DOCUMENT_TYPE,
+  }
+
+  return rootDocument
+}
+
+export type MakeswiftComponentSnapshot = {
+  document: MakeswiftComponentDocument | MakeswiftComponentDocumentFallback
+  key: string
+  cacheData: CacheData
+  meta: MakeswiftComponentMetadata
+}

--- a/packages/runtime/src/client/index.ts
+++ b/packages/runtime/src/client/index.ts
@@ -1,18 +1,26 @@
 import { z } from 'zod'
+
+import {
+  type UnversionedResourcesQueryResult,
+  type UnversionedResourcesQueryVariables,
+} from '../api/graphql/generated/types'
+
 import {
   APIResourceType,
-  File,
-  GlobalElement,
-  LocalizedGlobalElement,
-  PagePathnameSlice,
-  Swatch,
-  Table,
-  Typography,
-} from '../api'
-import { MakeswiftGraphQLApiClient } from '../api/graphql-api-client'
-import { type SnippetLocation } from '../api/graphql/generated/types'
+  type File,
+  type GlobalElement,
+  type LocalizedGlobalElement,
+  type Swatch,
+  type Table,
+  type Typography,
+} from '../api/types'
 
 import { CacheData } from '../api/api-resources-client'
+
+import { MakeswiftGraphQLApiClient } from '../api/graphql-api-client'
+import { MakeswiftRestAPIClient, failedResponseBody } from '../api/rest-api-client'
+import { type SiteVersion } from '../api/site-version'
+
 import { Descriptor as PropControllerDescriptor } from '../prop-controllers/descriptors'
 import {
   getElementChildren,
@@ -22,277 +30,55 @@ import {
   getTableIds,
   getTypographyIds,
 } from '../prop-controllers/introspection'
+
 import { type ReactRuntimeCore } from '../runtimes/react/react-runtime-core'
+
 import {
   type Element,
   type ElementData,
   type Data,
-  type Document,
   getPropControllerDescriptors,
   isElementReference,
 } from '../state/read-only-state'
-import { type SiteVersion } from '../api/site-version'
-import { toIterablePaginationResult } from '../utils/pagination'
-import { deterministicUUID } from '../utils/deterministic-uuid'
-import { Schema } from '@makeswift/controls'
-import { EMBEDDED_DOCUMENT_TYPE, EmbeddedDocument } from '../state/modules/read-only-documents'
+
 import { mergeTranslatedContent } from '../state/translations/merge'
 import { getTranslatableContent } from '../state/translations/get'
+
+import { deterministicUUID } from '../utils/deterministic-uuid'
+import { toIterablePaginationResult } from '../utils/pagination'
 import { isNonNullable } from '../utils/isNonNullable'
+
 import {
-  UnversionedResourcesQueryResult,
-  UnversionedResourcesQueryVariables,
-} from '../api/graphql/generated/types'
+  type MakeswiftComponentDocument,
+  type MakeswiftComponentSnapshot,
+} from './component-snapshot'
+
+import { type MakeswiftPageDocument, type MakeswiftPageSnapshot } from './page-snapshot'
+
+import * as Schema from './schema'
 
 export { SnippetLocation } from '../api/graphql/generated/types'
 
-const makeswiftPageResultSchema = z.object({
-  id: z.string(),
-  path: z.string(),
-  title: z.string().nullable(),
-  description: z.string().nullable(),
-  canonicalUrl: z.string().nullable(),
-  socialImageUrl: z.string().nullable(),
-  sitemapPriority: z.number().nullable(),
-  sitemapFrequency: z
-    .enum(['always', 'hourly', 'daily', 'weekly', 'monthly', 'yearly', 'never'])
-    .nullable(),
-  createdAt: z.string(),
-  updatedAt: z.string(),
-  publishedAt: z.string().nullable(),
-  isOnline: z.boolean().nullable(),
-  excludedFromSearch: z.boolean().nullable(),
-  locale: z.string(),
-  localizedVariants: z.array(
-    z.object({
-      locale: z.string(),
-      path: z.string(),
-    }),
-  ),
-})
+// TODO: clean up the exports below, as most of them are for internal consumptions only
+// and should not be publicly exposed
+export {
+  type MakeswiftComponentDocument,
+  type MakeswiftComponentDocumentFallback,
+  type MakeswiftComponentSnapshot,
+  type MakeswiftComponentMetadata as MakeswiftComponentSnapshotMetadata,
+  componentDocumentToRootEmbeddedDocument,
+} from './component-snapshot'
 
-const makeswiftGetPagesResultAPISchema = z.object({
-  data: z.array(makeswiftPageResultSchema),
-  hasMore: z.boolean(),
-})
+export {
+  type Snippet,
+  type Font,
+  type MakeswiftPageDocument,
+  type MakeswiftPageSnapshot,
+  pageToRootDocument,
+} from './page-snapshot'
 
-const makeswiftGetPagesParamsSchema = z.object({
-  limit: z.number().optional(),
-  after: z.string().optional(),
-  sortBy: z.enum(['title', 'path', 'description', 'createdAt', 'updatedAt']).optional(),
-  sortDirection: z.enum(['asc', 'desc']).optional(),
-  includeOffline: z.boolean().optional(),
-  pathPrefix: z.string().optional(),
-  locale: z.string().optional(),
-})
-
-function getPagesQueryParams({
-  limit = 100,
-  after,
-  sortBy,
-  sortDirection,
-  includeOffline,
-  pathPrefix,
-  locale,
-}: GetPagesParams): URLSearchParams {
-  const params = new URLSearchParams()
-
-  if (limit != null) params.set('limit', limit.toString())
-  if (after != null) params.set('after', after)
-  if (sortBy != null) params.set('sortBy', sortBy)
-  if (sortDirection != null) params.set('sortDirection', sortDirection)
-  if (includeOffline != null) params.set('includeOffline', includeOffline.toString())
-  if (pathPrefix != null) params.set('pathPrefix', pathPrefix)
-  if (locale != null) params.set('locale', locale)
-
-  return params
-}
-
-type GetPagesParams = z.infer<typeof makeswiftGetPagesParamsSchema>
-export type MakeswiftPage = z.infer<typeof makeswiftPageResultSchema>
-export type MakeswiftGetPagesResult = z.infer<typeof makeswiftGetPagesResultAPISchema>
-
-export type MakeswiftPageDocument = {
-  id: string
-  site: { id: string }
-  data: Element
-  snippets: Snippet[]
-  fonts: Font[]
-  meta: Meta
-  seo: Seo
-  localizedPages: LocalizedPage[]
-  locale: string | null
-}
-
-export function pageToRootDocument(pageDocument: MakeswiftPageDocument): Document {
-  const { locale, localizedPages, id, data } = pageDocument
-  const localizedPage = localizedPages.find(({ parentId }) => parentId == null)
-  return localizedPage
-    ? { key: localizedPage.elementTreeId, rootElement: localizedPage.data, locale }
-    : { key: id, rootElement: data, locale }
-}
-
-export type MakeswiftPageSnapshot = {
-  document: MakeswiftPageDocument
-  cacheData: CacheData
-}
-
-const makeswiftComponentDocumentSchema = z.object({
-  id: z.string(),
-  name: z.string().nullable(),
-  locale: z.string().nullable(),
-  data: Schema.element,
-  siteId: z.string(),
-  inheritsFromParent: z.boolean(),
-})
-
-export type MakeswiftComponentDocument = z.infer<typeof makeswiftComponentDocumentSchema>
-
-const makeswiftComponentDocumentFallbackSchema = z.object({
-  id: z.string(),
-  locale: z.string().nullable(),
-  data: z.null(),
-})
-
-export type MakeswiftComponentDocumentFallback = z.infer<
-  typeof makeswiftComponentDocumentFallbackSchema
->
-
-export type MakeswiftComponentSnapshotMetadata = {
-  allowLocaleFallback: boolean
-  requestedLocale: string | null
-}
-
-export type MakeswiftComponentSnapshot = {
-  document: MakeswiftComponentDocument | MakeswiftComponentDocumentFallback
-  key: string
-  cacheData: CacheData
-  meta: MakeswiftComponentSnapshotMetadata
-}
-
-export const previewTokenPayloadSchema = z.object({
-  payload: z.object({
-    version: z.string(),
-  }),
-})
-
-export type PreviewTokenPayload = z.infer<typeof previewTokenPayloadSchema>
-
-export function componentDocumentToRootEmbeddedDocument({
-  document,
-  documentKey,
-  name,
-  type,
-  description,
-  meta,
-}: {
-  document: MakeswiftComponentDocument | MakeswiftComponentDocumentFallback
-  documentKey: string
-  name: string
-  type: string
-  description?: string
-  meta: MakeswiftComponentSnapshotMetadata
-}): EmbeddedDocument {
-  const { data: rootElement, locale, id } = document
-
-  if (rootElement != null && rootElement.type !== type) {
-    throw new Error(
-      `Type "${rootElement.type}" does not match the expected type "${type}" from the snapshot`,
-    )
-  }
-
-  const rootDocument: EmbeddedDocument = {
-    key: documentKey,
-    rootElement: rootElement ?? {
-      // Fallback rootElement
-      // Create a stable uuid so two different clients will have the same empty element data.
-      // This is needed to make presence feature work for an element that is not yet created.
-      key: deterministicUUID({ id, locale, seed: documentKey }),
-      type,
-      props: {},
-    },
-    locale,
-    id,
-    type,
-    name,
-    meta: { ...meta, description },
-    __type: EMBEDDED_DOCUMENT_TYPE,
-  }
-
-  return rootDocument
-}
-
-// This function attempts to consume the response body of a failed response, and
-// returns either the parsed JSON or raw text. This is useful for logging more
-// detailed error information when an API request fails.
-//
-// Cloudflare Worker Note: The Cloudflare Worker runtime has automatic deadlock
-// prevention (in the form of auto-cancelling responses) that triggers when too
-// many response bodies are unconsumed. This applies for error responses as
-// well. As such, in this client we use this function to consume the response
-// body whenever the request fails, even if we don't end up logging the body
-// itself, to avoid hitting the deadlock prevention.
-export async function failedResponseBody(response: Response): Promise<unknown> {
-  try {
-    const text = await response.text()
-    try {
-      return JSON.parse(text)
-    } catch {
-      return text
-    }
-  } catch (e) {
-    return `Failed to extract response body: ${e}`
-  }
-}
-
-function responseError(response: Response): string {
-  return `${response.status} ${response.statusText}`
-}
-
-export type Snippet = {
-  id: string
-  code: string
-  location: SnippetLocation
-  liveEnabled: boolean
-  builderEnabled: boolean
-  cleanup: string | null
-}
-
-export type Font = { family: string; variants: string[] }
-
-type Meta = {
-  title?: string | null
-  description?: string | null
-  keywords?: string | null
-  socialImage?: {
-    id: string
-    publicUrl: string
-    mimetype: string
-  } | null
-  favicon?: {
-    id: string
-    publicUrl: string
-    mimetype: string
-  } | null
-}
-type Seo = {
-  canonicalUrl?: string | null
-  isIndexingBlocked?: boolean | null
-}
-
-type LocalizedPage = {
-  id: string
-  data: Element
-  elementTreeId: string
-  parentId: string | null
-  meta: Omit<Meta, 'favicon'>
-  seo: Seo
-}
-
-type MakeswiftConfig = {
-  runtime: ReactRuntimeCore
-}
-
+// TODO: remove, leftover from the `getSitemap` method removed in 0.25.0:
+// https://github.com/makeswift/makeswift/releases/tag/%40makeswift%2Fruntime%400.25.0
 export type Sitemap = {
   id: string
   loc: string
@@ -305,50 +91,26 @@ export type Sitemap = {
   }[]
 }[]
 
-const pagePathnameSlicesAPISchema = z.array(
-  z
-    .object({
-      id: z.string(),
-      basePageId: z.string(),
-      pathname: z.string(),
-      localizedPathname: z.string().optional(),
-      __typename: z.literal('PagePathnameSlice'),
-    })
-    .nullable(),
-)
+export type MakeswiftPage = z.infer<typeof Schema.pageData>
+export type MakeswiftGetPagesResult = z.infer<typeof Schema.getPagesResult>
+export type PreviewTokenPayload = z.infer<typeof Schema.previewTokenPayload>
+export type GetFontsAPI = z.infer<typeof Schema.fonts>
 
-const getPageAPISchema = z.object({
-  pathname: z.string(),
-  locale: z.string(),
-  alternate: z.array(
-    z.object({
-      pathname: z.string(),
-      locale: z.string(),
-    }),
-  ),
-})
+type GetPagesParams = z.infer<typeof Schema.getPagesParams>
+type GetPageResult = z.infer<typeof Schema.getPageResult>
 
-type GetPageAPI = z.infer<typeof getPageAPISchema>
-
-const getFontsAPISchema = z.object({
-  googleFonts: z.array(
-    z.object({
-      family: z.string(),
-      variants: z.array(z.string()),
-    }),
-  ),
-  siteId: z.string(),
-})
-
-export type GetFontsAPI = z.infer<typeof getFontsAPISchema>
-
-export class MakeswiftClient {
+export class MakeswiftClient extends MakeswiftRestAPIClient {
   private graphqlClient: MakeswiftGraphQLApiClient
   private runtime: ReactRuntimeCore
 
-  readonly apiKey: string
-
-  constructor(apiKey: string, { runtime }: MakeswiftConfig) {
+  constructor(
+    apiKey: string,
+    {
+      runtime,
+    }: {
+      runtime: ReactRuntimeCore
+    },
+  ) {
     if (typeof apiKey !== 'string') {
       throw new Error(
         'The Makeswift client must be passed a valid Makeswift site API key: ' +
@@ -357,57 +119,16 @@ export class MakeswiftClient {
       )
     }
 
-    this.apiKey = apiKey
+    super({
+      apiKey,
+      apiOrigin: runtime.apiOrigin,
+    })
+
     this.graphqlClient = new MakeswiftGraphQLApiClient({
       endpoint: runtime.graphqlApiEndpoint,
     })
 
     this.runtime = runtime
-  }
-
-  get apiOrigin(): string {
-    return this.runtime.apiOrigin
-  }
-
-  private async fetch(
-    path: string,
-    siteVersion: SiteVersion | null,
-    init?: RequestInit,
-  ): Promise<Response> {
-    const requestUrl = new URL(path, this.apiOrigin)
-
-    const requestHeaders = new Headers({
-      'x-api-key': this.apiKey,
-      'makeswift-site-api-key': this.apiKey,
-      'makeswift-runtime-version': PACKAGE_VERSION,
-    })
-
-    if (siteVersion?.token) {
-      requestUrl.searchParams.set('version', siteVersion.version)
-      requestHeaders.set('makeswift-preview-token', siteVersion.token)
-    }
-
-    if (init?.headers) {
-      new Headers(init.headers).forEach((value, key) => {
-        requestHeaders.set(key, value)
-      })
-    }
-
-    const response = await fetch(requestUrl.toString(), {
-      ...init,
-      headers: requestHeaders,
-      ...(siteVersion != null ? { cache: 'no-store' } : {}),
-      ...this.fetchOptions(siteVersion),
-    })
-
-    return response
-  }
-
-  /**
-   * Override this method to provide additional fetch options, e.g. revalidation, cache tags, etc.
-   */
-  fetchOptions(_siteVersion: SiteVersion | null): Record<string, unknown> {
-    return {}
   }
 
   private getPagesInternal = async ({
@@ -430,7 +151,7 @@ export class MakeswiftClient {
     }
 
     const result = await response.json()
-    const parsedResponse = makeswiftGetPagesResultAPISchema.safeParse(result)
+    const parsedResponse = Schema.getPagesResult.safeParse(result)
     if (!parsedResponse.success) {
       throw new Error(
         `Failed to parse 'getPages' response: ${parsedResponse.error.errors.map(e => e.message).join('; ')}`,
@@ -444,7 +165,7 @@ export class MakeswiftClient {
   async getPage(
     pathname: string,
     { siteVersion = null, locale }: { siteVersion?: SiteVersion | null; locale?: string } = {},
-  ): Promise<GetPageAPI | null> {
+  ): Promise<GetPageResult | null> {
     const url = new URL(`v3/pages/${encodeURIComponent(pathname)}`, this.apiOrigin)
     if (locale) url.searchParams.set('locale', locale)
 
@@ -465,7 +186,7 @@ export class MakeswiftClient {
 
     const json = await response.json()
 
-    return getPageAPISchema.parse(json)
+    return Schema.getPageResult.parse(json)
   }
 
   private async getTypographies(
@@ -556,7 +277,7 @@ export class MakeswiftClient {
     const responseBody = await response.json()
 
     return responseBody.map((item: unknown) =>
-      item != null ? makeswiftComponentDocumentSchema.parse(item) : null,
+      item != null ? Schema.componentDocument.parse(item) : null,
     )
   }
 
@@ -1094,7 +815,7 @@ export class MakeswiftClient {
       throw new Error(`Failed to get component snapshot for '${id}': ${responseError(response)}`)
     }
 
-    const document = makeswiftComponentDocumentSchema.parse(await response.json())
+    const document = Schema.componentDocument.parse(await response.json())
     const cacheData = await this.introspect(document.data, siteVersion, locale ?? null)
 
     return {
@@ -1182,155 +903,8 @@ export class MakeswiftClient {
     })
   }
 
-  async getSwatch(swatchId: string, siteVersion: SiteVersion | null): Promise<Swatch | null> {
-    const response = await this.fetch(`v3/swatches/${swatchId}`, siteVersion)
-
-    if (!response.ok) {
-      const failedBody = await failedResponseBody(response)
-      if (response.status !== 404) {
-        console.error(`Failed to get swatch '${swatchId}'`, {
-          response: failedBody,
-          siteVersion,
-        })
-      }
-
-      return null
-    }
-
-    const swatch = await response.json()
-
-    return swatch
-  }
-
   async getFile(fileId: string): Promise<File | null> {
     return this.graphqlClient.getFile(fileId)
-  }
-
-  async getTypography(
-    typographyId: string,
-    siteVersion: SiteVersion | null,
-  ): Promise<Typography | null> {
-    const response = await this.fetch(`v3/typographies/${typographyId}`, siteVersion)
-
-    if (!response.ok) {
-      const failedBody = await failedResponseBody(response)
-      if (response.status !== 404) {
-        console.error(`Failed to get typography '${typographyId}'`, {
-          response: failedBody,
-          siteVersion,
-        })
-      }
-
-      return null
-    }
-
-    const typography = await response.json()
-
-    return typography
-  }
-
-  async getGlobalElement(
-    globalElementId: string,
-    siteVersion: SiteVersion | null,
-  ): Promise<GlobalElement | null> {
-    const response = await this.fetch(`v3/global-elements/${globalElementId}`, siteVersion)
-
-    if (!response.ok) {
-      const failedBody = await failedResponseBody(response)
-      if (response.status !== 404) {
-        console.error(`Failed to get global element '${globalElementId}'`, {
-          response: failedBody,
-          siteVersion,
-        })
-      }
-
-      return null
-    }
-
-    const globalElement = await response.json()
-
-    return globalElement
-  }
-
-  async getLocalizedGlobalElement(
-    globalElementId: string,
-    locale: string,
-    siteVersion: SiteVersion | null,
-  ): Promise<LocalizedGlobalElement | null> {
-    const response = await this.fetch(
-      `v3/localized-global-elements/${globalElementId}?locale=${locale}`,
-      siteVersion,
-    )
-
-    if (!response.ok) {
-      const failedBody = await failedResponseBody(response)
-      if (response.status !== 404) {
-        console.error(`Failed to get localized global element '${globalElementId}'`, {
-          response: failedBody,
-          siteVersion,
-          locale,
-        })
-      }
-
-      return null
-    }
-
-    const localizedGlobalElement = await response.json()
-
-    return localizedGlobalElement
-  }
-
-  async getPagePathnameSlices(
-    pageIds: string[],
-    siteVersion: SiteVersion | null,
-    { locale }: { locale?: string | null },
-  ): Promise<(PagePathnameSlice | null)[]> {
-    if (pageIds.length === 0) return []
-
-    const url = new URL(`v3/page-pathname-slices/bulk`, this.apiOrigin)
-
-    pageIds.forEach(id => url.searchParams.append('ids', id))
-    if (locale != null) url.searchParams.set('locale', locale)
-
-    const response = await this.fetch(url.pathname + url.search, siteVersion)
-
-    if (!response.ok) {
-      console.error(`Failed to get page pathname slice(s) for ${pageIds.join(', ')}`, {
-        response: await failedResponseBody(response),
-        siteVersion,
-        locale,
-      })
-
-      return []
-    }
-
-    const json = await response.json()
-
-    const pagePathnameSlices = pagePathnameSlicesAPISchema.parse(json)
-
-    // We're mapping the basePageId to be the id, because we're still using the GraphQL
-    // fragment as our APIResource. The id on the APIResource needs to match the pageId
-    // so that we can find the corresponding page pathname slice when we call getPagePathnameSlice(pageId).
-    // TODO: Update this once we move away from the GraphQL fragments.
-    return pagePathnameSlices.map(pagePathnameSlice => {
-      if (pagePathnameSlice == null) return null
-
-      return {
-        ...pagePathnameSlice,
-        id: pagePathnameSlice.basePageId,
-        localizedPathname: pagePathnameSlice.localizedPathname ?? null,
-      }
-    })
-  }
-
-  async getPagePathnameSlice(
-    pageId: string,
-    siteVersion: SiteVersion | null,
-    { locale }: { locale?: string } = {},
-  ): Promise<PagePathnameSlice | null> {
-    const pagePathnameSlices = await this.getPagePathnameSlices([pageId], siteVersion, { locale })
-
-    return pagePathnameSlices.at(0) ?? null
   }
 
   async getTable(tableId: string): Promise<Table | null> {
@@ -1375,7 +949,7 @@ export class MakeswiftClient {
 
     const json = await response.json()
 
-    const parsed = previewTokenPayloadSchema.safeParse(json)
+    const parsed = Schema.previewTokenPayload.safeParse(json)
     if (!parsed.success) {
       throw new Error(
         `Failed to parse preview token payload: ${parsed.error.errors.map(e => e.message).join('; ')}`,
@@ -1399,7 +973,7 @@ export class MakeswiftClient {
 
     const json = await response.json()
 
-    const parsed = getFontsAPISchema.safeParse(json)
+    const parsed = Schema.fonts.safeParse(json)
     if (!parsed.success) {
       console.error('Failed to parse fonts API response', {
         response: json,
@@ -1415,4 +989,30 @@ export class MakeswiftClient {
   private getElementDescriptors() {
     return getPropControllerDescriptors(this.runtime.protoStore.getState())
   }
+}
+
+function getPagesQueryParams({
+  limit = 100,
+  after,
+  sortBy,
+  sortDirection,
+  includeOffline,
+  pathPrefix,
+  locale,
+}: GetPagesParams): URLSearchParams {
+  const params = new URLSearchParams()
+
+  if (limit != null) params.set('limit', limit.toString())
+  if (after != null) params.set('after', after)
+  if (sortBy != null) params.set('sortBy', sortBy)
+  if (sortDirection != null) params.set('sortDirection', sortDirection)
+  if (includeOffline != null) params.set('includeOffline', includeOffline.toString())
+  if (pathPrefix != null) params.set('pathPrefix', pathPrefix)
+  if (locale != null) params.set('locale', locale)
+
+  return params
+}
+
+function responseError(response: Response): string {
+  return `${response.status} ${response.statusText}`
 }

--- a/packages/runtime/src/client/page-snapshot.ts
+++ b/packages/runtime/src/client/page-snapshot.ts
@@ -1,0 +1,70 @@
+import { type SnippetLocation } from '../api/graphql/generated/types'
+import { type CacheData } from '../api/api-resources-client'
+
+import { type Element, type Document } from '../state/read-only-state'
+
+export type Snippet = {
+  id: string
+  code: string
+  location: SnippetLocation
+  liveEnabled: boolean
+  builderEnabled: boolean
+  cleanup: string | null
+}
+
+export type Font = { family: string; variants: string[] }
+
+type Meta = {
+  title?: string | null
+  description?: string | null
+  keywords?: string | null
+  socialImage?: {
+    id: string
+    publicUrl: string
+    mimetype: string
+  } | null
+  favicon?: {
+    id: string
+    publicUrl: string
+    mimetype: string
+  } | null
+}
+
+type Seo = {
+  canonicalUrl?: string | null
+  isIndexingBlocked?: boolean | null
+}
+
+type LocalizedPage = {
+  id: string
+  data: Element
+  elementTreeId: string
+  parentId: string | null
+  meta: Omit<Meta, 'favicon'>
+  seo: Seo
+}
+
+export type MakeswiftPageDocument = {
+  id: string
+  site: { id: string }
+  data: Element
+  snippets: Snippet[]
+  fonts: Font[]
+  meta: Meta
+  seo: Seo
+  localizedPages: LocalizedPage[]
+  locale: string | null
+}
+
+export function pageToRootDocument(pageDocument: MakeswiftPageDocument): Document {
+  const { locale, localizedPages, id, data } = pageDocument
+  const localizedPage = localizedPages.find(({ parentId }) => parentId == null)
+  return localizedPage
+    ? { key: localizedPage.elementTreeId, rootElement: localizedPage.data, locale }
+    : { key: id, rootElement: data, locale }
+}
+
+export type MakeswiftPageSnapshot = {
+  document: MakeswiftPageDocument
+  cacheData: CacheData
+}

--- a/packages/runtime/src/client/schema/component-document.ts
+++ b/packages/runtime/src/client/schema/component-document.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod'
+
+import { Schema } from '@makeswift/controls'
+
+export const componentDocument = z.object({
+  id: z.string(),
+  name: z.string().nullable(),
+  locale: z.string().nullable(),
+  data: Schema.element,
+  siteId: z.string(),
+  inheritsFromParent: z.boolean(),
+})
+
+export const componentDocumentFallback = z.object({
+  id: z.string(),
+  locale: z.string().nullable(),
+  data: z.null(),
+})

--- a/packages/runtime/src/client/schema/fonts.ts
+++ b/packages/runtime/src/client/schema/fonts.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod'
+
+export const fonts = z.object({
+  googleFonts: z.array(
+    z.object({
+      family: z.string(),
+      variants: z.array(z.string()),
+    }),
+  ),
+  siteId: z.string(),
+})

--- a/packages/runtime/src/client/schema/get-page.ts
+++ b/packages/runtime/src/client/schema/get-page.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod'
+
+export const getPageResult = z.object({
+  pathname: z.string(),
+  locale: z.string(),
+  alternate: z.array(
+    z.object({
+      pathname: z.string(),
+      locale: z.string(),
+    }),
+  ),
+})

--- a/packages/runtime/src/client/schema/get-pages.ts
+++ b/packages/runtime/src/client/schema/get-pages.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod'
+
+export const pageData = z.object({
+  id: z.string(),
+  path: z.string(),
+  title: z.string().nullable(),
+  description: z.string().nullable(),
+  canonicalUrl: z.string().nullable(),
+  socialImageUrl: z.string().nullable(),
+  sitemapPriority: z.number().nullable(),
+  sitemapFrequency: z
+    .enum(['always', 'hourly', 'daily', 'weekly', 'monthly', 'yearly', 'never'])
+    .nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  publishedAt: z.string().nullable(),
+  isOnline: z.boolean().nullable(),
+  excludedFromSearch: z.boolean().nullable(),
+  locale: z.string(),
+  localizedVariants: z.array(
+    z.object({
+      locale: z.string(),
+      path: z.string(),
+    }),
+  ),
+})
+
+export const getPagesResult = z.object({
+  data: z.array(pageData),
+  hasMore: z.boolean(),
+})
+
+export const getPagesParams = z.object({
+  limit: z.number().optional(),
+  after: z.string().optional(),
+  sortBy: z.enum(['title', 'path', 'description', 'createdAt', 'updatedAt']).optional(),
+  sortDirection: z.enum(['asc', 'desc']).optional(),
+  includeOffline: z.boolean().optional(),
+  pathPrefix: z.string().optional(),
+  locale: z.string().optional(),
+})

--- a/packages/runtime/src/client/schema/index.ts
+++ b/packages/runtime/src/client/schema/index.ts
@@ -1,0 +1,5 @@
+export * from './component-document'
+export * from './fonts'
+export * from './get-page'
+export * from './get-pages'
+export * from './preview-token-payload'

--- a/packages/runtime/src/client/schema/preview-token-payload.ts
+++ b/packages/runtime/src/client/schema/preview-token-payload.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod'
+
+export const previewTokenPayload = z.object({
+  payload: z.object({
+    version: z.string(),
+  }),
+})


### PR DESCRIPTION
Extract `MakeswiftClient`'s resources fetching and basic REST API request handling methods into a separate REST API client that (eventually) can be instantiated and called independently. No semantic changes outside of removing two auxiliary internal exports from the `@makeswift/runtime/client` entrypoint.