### PR TITLE
refactor: switch `Makeswift`/REST API client to use runtime's `fetch`

### DIFF
--- a/.changeset/dry-suns-enjoy.md
+++ b/.changeset/dry-suns-enjoy.md
@@ -1,0 +1,8 @@
+---
+'@makeswift/express-react': patch
+'@makeswift/react-router': patch
+'@makeswift/hono-react': patch
+'@makeswift/runtime': patch
+---
+
+refactor: switch `Makeswift` client to use runtime's `fetch` implementation

--- a/packages/express-react/src/client.ts
+++ b/packages/express-react/src/client.ts
@@ -1,7 +1,1 @@
-import { type SiteVersion, MakeswiftClient } from '@makeswift/runtime/unstable-framework-support'
-
-export class Makeswift extends MakeswiftClient {
-  fetchOptions(_siteVersion: SiteVersion | null): Record<string, unknown> {
-    return {}
-  }
-}
+export { MakeswiftClient as Makeswift } from '@makeswift/runtime/unstable-framework-support'

--- a/packages/hono-react/src/client.ts
+++ b/packages/hono-react/src/client.ts
@@ -1,7 +1,1 @@
-import { type SiteVersion, MakeswiftClient } from '@makeswift/runtime/unstable-framework-support'
-
-export class Makeswift extends MakeswiftClient {
-  fetchOptions(_siteVersion: SiteVersion | null): Record<string, unknown> {
-    return {}
-  }
-}
+export { MakeswiftClient as Makeswift } from '@makeswift/runtime/unstable-framework-support'

--- a/packages/react-router/src/client.ts
+++ b/packages/react-router/src/client.ts
@@ -1,7 +1,1 @@
-import { type SiteVersion, MakeswiftClient } from '@makeswift/runtime/unstable-framework-support'
-
-export class Makeswift extends MakeswiftClient {
-  fetchOptions(_siteVersion: SiteVersion | null): Record<string, unknown> {
-    return {}
-  }
-}
+export { MakeswiftClient as Makeswift } from '@makeswift/runtime/unstable-framework-support'

--- a/packages/runtime/src/api/__tests__/rest-api-client.get-resources.test.ts
+++ b/packages/runtime/src/api/__tests__/rest-api-client.get-resources.test.ts
@@ -9,6 +9,7 @@ const baseUrl = `${TestOrigins.apiOrigin}/v3`
 
 function createTestClient() {
   return new MakeswiftRestAPIClient({
+    fetch: globalThis.fetch,
     apiKey: TEST_API_KEY,
     apiOrigin: TestOrigins.apiOrigin,
   })

--- a/packages/runtime/src/api/api-resources-client.ts
+++ b/packages/runtime/src/api/api-resources-client.ts
@@ -27,6 +27,7 @@ export const CacheData = {
     }
   },
 }
