### PR TITLE
feat: server-side implementation of `ApiResourcesClient` interface

### DIFF
--- a/.changeset/empty-pans-fry.md
+++ b/.changeset/empty-pans-fry.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+feat: server-side implementation of `ApiResourcesClient` interface

--- a/packages/runtime/src/api/api-resources-client.ts
+++ b/packages/runtime/src/api/api-resources-client.ts
@@ -2,6 +2,7 @@ import { type FetchableValue } from '@makeswift/controls'
 
 import { type Store as ApiClientStore } from '../state/api-client/store'
 import * as ApiClientState from '../state/api-client/state'
+import { fetchAPIResource } from '../state/api-client/fetch-api-resource'
 
 import {
   type File,
@@ -16,6 +17,8 @@ import {
   type Typography,
   APIResourceType,
 } from './types'
+
+import { type SiteVersion } from './site-version'
 
 export type CacheData = ApiClientState.SerializedState
 
@@ -37,7 +40,11 @@ export abstract class ApiResourcesClient {
     this.subscribe = this.store.subscribe
   }
 
-  abstract fetchSwatch(swatchId: string): Promise<Swatch | null>
+  async fetchSwatch(swatchId: string): Promise<Swatch | null> {
+    const fetch = (id: string, version: SiteVersion | null) => this.fetchSwatchImpl(id, version)
+
+    return await this.store.dispatch(fetchAPIResource(APIResourceType.Swatch, swatchId, fetch))
+  }
 
   readSwatch(swatchId: string): Swatch | null {
     return ApiClientState.getAPIResource(this.store.getState(), APIResourceType.Swatch, swatchId)
@@ -51,7 +58,11 @@ export abstract class ApiResourcesClient {
     })
   }
 
-  abstract fetchFile(fileId: string): Promise<File | null>
+  async fetchFile(fileId: string): Promise<File | null> {
+    const fetch = (id: string, version: SiteVersion | null) => this.fetchFileImpl(id, version)
+
+    return await this.store.dispatch(fetchAPIResource(APIResourceType.File, fileId, fetch))
+  }
 
   readFile(fileId: string): File | null {
     return ApiClientState.getAPIResource(this.store.getState(), APIResourceType.File, fileId)
@@ -65,7 +76,13 @@ export abstract class ApiResourcesClient {
     })
   }
 
-  abstract fetchTypography(typographyId: string): Promise<Typography | null>
+  async fetchTypography(typographyId: string): Promise<Typography | null> {
+    const fetch = (id: string, version: SiteVersion | null) => this.fetchTypographyImpl(id, version)
+
+    return await this.store.dispatch(
+      fetchAPIResource(APIResourceType.Typography, typographyId, fetch),
+    )
+  }
 
   readTypography(typographyId: string): Typography | null {
     return ApiClientState.getAPIResource(
@@ -83,7 +100,14 @@ export abstract class ApiResourcesClient {
     })
   }
 
