### PR TITLE
feat(runtime): experimental flag to enforce 200 responses

### DIFF
--- a/.changeset/sunny-eagles-lie.md
+++ b/.changeset/sunny-eagles-lie.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+feat: add experimental option to `getComponentSnapshot` to enforce 200 responses from the Makeswift API.

--- a/packages/runtime/src/client/index.ts
+++ b/packages/runtime/src/client/index.ts
@@ -760,63 +760,90 @@ export class MakeswiftClient extends MakeswiftRestAPIClient {
       siteVersion: siteVersionPromise,
       locale,
       allowLocaleFallback = true,
+      unstable_enforceSuccess = false,
     }: {
       siteVersion: SiteVersion | null | Promise<SiteVersion | null>
       locale?: string
       allowLocaleFallback?: boolean
+      unstable_enforceSuccess?: boolean
     },
   ): Promise<MakeswiftComponentSnapshot> {
-    const searchParams = new URLSearchParams()
-    if (locale) searchParams.set('locale', locale)
-
     const siteVersion = await siteVersionPromise
     const key = deterministicUUID({ id, locale, seed: this.apiKey.split('-').at(0) })
     const baseLocaleWasRequested = locale == null
     const canAttemptLocaleFallback = !baseLocaleWasRequested && allowLocaleFallback
 
-    let response
-    const responseForRequestedLocale = await this.fetch(
-      `v2/element-trees/${encodeURIComponent(id)}?${searchParams.toString()}`,
-      siteVersion,
-    )
-
-    if (responseForRequestedLocale.status === 404 && canAttemptLocaleFallback) {
-      await failedResponseBody(responseForRequestedLocale)
-      response = await this.fetch(`v2/element-trees/${encodeURIComponent(id)}`, siteVersion)
-    } else {
-      response = responseForRequestedLocale
-    }
-
-    if (!response.ok) {
-      // See comment on `failedResponseBody` for why we always consume the
-      // response body of failed responses.
-      const failedBody = await failedResponseBody(response)
-      if (response.status === 404) {
-        return {
-          document: {
-            id,
-            locale: locale ?? null,
-            data: null,
-          },
-          key,
-          cacheData: CacheData.empty(),
-          meta: {
-            allowLocaleFallback,
-            requestedLocale: locale ?? null,
-          },
+    const parseElementTreeResponse = async (
+      response: Response,
+    ): Promise<MakeswiftComponentDocument | null> => {
+      if (!response.ok) {
+        // See comment on `failedResponseBody` for why we always consume the
+        // response body of failed responses.
+        const failedBody = await failedResponseBody(response)
+        if (response.status === 404) {
+          return null
         }
+
+        console.error(`Failed to get component snapshot for '${id}':`, {
+          response: failedBody,
+          siteVersion,
+          locale,
+        })
+
+        throw new Error(`Failed to get component snapshot for '${id}': ${responseError(response)}`)
       }
 
-      console.error(`Failed to get component snapshot for '${id}':`, {
-        response: failedBody,
-        siteVersion,
-        locale,
-      })
-
-      throw new Error(`Failed to get component snapshot for '${id}': ${responseError(response)}`)
+      const responseBody = await response.json()
+      const parsed = Schema.componentDocumentResponse.parse(responseBody)
+      if ('notFound' in parsed) return null
+      return parsed
     }
 
-    const document = Schema.componentDocument.parse(await response.json())
+    const getElementTree = async (
+      searchParams: URLSearchParams,
+    ): Promise<MakeswiftComponentDocument | null> => {
+      const response = await this.fetch(
+        `v2/element-trees/${encodeURIComponent(id)}?${searchParams.toString()}`,
+        siteVersion,
+      )
+      return await parseElementTreeResponse(response)
+    }
+
+    const getPrimaryTree = async (): Promise<MakeswiftComponentDocument | null> => {
+      const searchParams = new URLSearchParams()
+      if (locale) searchParams.set('locale', locale)
+      if (unstable_enforceSuccess) searchParams.set('unstable_enforceSuccess', 'true')
+      return await getElementTree(searchParams)
+    }
+
+    const getFallbackTree = async (): Promise<MakeswiftComponentDocument | null> => {
+      const searchParams = new URLSearchParams()
+      if (unstable_enforceSuccess) searchParams.set('unstable_enforceSuccess', 'true')
+      return await getElementTree(searchParams)
+    }
+
+    const primaryTree = await getPrimaryTree()
+
+    const result =
+      primaryTree == null && canAttemptLocaleFallback ? await getFallbackTree() : primaryTree
+
+    if (result == null) {
+      return {
+        document: {
+          id,
+          locale: locale ?? null,
+          data: null,
+        },
+        key,
+        cacheData: CacheData.empty(),
+        meta: {
+          allowLocaleFallback,
+          requestedLocale: locale ?? null,
+        },
+      }
+    }
+
+    const document = result
     const cacheData = await this.introspect(document.data, siteVersion, document.locale)
 
     return {

--- a/packages/runtime/src/client/schema/component-document.ts
+++ b/packages/runtime/src/client/schema/component-document.ts
@@ -16,3 +16,12 @@ export const componentDocumentFallback = z.object({
   locale: z.string().nullable(),
   data: z.null(),
 })
+
+const unstableNotFoundComponentDocumentResponse = z.object({
+  notFound: z.literal(true),
+})
+
+export const componentDocumentResponse = z.union([
+  unstableNotFoundComponentDocumentResponse,
+  componentDocument,
+])

--- a/packages/runtime/src/client/tests/client.get-component-snapshot.test.ts
+++ b/packages/runtime/src/client/tests/client.get-component-snapshot.test.ts
@@ -45,6 +45,96 @@ describe('getComponentSnapshot using v2 element tree endpoint', () => {
     expect(result.document.data).toBeNull()
   })
 
+  test('return null document data on a 200 `{ notFound: true }` response', async () => {
+    // Arrange
+    const client = createTestClient()
+    const treeId = 'myTree'
+    server.use(
+      http.get(
+        `${baseUrl}/${treeId}`,
+        () => HttpResponse.json({ notFound: true }, { status: 200 }),
+        { once: true },
+      ),
+    )
+
+    // Act
+    const result = await client.getComponentSnapshot(treeId, {
+      siteVersion: TestWorkingSiteVersion,
+    })
+
+    // Assert
+    expect(result.document).not.toBeNull()
+    expect(result.document.id).toBe(treeId)
+    expect(result.document.data).toBeNull()
+  })
+
+  test('omits the `unstable_enforceSuccess` QSP when `unstable_enforceSuccess` is false', async () => {
+    // Arrange
+    const client = createTestClient()
+    const treeId = 'myTree'
+    const httpHandler = jest.fn(({ request }) => {
+      void request
+      return HttpResponse.text('', { status: 404 })
+    })
+    server.use(http.get(`${baseUrl}/${treeId}`, httpHandler))
+
+    // Act
+    await client.getComponentSnapshot(treeId, {
+      siteVersion: TestWorkingSiteVersion,
+      unstable_enforceSuccess: false,
+    })
+
+    // Assert
+    expect(httpHandler.mock.calls[0][0].request.url).not.toContain('unstable_enforceSuccess')
+  })
+
+  test('performs locale fallback on a 200 `{ notFound: true }` response', async () => {
+    // Arrange
+    const client = createTestClient()
+    const localeToTest = 'fr-FR'
+    const treeId = 'myTree123'
+    const elementTreeKey = 'abc123'
+    const document: MakeswiftComponentDocument = {
+      id: treeId,
+      name: 'myElementTree',
+      data: {
+        type: 'myType',
+        key: elementTreeKey,
+        props: {},
+      },
+      locale: null,
+      siteId: 'mySiteId',
+      inheritsFromParent: false,
+    }
+
+    const httpHandler = jest.fn(({ request }) => {
+      const { searchParams } = new URL(request.url)
+      if (searchParams.get('locale') === localeToTest) {
+        return HttpResponse.json({ notFound: true }, { status: 200 })
+      }
+
+      return HttpResponse.json(document, { status: 200 })
+    })
+
+    server.use(
+      http.get(`${baseUrl}/${encodeURIComponent(treeId)}`, httpHandler),
+      graphql.operation(() => {
+        return HttpResponse.json({})
+      }),
+    )
+
+    // Act
+    const result = await client.getComponentSnapshot(treeId, {
+      siteVersion: TestWorkingSiteVersion,
+      locale: localeToTest,
+    })
+
+    // Assert
+    expect(result.document.data?.key).toBe(elementTreeKey)
+    expect(result.document.locale).toBeNull()
+    expect(httpHandler).toHaveBeenCalledTimes(2)
+  })
+
   test('throws on errors other than 404', async () => {
     // Arrange
     const client = createTestClient()


### PR DESCRIPTION
Introduces a new option for the `getComponentSnapshot` that causes the endpoint to return a 200 response, making the fetched results more easily cacheable by higher-level frameworks.