+
 export abstract class ApiResourcesClient {
   readonly store: ApiClientStore
   readonly subscribe: ApiClientStore['subscribe']

--- a/packages/runtime/src/api/host-api-resources-client.ts
+++ b/packages/runtime/src/api/host-api-resources-client.ts
@@ -1,5 +1,5 @@
 import { type State as ApiClientState } from '../state/api-client/state'
-import { type HttpFetch, fetchAPIResource } from '../state/api-client/fetch-api-resource'
+import { fetchAPIResource } from '../state/api-client/fetch-api-resource'
 import { configureClientStore } from '../state/api-client/client-store'
 
 import {
@@ -10,6 +10,7 @@ import {
   type Swatch,
   type Table,
   type Typography,
+  type HttpFetch,
   APIResourceType,
 } from './types'
 

--- a/packages/runtime/src/api/rest-api-client.ts
+++ b/packages/runtime/src/api/rest-api-client.ts
@@ -4,16 +4,28 @@ import {
   type PagePathnameSlice,
   type Swatch,
   type Typography,
+  type HttpFetch,
 } from './types'
 
 import { type SiteVersion } from './site-version'
 import * as Schema from './schema'
 
 export class MakeswiftRestAPIClient {
+  private _fetch: HttpFetch
+
   readonly apiKey: string
   readonly apiOrigin: string
 
-  constructor({ apiKey, apiOrigin }: { apiKey: string; apiOrigin: string }) {
+  constructor({
+    fetch,
+    apiKey,
+    apiOrigin,
+  }: {
+    fetch: HttpFetch
+    apiKey: string
+    apiOrigin: string
+  }) {
+    this._fetch = fetch
     this.apiKey = apiKey
     this.apiOrigin = apiOrigin
   }
@@ -189,21 +201,13 @@ export class MakeswiftRestAPIClient {
       })
     }
 
-    const response = await fetch(requestUrl.toString(), {
+    const response = await this._fetch(requestUrl.toString(), {
       ...init,
       headers: requestHeaders,
       ...(siteVersion != null ? { cache: 'no-store' } : {}),
-      ...this.fetchOptions(siteVersion),
     })
 
     return response
-  }
-
-  /**
-   * Override this method to provide additional fetch options, e.g. revalidation, cache tags, etc.
-   */
-  protected fetchOptions(_siteVersion: SiteVersion | null): Record<string, unknown> {
-    return {}
   }
 }
 

--- a/packages/runtime/src/api/types.ts
+++ b/packages/runtime/src/api/types.ts
@@ -71,3 +71,5 @@ export type APIResourceLocale<R extends APIResource | APIResourceType> = R exten
   | LocalizableAPIResourceType
   ? string | null
   : never
+
+export type HttpFetch = (url: string | URL, init?: RequestInit) => Promise<Response>

--- a/packages/runtime/src/client/index.ts
+++ b/packages/runtime/src/client/index.ts
@@ -120,6 +120,7 @@ export class MakeswiftClient extends MakeswiftRestAPIClient {
     }
 
     super({
+      fetch: runtime.fetch,
       apiKey,
       apiOrigin: runtime.apiOrigin,
     })

--- a/packages/runtime/src/next/client.ts
+++ b/packages/runtime/src/next/client.ts
@@ -4,7 +4,6 @@ import { z } from 'zod'
 import { deserializeSiteVersion, type SiteVersion } from '../api/site-version'
 
 import { MakeswiftClient } from '../client'
-import { MAKESWIFT_CACHE_TAG } from './cache'
 
 const previewDataSchema = z.object({
   siteVersion: z.string(),
@@ -20,13 +19,5 @@ export class Makeswift extends MakeswiftClient {
 
   static getPreviewMode(previewData: PreviewData): boolean {
     return this.getSiteVersion(previewData) != null
-  }
-
-  fetchOptions(_siteVersion: SiteVersion): Record<string, unknown> {
-    return {
-      next: {
-        tags: [MAKESWIFT_CACHE_TAG],
-      },
-    }
   }
 }

--- a/packages/runtime/src/next/fetch.ts
+++ b/packages/runtime/src/next/fetch.ts
@@ -1,4 +1,4 @@
-import { type HttpFetch } from '../state/api-client/fetch-api-resource'
+import { type HttpFetch } from '../api/types'
 
 import { MAKESWIFT_CACHE_TAG } from './cache'
 

--- a/packages/runtime/src/runtimes/react/runtime-core.ts
+++ b/packages/runtime/src/runtimes/react/runtime-core.ts
@@ -1,7 +1,7 @@
 import { type SerializableReplacementContext } from '@makeswift/controls'
 
 import { HostApiResourcesClient } from '../../api/host-api-resources-client'
-import { type HttpFetch } from '../../state/api-client/fetch-api-resource'
+import { type HttpFetch } from '../../api/types'
 import { type SiteVersion } from '../../api/site-version'
 
 import {

--- a/packages/runtime/src/runtimes/react/testing/react-runtime.tsx
+++ b/packages/runtime/src/runtimes/react/testing/react-runtime.tsx
@@ -3,5 +3,11 @@ import { TestOrigins } from '../../../testing/fixtures'
 import { ReactRuntime } from '../react-runtime'
 
 export function createReactRuntime({ breakpoints }: { breakpoints?: BreakpointsInput } = {}) {
-  return new ReactRuntime({ fetch, breakpoints, ...TestOrigins })
+  return new ReactRuntime({
+    // Mock Service Worker patches global `fetch` for interception; make sure our test calls go
+    // through the patched version instead of an eagerly captured reference to the original
+    fetch: (...args) => globalThis.fetch(...args),
+    breakpoints,
+    ...TestOrigins,
+  })
 }

--- a/packages/runtime/src/state/api-client/fetch-api-resource.ts
+++ b/packages/runtime/src/state/api-client/fetch-api-resource.ts
@@ -19,11 +19,10 @@ import {
   type Table,
   type LocalizedGlobalElement,
   type APIResourceLocale,
-} from '../../api'
+  type HttpFetch,
+} from '../../api/types'
 
 import { type State, getHasAPIResource, getAPIResource, getLocalizedResourceId } from './state'
-
-export type HttpFetch = (url: string | URL, init?: RequestInit) => Promise<Response>
 
 type Thunk<ReturnType> = ThunkAction<ReturnType, State, unknown, Action>
 


### PR DESCRIPTION
Following up on https://github.com/makeswift/makeswift/pull/1219, where we moved `fetch` parameterization from the framework context to the runtime instance, but didn't unify it with `MakeswiftClient`'s usage; superseds https://github.com/makeswift/makeswift/pull/1307.