### PR TITLE
tests(runtime): add tests for `HostApiResourcesClient`

### DIFF
--- a/packages/runtime/src/api/__tests__/host-api-resource-client.test.ts
+++ b/packages/runtime/src/api/__tests__/host-api-resource-client.test.ts
@@ -1,0 +1,274 @@
+import { getLocalizedResourceId } from '../../state/api-client/state'
+import { HostApiResourcesClient } from '../host-api-resources-client'
+import { http, HttpResponse } from 'msw'
+
+import { server } from '../../mocks/server'
+import { TestWorkingSiteVersion, TestOrigins } from '../../testing/fixtures'
+import {
+  makeSwatch,
+  makeFile,
+  makeTypography,
+  makeGlobalElement,
+  makeLocalizedGlobalElement,
+  makePagePathnameSlice,
+  makeTable,
+} from '../../testing/fixtures/resources'
+
+import { type SiteVersion, ApiHandlerHeaders, deserializeSiteVersion } from '../site-version'
+import { APIResource } from '../types'
+
+const { apiOrigin } = TestOrigins
+const baseUrl = `${apiOrigin}/api/makeswift`
+
+function createTestClient({
+  siteVersion,
+  locale,
+}: {
+  siteVersion?: SiteVersion | null
+  locale?: string
+} = {}) {
+  return new HostApiResourcesClient({
+    fetch: (url, init) => globalThis.fetch(`${apiOrigin}${url}`, init),
+    preloadedState: {
+      siteVersion: siteVersion === undefined ? TestWorkingSiteVersion : siteVersion,
+      locale,
+    },
+  })
+}
+
+const searchParams = (req: Request) => new URL(req.url).searchParams
+
+let consoleErrorSpy: jest.SpyInstance
+
+beforeEach(() => {
+  consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  consoleErrorSpy.mockRestore()
+})
+
+type TestCase = {
+  name: string
+  resource: APIResource
+  makeUrl: (id: string) => string
+  readResource: (client: HostApiResourcesClient, id: string, locale?: string) => APIResource | null
+  fetchResource: (client: HostApiResourcesClient, id: string) => Promise<APIResource | null>
+}
+
+describe.each<TestCase>([
+  {
+    name: 'swatches',
+    resource: makeSwatch('mySwatch'),
+    makeUrl: id => `${baseUrl}/swatches/${id}`,
+    readResource: (client, id) => client.readSwatch(id),
+    fetchResource: (client, id) => client.fetchSwatch(id),
+  },
+  {
+    name: 'files',
+    resource: makeFile('myFile'),
+    makeUrl: id => `${baseUrl}/files/${id}`,
+    readResource: (client, id) => client.readFile(id),
+    fetchResource: (client, id) => client.fetchFile(id),
+  },
+  {
+    name: 'global elements',
+    resource: makeGlobalElement('myGlobalElement'),
+    makeUrl: id => `${baseUrl}/global-elements/${id}`,
+    readResource: (client, id) => client.readGlobalElement(id),
+    fetchResource: (client, id) => client.fetchGlobalElement(id),
+  },
+  {
+    name: 'localized global elements',
+    resource: makeLocalizedGlobalElement('myLocalizedGlobalElement'),
+    makeUrl: id => `${baseUrl}/localized-global-elements/${id}/es-MX`,
+    readResource: (client, globalElementId) =>
+      client.readLocalizedGlobalElement({ globalElementId, locale: 'es-MX' }),
+    fetchResource: (client, globalElementId) =>
+      client.fetchLocalizedGlobalElement({ globalElementId, locale: 'es-MX' }),
+  },
+  {
+    name: 'typographies',
+    resource: makeTypography('myTypography'),
+    makeUrl: id => `${baseUrl}/typographies/${id}`,
+    readResource: (client, id) => client.readTypography(id),
+    fetchResource: (client, id) => client.fetchTypography(id),
+  },
+  {
+    name: 'page pathnames',
+    resource: makePagePathnameSlice('myPathnameSlice'),
+    makeUrl: id => `${baseUrl}/page-pathname-slices/${id}`,
+    readResource: (client, pageId) => client.readPagePathnameSlice({ pageId, locale: null }),
+    fetchResource: (client, pageId) => client.fetchPagePathnameSlice({ pageId, locale: null }),
+  },
+  {
+    name: 'tables',
+    resource: makeTable('myTable'),
+    makeUrl: id => `${baseUrl}/tables/${id}`,
+    readResource: (client, id) => client.readTable(id),
+    fetchResource: (client, id) => client.fetchTable(id),
+  },
+])('$name', ({ resource, makeUrl, readResource, fetchResource }) => {
+  const resourceUrl = makeUrl(resource.id)
+
+  test('returns null on first read, retrieves from cache after fetch', async () => {
+    // Arrange
+    const client = createTestClient()
+    const httpGet = jest.fn(r => r)
+
+    server.use(http.get(resourceUrl, () => httpGet(HttpResponse.json(resource))))
+
+    // Act & Assert
+    const firstRead = readResource(client, resource.id)
+    expect(firstRead).toBeNull()
+    expect(httpGet).not.toHaveBeenCalled()
+
+    const fetchResult = await fetchResource(client, resource.id)
+    expect(fetchResult).toEqual(resource)
+    expect(httpGet).toHaveBeenCalledTimes(1)
+
+    const secondRead = readResource(client, resource.id)
+    expect(secondRead).toEqual(resource)
+    expect(httpGet).toHaveBeenCalledTimes(1)
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+  })
+
+  test('fetch returns null on 404', async () => {
+    // Arrange
+    const client = createTestClient()
+    const httpGet = jest.fn(r => r)
+
+    server.use(
+      http.get(resourceUrl, () => httpGet(HttpResponse.text('', { status: 404 })), {
+        once: true,
+      }),
+    )
+
+    // Act
+    const result = await fetchResource(client, resource.id)
+
+    // Assert
+    expect(result).toBeNull()
+    expect(httpGet).toHaveBeenCalledTimes(1)
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+  })
+
+  test('fetch include site version header', async () => {
+    // Arrange
+    const client = createTestClient()
+    const httpRequest = jest.fn()
+
+    server.use(
+      http.get(resourceUrl, ({ request }) => (httpRequest(request), HttpResponse.json(resource))),
+    )
+
+    // Act
+    await fetchResource(client, resource.id)
+
+    // Assert
+    expect(httpRequest).toHaveBeenCalledTimes(1)
+
+    const request = httpRequest.mock.calls[0][0] as Request
+    expect(
+      deserializeSiteVersion(request.headers.get(ApiHandlerHeaders.SiteVersion) ?? ''),
+    ).toEqual(TestWorkingSiteVersion)
+  })
+})
+
+describe('localized global elements', () => {
+  const globalElementId = 'myGlobalElement'
+  const locale = 'es-MX'
+  const resource = makeLocalizedGlobalElement('myLocalizedGlobalElement')
+  const resourceUrl = (locale: string) =>
+    `${baseUrl}/localized-global-elements/${globalElementId}/${locale}`
+
+  test('reads and fetches are partitioned by locale', async () => {
+    // Arrange
+    const client = createTestClient()
+    const httpGet = jest.fn(r => r)
+    const resource1 = makeLocalizedGlobalElement('myLocalizedGlobalElement1')
+    const resource2 = makeLocalizedGlobalElement('myLocalizedGlobalElement2')
+    const altLocale = 'fr'
+
+    server.use(http.get(resourceUrl(locale), () => httpGet(HttpResponse.json(resource1))))
+    server.use(http.get(resourceUrl(altLocale), () => httpGet(HttpResponse.json(resource2))))
+
+    // Act & Assert
+    const result1 = await client.fetchLocalizedGlobalElement({ globalElementId, locale })
+    expect(result1).toEqual(resource1)
+    expect(httpGet).toHaveBeenCalledTimes(1)
+
+    expect(client.readLocalizedGlobalElement({ globalElementId, locale: altLocale })).toBe(null)
+    const result2 = await client.fetchLocalizedGlobalElement({
+      globalElementId,
+      locale: altLocale,
+    })
+
+    expect(result2).toEqual(resource2)
+    expect(httpGet).toHaveBeenCalledTimes(2)
+  })
+
+  test('consequent fetches of missing element are cached', async () => {
+    // Arrange
+    const client = createTestClient()
+    const httpGet = jest.fn(r => r)
+
+    server.use(http.get(resourceUrl(locale), () => httpGet(HttpResponse.text('', { status: 404 }))))
+
+    // Act & Assert
+    const firstFetch = await client.fetchLocalizedGlobalElement({ globalElementId, locale })
+
+    expect(firstFetch).toBe(null)
+    expect(httpGet).toHaveBeenCalledTimes(1)
+
+    const secondFetch = await client.fetchLocalizedGlobalElement({ globalElementId, locale })
+
+    expect(secondFetch).toBe(null)
+    expect(httpGet).toHaveBeenCalledTimes(1)
+  })
+
+  test('fetching existing localized element sets localized resource ID', async () => {
+    // Arrange
+    const client = createTestClient()
+    const httpGet = jest.fn(r => r)
+    const localizedResourceId = () =>
+      getLocalizedResourceId(client.store.getState(), locale, globalElementId)
+
+    server.use(http.get(resourceUrl(locale), () => httpGet(HttpResponse.json(resource))))
+
+    // Act & Assert
+    expect(localizedResourceId()).toBe(undefined)
+
+    const result = await client.fetchLocalizedGlobalElement({ globalElementId, locale })
+
+    expect(result).toEqual(resource)
+    expect(httpGet).toHaveBeenCalledTimes(1)
+    expect(localizedResourceId()).toBe(resource.id)
+  })
+})
+
+describe('page pathnames', () => {
+  const resource = makePagePathnameSlice('myPagePathname')
+  const resourceUrl = `${baseUrl}/page-pathname-slices/${resource.id}`
+  const locale = 'es-MX'
+
+  test('fetches localized pathname when non-null locale is provided', async () => {
+    // Arrange
+    const client = createTestClient()
+    const httpRequest = jest.fn()
+
+    server.use(
+      http.get(resourceUrl, ({ request }) => (httpRequest(request), HttpResponse.json(resource))),
+    )
+
+    // Act
+    await client.fetchPagePathnameSlice({ pageId: resource.id, locale })
+
+    // Assert
+    expect(httpRequest).toHaveBeenCalledTimes(1)
+
+    const request = httpRequest.mock.calls[0][0] as Request
+    expect(searchParams(request).get('locale')).toEqual(locale)
+  })
+})

