### PR TITLE
feat(runtime): use `MakeswiftApiResourcesClient` on the server if runtime instance was provided with an API key

### DIFF
--- a/.changeset/twenty-years-throw.md
+++ b/.changeset/twenty-years-throw.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+feat: use `MakeswiftApiResourcesClient` on the server if runtime instance was provided with an API key

--- a/packages/runtime/src/api/makeswift-api-resources-client.ts
+++ b/packages/runtime/src/api/makeswift-api-resources-client.ts
@@ -13,9 +13,11 @@ import {
 } from './types'
 
 import { ApiResourcesClient } from './api-resources-client'
-import { MakeswiftGraphQLApiClient } from './graphql-api-client'
-import { MakeswiftRestAPIClient } from './rest-api-client'
 import { type SiteVersion } from './site-version'
+
+// see the comment in `MakeswiftApiResourcesClient` constructor below
+import { type MakeswiftGraphQLApiClient } from './graphql-api-client'
+import { type MakeswiftRestAPIClient } from './rest-api-client'
 
 /**
  * Server-side implementation that makes direct authenticated requests to the Makeswift API.
@@ -25,8 +27,8 @@ import { type SiteVersion } from './site-version'
  * `/api/makeswift/...` endpoints.
  */
 export class MakeswiftApiResourcesClient extends ApiResourcesClient {
-  private restApiClient: MakeswiftRestAPIClient
-  private graphQlClient: MakeswiftGraphQLApiClient
+  private restApiClient: Promise<MakeswiftRestAPIClient>
+  private graphQlClient: Promise<MakeswiftGraphQLApiClient>
 
   constructor({
     fetch,
@@ -45,31 +47,45 @@ export class MakeswiftApiResourcesClient extends ApiResourcesClient {
       store: configureClientStore({ preloadedState }),
     })
 
-    this.restApiClient = new MakeswiftRestAPIClient({ fetch, apiKey, apiOrigin })
-    this.graphQlClient = new MakeswiftGraphQLApiClient({ endpoint: graphqlApiEndpoint })
+    // `MakeswiftApiResourcesClient` is used by the runtime and therefore will be imported
+    // on the client; lazy import server-side REST/GraphQL clients to avoid unnecessarily
+    // pulling their code into a client bundle.
+    //
+    // (we can't easily lazy-load `MakeswiftApiResourcesClient` itself, at it will make its
+    // construction async, but because it shares most of its implementation with
+    // `HostApiResourcesClient`, the overhead of this module on its own is negligible)
+    this.restApiClient = (async () => {
+      const { MakeswiftRestAPIClient } = await import('./rest-api-client')
+      return new MakeswiftRestAPIClient({ fetch, apiKey, apiOrigin })
+    })()
+
+    this.graphQlClient = (async () => {
+      const { MakeswiftGraphQLApiClient } = await import('./graphql-api-client')
+      return new MakeswiftGraphQLApiClient({ endpoint: graphqlApiEndpoint })
+    })()
   }
 
   protected async fetchSwatchImpl(id: string, version: SiteVersion | null): Promise<Swatch | null> {
-    return this.restApiClient.getSwatch(id, version)
+    return (await this.restApiClient).getSwatch(id, version)
   }
 
   protected async fetchFileImpl(id: string, _version: SiteVersion | null): Promise<File | null> {
     // files are unversioned
-    return this.graphQlClient.getFile(id)
+    return (await this.graphQlClient).getFile(id)
   }
 
   protected async fetchTypographyImpl(
     id: string,
     version: SiteVersion | null,
   ): Promise<Typography | null> {
-    return this.restApiClient.getTypography(id, version)
+    return (await this.restApiClient).getTypography(id, version)
   }
 
   protected async fetchGlobalElementImpl(
     id: string,
     version: SiteVersion | null,
   ): Promise<GlobalElement | null> {
-    return this.restApiClient.getGlobalElement(id, version)
+    return (await this.restApiClient).getGlobalElement(id, version)
   }
 
   protected async fetchLocalizedGlobalElementImpl(
@@ -77,7 +93,7 @@ export class MakeswiftApiResourcesClient extends ApiResourcesClient {
     version: SiteVersion | null,
     locale: string,
   ): Promise<LocalizedGlobalElement | null> {
-    return this.restApiClient.getLocalizedGlobalElement(id, locale, version)
+    return (await this.restApiClient).getLocalizedGlobalElement(id, locale, version)
   }
 
   protected async fetchPagePathnameSliceImpl(
@@ -85,11 +101,11 @@ export class MakeswiftApiResourcesClient extends ApiResourcesClient {
     version: SiteVersion | null,
     locale: string | null | undefined,
   ): Promise<PagePathnameSlice | null> {
-    return this.restApiClient.getPagePathnameSlice(id, version, { locale })
+    return (await this.restApiClient).getPagePathnameSlice(id, version, { locale })
   }
 
   protected async fetchTableImpl(id: string, _version: SiteVersion | null): Promise<Table | null> {
     // tables are unversioned
-    return this.graphQlClient.getTable(id)
+    return (await this.graphQlClient).getTable(id)
   }
 }

--- a/packages/runtime/src/runtimes/react/runtime-core.ts
+++ b/packages/runtime/src/runtimes/react/runtime-core.ts
@@ -1,12 +1,14 @@
 import { type SerializableReplacementContext } from '@makeswift/controls'
 
+import { ApiResourcesClient } from '../../api/api-resources-client'
 import { HostApiResourcesClient } from '../../api/host-api-resources-client'
+import { MakeswiftApiResourcesClient } from '../../api/makeswift-api-resources-client'
 import { type HttpFetch } from '../../api/types'
 import { type SiteVersion } from '../../api/site-version'
 
 import {
-  Breakpoints,
-  BreakpointsInput,
+  type Breakpoints,
+  type BreakpointsInput,
   parseBreakpointsInput,
 } from '../../state/modules/breakpoints'
 
@@ -43,6 +45,8 @@ export class RuntimeCore {
     ttlCheck: RefCountedMap.TTLCheck.ON_RETAIN | RefCountedMap.TTLCheck.ON_RELEASE,
   })
 
+  private readonly apiKey: string | undefined
+
   readonly protoStore: ProtoStore
   readonly appOrigin: string
   readonly apiOrigin: string
@@ -52,18 +56,21 @@ export class RuntimeCore {
   constructor({
     appOrigin = 'https://app.makeswift.com',
     apiOrigin = 'https://api.makeswift.com',
+    apiKey,
     breakpoints,
     requestKey,
     fetch,
   }: {
     appOrigin?: string
     apiOrigin?: string
+    apiKey?: string
     breakpoints?: BreakpointsInput
     requestKey?: StoreKey
     fetch: HttpFetch
   }) {
     this.appOrigin = validateOrigin(appOrigin, 'appOrigin')
     this.apiOrigin = validateOrigin(apiOrigin, 'apiOrigin')
+    this.apiKey = apiKey
     this.requestKey = requestKey
     this.fetch = fetch
 
@@ -148,7 +155,17 @@ export class RuntimeCore {
   private createApiResourcesClient(preloadedState: {
     siteVersion: SiteVersion | null
     locale: string | undefined
-  }) {
+  }): ApiResourcesClient {
+    if (isServer() && this.apiKey) {
+      return new MakeswiftApiResourcesClient({
+        fetch: this.fetch,
+        apiKey: this.apiKey,
+        apiOrigin: this.apiOrigin,
+        graphqlApiEndpoint: this.graphqlApiEndpoint,
+        preloadedState,
+      })
+    }
+
     return new HostApiResourcesClient({
       fetch: this.fetch,
       preloadedState,


### PR DESCRIPTION
Non-breaking. No behavior change unless user provided an API key when constructing the runtime.