-  abstract fetchGlobalElement(globalElementId: string): Promise<GlobalElement | null>
+  async fetchGlobalElement(globalElementId: string): Promise<GlobalElement | null> {
+    const fetch = (id: string, version: SiteVersion | null) =>
+      this.fetchGlobalElementImpl(id, version)
+
+    return await this.store.dispatch(
+      fetchAPIResource(APIResourceType.GlobalElement, globalElementId, fetch),
+    )
+  }
 
   readGlobalElement(globalElementId: string): GlobalElement | null {
     return ApiClientState.getAPIResource(
@@ -93,13 +117,22 @@ export abstract class ApiResourcesClient {
     )
   }
 
-  abstract fetchLocalizedGlobalElement({
+  async fetchLocalizedGlobalElement({
     globalElementId,
     locale,
   }: {
     globalElementId: string
     locale: string
-  }): Promise<LocalizedGlobalElement | null>
+  }): Promise<LocalizedGlobalElement | null> {
+    const fetch = (id: string, version: SiteVersion | null, locale: string | null | undefined) => {
+      if (locale == null) throw new Error('Locale is required to fetch LocalizedGlobalElement')
+      return this.fetchLocalizedGlobalElementImpl(id, version, locale)
+    }
+
+    return await this.store.dispatch(
+      fetchAPIResource(APIResourceType.LocalizedGlobalElement, globalElementId, fetch, locale),
+    )
+  }
 
   readLocalizedGlobalElement({
     globalElementId,
@@ -113,6 +146,21 @@ export abstract class ApiResourcesClient {
       APIResourceType.LocalizedGlobalElement,
       globalElementId,
       locale,
+    )
+  }
+
+  async fetchPagePathnameSlice({
+    pageId,
+    locale,
+  }: {
+    pageId: string
+    locale: string | null
+  }): Promise<PagePathnameSlice | null> {
+    const fetch = (id: string, version: SiteVersion | null, locale: string | null | undefined) =>
+      this.fetchPagePathnameSliceImpl(id, version, locale)
+
+    return await this.store.dispatch(
+      fetchAPIResource(APIResourceType.PagePathnameSlice, pageId, fetch, locale),
     )
   }
 
@@ -130,14 +178,6 @@ export abstract class ApiResourcesClient {
       locale,
     )
   }
-
-  abstract fetchPagePathnameSlice({
-    pageId,
-    locale,
-  }: {
-    pageId: string
-    locale: string | null
-  }): Promise<PagePathnameSlice | null>
 
   resolvePagePathnameSlice({
     pageId,
@@ -178,7 +218,11 @@ export abstract class ApiResourcesClient {
     }
   }
 
-  abstract fetchTable(tableId: string): Promise<Table | null>
+  async fetchTable(tableId: string): Promise<Table | null> {
+    const fetch = (id: string, version: SiteVersion | null) => this.fetchTableImpl(id, version)
+
+    return await this.store.dispatch(fetchAPIResource(APIResourceType.Table, tableId, fetch))
+  }
 
   readTable(tableId: string): Table | null {
     return ApiClientState.getAPIResource(this.store.getState(), APIResourceType.Table, tableId)
@@ -195,4 +239,34 @@ export abstract class ApiResourcesClient {
   readSnippet(snippetId: string): Snippet | null {
     return ApiClientState.getAPIResource(this.store.getState(), APIResourceType.Snippet, snippetId)
   }
+
+  protected abstract fetchSwatchImpl(
+    id: string,
+    version: SiteVersion | null,
+  ): Promise<Swatch | null>
+
+  protected abstract fetchFileImpl(id: string, version: SiteVersion | null): Promise<File | null>
+  protected abstract fetchTypographyImpl(
+    id: string,
+    version: SiteVersion | null,
+  ): Promise<Typography | null>
+
+  protected abstract fetchGlobalElementImpl(
+    id: string,
+    version: SiteVersion | null,
+  ): Promise<GlobalElement | null>
+
+  protected abstract fetchLocalizedGlobalElementImpl(
+    id: string,
+    version: SiteVersion | null,
+    locale: string,
+  ): Promise<LocalizedGlobalElement | null>
+
+  protected abstract fetchPagePathnameSliceImpl(
+    id: string,
+    version: SiteVersion | null,
+    locale: string | null | undefined,
+  ): Promise<PagePathnameSlice | null>
+
+  protected abstract fetchTableImpl(id: string, version: SiteVersion | null): Promise<Table | null>
 }

--- a/packages/runtime/src/api/host-api-resources-client.ts
+++ b/packages/runtime/src/api/host-api-resources-client.ts
@@ -1,5 +1,5 @@
 import { type State as ApiClientState } from '../state/api-client/state'
-import { fetchAPIResource } from '../state/api-client/fetch-api-resource'
+
 import { configureClientStore } from '../state/api-client/client-store'
 
 import {
@@ -11,12 +11,10 @@ import {
   type Table,
   type Typography,
   type HttpFetch,
-  APIResourceType,
 } from './types'
 
+import { type SiteVersion, ApiHandlerHeaders, serializeSiteVersion } from './site-version'
 import { ApiResourcesClient } from './api-resources-client'
-
-export { CacheData } from './api-resources-client'
 
 /**
  * NOTE(miguel): This "client" is used to fetch Makeswift API resources needed for the host. For
@@ -54,51 +52,74 @@ export class HostApiResourcesClient extends ApiResourcesClient {
     this.fetch = fetch
   }
 
-  async fetchSwatch(swatchId: string): Promise<Swatch | null> {
-    return await this.store.dispatch(fetchAPIResource(APIResourceType.Swatch, swatchId, this.fetch))
+  protected async fetchSwatchImpl(id: string, version: SiteVersion | null): Promise<Swatch | null> {
+    return await this.fetchVersioned<Swatch>(`/api/makeswift/swatches/${id}`, version)
   }
 
-  async fetchFile(fileId: string): Promise<File | null> {
-    return await this.store.dispatch(fetchAPIResource(APIResourceType.File, fileId, this.fetch))
+  protected async fetchFileImpl(id: string, version: SiteVersion | null): Promise<File | null> {
+    return await this.fetchVersioned<File>(`/api/makeswift/files/${id}`, version)
   }
 
-  async fetchTypography(typographyId: string): Promise<Typography | null> {
-    return await this.store.dispatch(
-      fetchAPIResource(APIResourceType.Typography, typographyId, this.fetch),
+  protected async fetchTypographyImpl(
+    id: string,
+    version: SiteVersion | null,
+  ): Promise<Typography | null> {
+    return await this.fetchVersioned<Typography>(`/api/makeswift/typographies/${id}`, version)
+  }
+
+  protected async fetchGlobalElementImpl(
+    id: string,
+    version: SiteVersion | null,
+  ): Promise<GlobalElement | null> {
+    return await this.fetchVersioned<GlobalElement>(`/api/makeswift/global-elements/${id}`, version)
+  }
+
+  protected async fetchLocalizedGlobalElementImpl(
+    id: string,
+    version: SiteVersion | null,
+    locale: string,
+  ): Promise<LocalizedGlobalElement | null> {
+    return await this.fetchVersioned<LocalizedGlobalElement>(
+      `/api/makeswift/localized-global-elements/${id}/${locale}`,
+      version,
     )
   }
 
-  async fetchGlobalElement(globalElementId: string): Promise<GlobalElement | null> {
-    return await this.store.dispatch(
-      fetchAPIResource(APIResourceType.GlobalElement, globalElementId, this.fetch),
-    )
+  protected async fetchPagePathnameSliceImpl(
+    id: string,
+    version: SiteVersion | null,
+    locale: string | null | undefined,
+  ): Promise<PagePathnameSlice | null> {
+    const url = new URL(`/api/makeswift/page-pathname-slices/${id}`, 'http://n')
+
+    if (locale != null) url.searchParams.set('locale', locale)
+
+    return await this.fetchVersioned<PagePathnameSlice>(url.pathname + url.search, version)
   }
 
-  async fetchLocalizedGlobalElement({
-    globalElementId,
-    locale,
-  }: {
-    globalElementId: string
-    locale: string
-  }): Promise<LocalizedGlobalElement | null> {
-    return await this.store.dispatch(
-      fetchAPIResource(APIResourceType.LocalizedGlobalElement, globalElementId, this.fetch, locale),
-    )
+  protected async fetchTableImpl(id: string, version: SiteVersion | null): Promise<Table | null> {
+    return await this.fetchVersioned<Table>(`/api/makeswift/tables/${id}`, version)
   }
 
-  async fetchPagePathnameSlice({
-    pageId,
-    locale,
-  }: {
-    pageId: string
-    locale: string | null
-  }): Promise<PagePathnameSlice | null> {
-    return await this.store.dispatch(
-      fetchAPIResource(APIResourceType.PagePathnameSlice, pageId, this.fetch, locale),
-    )
-  }
+  private async fetchVersioned<T>(url: string, version: SiteVersion | null): Promise<T | null> {
+    const response = await this.fetch(url, {
+      headers: {
+        'Content-Type': 'application/json',
+        ...(version != null
+          ? { [ApiHandlerHeaders.SiteVersion]: serializeSiteVersion(version) }
+          : {}),
+      },
+    })
 
-  async fetchTable(tableId: string): Promise<Table | null> {
-    return await this.store.dispatch(fetchAPIResource(APIResourceType.Table, tableId, this.fetch))
+    if (response.status === 404) return null
+    if (!response.ok) throw new Error(response.statusText)
+
+    if (response.headers.get('content-type')?.includes('application/json') !== true) {
+      throw new Error(
+        `Expected JSON response from "${url}" but got "${response.headers.get('content-type')}"`,
+      )
+    }
+
+    return response.json()
   }
 }

--- a/packages/runtime/src/api/makeswift-api-resources-client.ts
+++ b/packages/runtime/src/api/makeswift-api-resources-client.ts
@@ -1,0 +1,95 @@
+import { type State as ApiClientState } from '../state/api-client/state'
+import { configureClientStore } from '../state/api-client/client-store'
+
+import {
+  type File,
+  type GlobalElement,
+  type LocalizedGlobalElement,
+  type PagePathnameSlice,
+  type Swatch,
+  type Table,
+  type Typography,
+  type HttpFetch,
+} from './types'
+
+import { ApiResourcesClient } from './api-resources-client'
+import { MakeswiftGraphQLApiClient } from './graphql-api-client'
+import { MakeswiftRestAPIClient } from './rest-api-client'
+import { type SiteVersion } from './site-version'
+
+/**
+ * Server-side implementation that makes direct authenticated requests to the Makeswift API.
+ * Requires an API key.
+ *
+ * For client-side usage, see `HostApiResourcesClient`, which goes through the host via
+ * `/api/makeswift/...` endpoints.
+ */
+export class MakeswiftApiResourcesClient extends ApiResourcesClient {
+  private restApiClient: MakeswiftRestAPIClient
+  private graphQlClient: MakeswiftGraphQLApiClient
+
+  constructor({
+    fetch,
+    apiKey,
+    apiOrigin,
+    graphqlApiEndpoint,
+    preloadedState,
+  }: {
+    fetch: HttpFetch
+    apiKey: string
+    apiOrigin: string
+    graphqlApiEndpoint: string
+    preloadedState: Partial<ApiClientState>
+  }) {
+    super({
+      store: configureClientStore({ preloadedState }),
+    })
+
+    this.restApiClient = new MakeswiftRestAPIClient({ fetch, apiKey, apiOrigin })
+    this.graphQlClient = new MakeswiftGraphQLApiClient({ endpoint: graphqlApiEndpoint })
+  }
+
+  protected async fetchSwatchImpl(id: string, version: SiteVersion | null): Promise<Swatch | null> {
+    return this.restApiClient.getSwatch(id, version)
+  }
+
+  protected async fetchFileImpl(id: string, _version: SiteVersion | null): Promise<File | null> {
+    // files are unversioned
+    return this.graphQlClient.getFile(id)
+  }
+
+  protected async fetchTypographyImpl(
+    id: string,
+    version: SiteVersion | null,
+  ): Promise<Typography | null> {
+    return this.restApiClient.getTypography(id, version)
+  }
+
+  protected async fetchGlobalElementImpl(
+    id: string,
+    version: SiteVersion | null,
+  ): Promise<GlobalElement | null> {
+    return this.restApiClient.getGlobalElement(id, version)
+  }
+
+  protected async fetchLocalizedGlobalElementImpl(
+    id: string,
+    version: SiteVersion | null,
+    locale: string,
+  ): Promise<LocalizedGlobalElement | null> {
+    return this.restApiClient.getLocalizedGlobalElement(id, locale, version)
+  }
+
+  protected async fetchPagePathnameSliceImpl(
+    id: string,
+    version: SiteVersion | null,
+    locale: string | null | undefined,
+  ): Promise<PagePathnameSlice | null> {
+    return this.restApiClient.getPagePathnameSlice(id, version, { locale })
+  }
+
+  protected async fetchTableImpl(id: string, _version: SiteVersion | null): Promise<Table | null> {
+    // tables are unversioned
+    return this.graphQlClient.getTable(id)
+  }
+}

--- a/packages/runtime/src/api/rest-api-client.ts
+++ b/packages/runtime/src/api/rest-api-client.ts
@@ -170,7 +170,7 @@ export class MakeswiftRestAPIClient {
   async getPagePathnameSlice(
     pageId: string,
     siteVersion: SiteVersion | null,
-    { locale }: { locale?: string } = {},
+    { locale }: { locale?: string | null } = {},
   ): Promise<PagePathnameSlice | null> {
     const pagePathnameSlices = await this.getPagePathnameSlices([pageId], siteVersion, { locale })
 

--- a/packages/runtime/src/api/types.ts
+++ b/packages/runtime/src/api/types.ts
@@ -66,6 +66,8 @@ export const APIResourceType: { [R in APIResource as R['__typename']]: R['__type
 
 export type APIResourceType = (typeof APIResourceType)[keyof typeof APIResourceType]
 
+export type APIResourceByType<T extends APIResourceType> = Extract<APIResource, { __typename: T }>
+
 export type APIResourceLocale<R extends APIResource | APIResourceType> = R extends
   | LocalizableAPIResource
   | LocalizableAPIResourceType

--- a/packages/runtime/src/state/api-client/fetch-api-resource.ts
+++ b/packages/runtime/src/state/api-client/fetch-api-resource.ts
@@ -1,6 +1,6 @@
 import { type ThunkAction } from '@reduxjs/toolkit'
 
-import { type SiteVersion, ApiHandlerHeaders, serializeSiteVersion } from '../../api/site-version'
+import { type SiteVersion } from '../../api/site-version'
 
 import * as SiteVersionState from '../modules/site-version'
 
@@ -11,15 +11,8 @@ import { setLocalizedResourceId } from '../host-api'
 import {
   APIResourceType,
   type APIResource,
-  type Swatch,
-  type File,
-  type Typography,
-  type GlobalElement,
-  type PagePathnameSlice,
-  type Table,
-  type LocalizedGlobalElement,
+  type APIResourceByType,
   type APIResourceLocale,
-  type HttpFetch,
 } from '../../api/types'
 
 import { type State, getHasAPIResource, getAPIResource, getLocalizedResourceId } from './state'
@@ -29,31 +22,13 @@ type Thunk<ReturnType> = ThunkAction<ReturnType, State, unknown, Action>
 export function fetchAPIResource<T extends APIResourceType>(
   resourceType: T,
   resourceId: string,
-  fetch: HttpFetch,
+  fetchResource: (
+    resourceId: string,
+    version: SiteVersion | null,
+    locale?: APIResourceLocale<T>,
+  ) => Promise<APIResourceByType<T> | null>,
   locale?: APIResourceLocale<T>,
-): Thunk<Promise<Extract<APIResource, { __typename: T }> | null>> {
-  const fetchVersioned = async <T>(url: string, version: SiteVersion | null): Promise<T | null> => {
-    const response = await fetch(url, {
-      headers: {
-        'Content-Type': 'application/json',
-        ...(version != null
-          ? { [ApiHandlerHeaders.SiteVersion]: serializeSiteVersion(version) }
-          : {}),
-      },
-    })
-
-    if (response.status === 404) return null
-    if (!response.ok) throw new Error(response.statusText)
-
-    if (response.headers.get('content-type')?.includes('application/json') !== true) {
-      throw new Error(
-        `Expected JSON response from "${url}" but got "${response.headers.get('content-type')}"`,
-      )
-    }
-
-    return response.json()
-  }
-
+): Thunk<Promise<APIResourceByType<T> | null>> {
   return async (dispatch, getState) => {
     const state = getState()
     const version = SiteVersionState.getSiteVersion(state.siteVersion)
@@ -66,25 +41,12 @@ export function fetchAPIResource<T extends APIResourceType>(
 
     switch (resourceType) {
       case APIResourceType.Swatch:
-        resource = await fetchVersioned<Swatch>(`/api/makeswift/swatches/${resourceId}`, version)
-        break
-
       case APIResourceType.File:
-        resource = await fetchVersioned<File>(`/api/makeswift/files/${resourceId}`, version)
-        break
-
       case APIResourceType.Typography:
-        resource = await fetchVersioned<Typography>(
-          `/api/makeswift/typographies/${resourceId}`,
-          version,
-        )
-        break
-
       case APIResourceType.GlobalElement:
-        resource = await fetchVersioned<GlobalElement>(
-          `/api/makeswift/global-elements/${resourceId}`,
-          version,
-        )
+      case APIResourceType.PagePathnameSlice:
+      case APIResourceType.Table:
+        resource = await fetchResource(resourceId, version, locale)
         break
 
       case APIResourceType.LocalizedGlobalElement: {
@@ -96,10 +58,7 @@ export function fetchAPIResource<T extends APIResourceType>(
           return null
         }
 
-        resource = await fetchVersioned<LocalizedGlobalElement>(
-          `/api/makeswift/localized-global-elements/${resourceId}/${locale}`,
-          version,
-        )
+        resource = await fetchResource(resourceId, version, locale)
 
         dispatch(
           setLocalizedResourceId({
@@ -112,25 +71,12 @@ export function fetchAPIResource<T extends APIResourceType>(
         break
       }
 
-      case APIResourceType.PagePathnameSlice: {
-        const url = new URL(`/api/makeswift/page-pathname-slices/${resourceId}`, 'http://n')
-
-        if (locale != null) url.searchParams.set('locale', locale)
-
-        resource = await fetchVersioned<PagePathnameSlice>(url.pathname + url.search, version)
-        break
-      }
-
-      case APIResourceType.Table:
-        resource = await fetchVersioned<Table>(`/api/makeswift/tables/${resourceId}`, version)
-        break
-
       default:
         resource = null
     }
 
     dispatch(apiResourceFulfilled(resourceType, resourceId, resource, locale))
 
-    return resource as Extract<APIResource, { __typename: T }> | null
+    return resource as APIResourceByType<T> | null
   }
 }


### PR DESCRIPTION
Server-side implementation of `ApiResourcesClient` interface; includes `HostApiResourcesClient` and `ApiResourcesClient` refactoring to facilitate better code reuse/greater encapsulation of the `ApiResourcesClient`'s core logic.