--- a/packages/runtime/src/client/tests/client.introspect-many.test.ts
+++ b/packages/runtime/src/client/tests/client.introspect-many.test.ts
@@ -5,7 +5,14 @@ import { Table } from '@makeswift/prop-controllers'
 import { createReactRuntime } from '../../runtimes/react/testing/react-runtime'
 
 import { server } from '../../mocks/server'
-import { TestWorkingSiteVersion } from '../../testing/fixtures'
+import { TestWorkingSiteVersion } from '../../testing/fixtures/site-version'
+import {
+  makeSwatch,
+  makeFile,
+  makeTable,
+  makeTypography,
+  makePagePathnameSlice,
+} from '../../testing/fixtures/resources'
 import { Color, Image, Link, unstable_Typography } from '../../controls'
 import { type Element } from '../../state/read-only-state'
 
@@ -30,48 +37,6 @@ runtime.registerComponent(() => null, {
 
 function createTestClient() {
   return new MakeswiftClient(TEST_API_KEY, { runtime })
-}
-
-function makeSwatch(id: string, hue = 0) {
-  return { __typename: 'Swatch' as const, id, hue, saturation: 100, lightness: 50 }
-}
-
-function makeFile(id: string) {
-  return {
-    __typename: 'File' as const,
-    id,
-    name: `file-${id}`,
-    extension: 'png',
-    publicUrl: `https://example.com/${id}`,
-    dimensions: { width: 100, height: 100 },
-  }
-}
-
-function makeTable(id: string) {
-  return { __typename: 'Table' as const, id, name: `table-${id}`, columns: [] }
-}
-
-function makeTypography(id: string, styleSwatchId: string | null = null) {
-  return {
-    __typename: 'Typography' as const,
-    id,
-    name: `typo-${id}`,
-    style: [
-      {
-        deviceId: 'desktop',
-        value: styleSwatchId != null ? { color: { swatchId: styleSwatchId, alpha: 1 } } : {},
-      },
-    ],
-  }
-}
-
-function makePagePathnameSlice(pageId: string, pathname = `/${pageId}`) {
-  return {
-    __typename: 'PagePathnameSlice' as const,
-    id: `slice-${pageId}`,
-    basePageId: pageId,
-    pathname,
-  }
 }
 
 function componentTree(
@@ -676,7 +641,7 @@ describe('introspectMany', () => {
       const client = createTestClient()
 
       // typo-1 has a style swatch 'typo-swatch'; 'direct-swatch' is only in tree-direct.
-      const typo1 = makeTypography('typo-1', 'typo-swatch')
+      const typo1 = makeTypography('typo-1', { swatchId: 'typo-swatch' })
 
       server.use(
         http.get(`${runtime.apiOrigin}/v3/typographies/bulk`, ({ request }) => {

--- a/packages/runtime/src/testing/fixtures/index.ts
+++ b/packages/runtime/src/testing/fixtures/index.ts
@@ -1,0 +1,3 @@
+export * from './origins'
+export * from './site-version'
+export * from './resources'

--- a/packages/runtime/src/testing/fixtures/origins.ts
+++ b/packages/runtime/src/testing/fixtures/origins.ts
@@ -1,0 +1,4 @@
+export const TestOrigins = {
+  apiOrigin: 'https://api.fakeswift.com',
+  appOrigin: 'https://app.fakeswift.com',
+} as const

--- a/packages/runtime/src/testing/fixtures/resources.ts
+++ b/packages/runtime/src/testing/fixtures/resources.ts
@@ -1,0 +1,85 @@
+import {
+  type Swatch,
+  type File,
+  type GlobalElement,
+  type LocalizedGlobalElement,
+  type Table,
+  type Typography,
+  type PagePathnameSlice,
+} from '../../api'
+
+export const makeSwatch = (id: string, { hue = 0 }: { hue?: number } = {}): Swatch => ({
+  __typename: 'Swatch',
+  id,
+  hue,
+  saturation: 100,
+  lightness: 50,
+})
+
+export const makeFile = (id: string): File => ({
+  __typename: 'File',
+  id,
+  name: `file ${id}`,
+  extension: 'png',
+  publicUrl: `https://example.com/${id}`,
+  dimensions: { width: 100, height: 100 },
+})
+
+export const makeTable = (id: string): Table => ({
+  __typename: 'Table',
+  id,
+  name: `table ${id}`,
+  columns: [],
+})
+
+const emptyStyle = {
+  fontFamily: null,
+  lineHeight: null,
+  letterSpacing: null,
+  fontWeight: null,
+  textAlign: null,
+  uppercase: null,
+  underline: null,
+  strikethrough: null,
+  italic: null,
+  fontSize: null,
+  color: null,
+}
+
+export const makeTypography = (
+  id: string,
+  { swatchId }: { swatchId?: string } = {},
+): Typography => ({
+  __typename: 'Typography',
+  id,
+  name: `typography ${id}`,
+  style: [
+    {
+      deviceId: 'desktop',
+      value:
+        swatchId != null ? { ...emptyStyle, color: { swatchId: swatchId, alpha: 1 } } : emptyStyle,
+    },
+  ],
+})
+
+export const makeGlobalElement = (id: string): GlobalElement => ({
+  __typename: 'GlobalElement',
+  id,
+  data: {},
+})
+
+export const makeLocalizedGlobalElement = (id: string): LocalizedGlobalElement => ({
+  __typename: 'LocalizedGlobalElement',
+  id,
+  data: {},
+})
+
+export const makePagePathnameSlice = (
+  pageId: string,
+  { pathname = `/${pageId}` }: { pathname?: string } = {},
+): PagePathnameSlice => ({
+  __typename: 'PagePathnameSlice',
+  id: pageId,
+  basePageId: pageId,
+  pathname,
+})

--- a/packages/runtime/src/testing/fixtures/site-version.ts
+++ b/packages/runtime/src/testing/fixtures/site-version.ts
@@ -1,12 +1,7 @@
-import { type SiteVersion } from '../next'
+import { type SiteVersion } from '../../api/site-version'
 
 export const TestWorkingSiteVersion: SiteVersion = {
   version: 'draft',
   token:
     'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJtYWtlc3dpZnQtcnVudGltZSIsImlhdCI6MTc1NDU5OTE0OSwiZXhwIjo0MTAyNDMyNzQ5LCJhdWQiOiJ0ZXN0Iiwic3ViIjoibWFrZXN3aWZ0LXJ1bnRpbWUifQ.-1BDOmEN1Q1QeKP7qfjPyAkrKRjb4q4qaqyhPBvMnhg',
-} as const
-
-export const TestOrigins = {
-  apiOrigin: 'https://api.fakeswift.com',
-  appOrigin: 'https://app.fakeswift.com',
 } as const


### PR DESCRIPTION
Prep for an upcoming refactoring PR. No semantic changes.