### PR TITLE
feat(runtime): stackable `FrameworkContextProvider`

### DIFF
--- a/.changeset/crisp-plums-watch.md
+++ b/.changeset/crisp-plums-watch.md
@@ -1,0 +1,6 @@
+---
+'@makeswift/react-router': patch
+'@makeswift/runtime': patch
+---
+
+feat: stackable `FrameworkContextProvider` with support for partial overrides.

--- a/packages/react-router/src/components/framework-provider/index.tsx
+++ b/packages/react-router/src/components/framework-provider/index.tsx
@@ -1,21 +1,11 @@
-import { type PropsWithChildren, useState } from 'react'
+import { type PropsWithChildren } from 'react'
 
-import {
-  FrameworkContext,
-  DefaultHead,
-  DefaultHeadSnippet,
-  DefaultImage,
-} from '@makeswift/runtime/unstable-framework-support'
+import { FrameworkContextProvider } from '@makeswift/runtime/unstable-framework-support'
 
 import { Link } from './link'
 
-export function FrameworkProvider({ children }: PropsWithChildren) {
-  const [context] = useState<FrameworkContext>({
-    Head: DefaultHead,
-    HeadSnippet: DefaultHeadSnippet,
-    Image: DefaultImage,
-    Link,
-  })
+const context = { Link }
 
-  return <FrameworkContext.Provider value={context}>{children}</FrameworkContext.Provider>
+export function FrameworkProvider({ children }: PropsWithChildren) {
+  return <FrameworkContextProvider value={context}>{children}</FrameworkContextProvider>
 }

--- a/packages/runtime/src/next/components/framework-provider/app-router/index.ts
+++ b/packages/runtime/src/next/components/framework-provider/app-router/index.ts
@@ -1,13 +1,9 @@
-import {
-  type FrameworkContext,
-  DefaultHead,
-} from '../../../../runtimes/react/components/framework-context'
+import { type FrameworkContext } from '../../../../runtimes/react/components/framework-context'
 
 import { HeadSnippet } from './HeadSnippet'
 
-export const context: Pick<FrameworkContext, 'Head' | 'HeadSnippet'> = {
+export const context: Pick<FrameworkContext, 'HeadSnippet'> = {
   // The App Router uses built-in React Canary releases, which include all stable
   // React 19 features, so we can simply use our default head implementation
-  Head: DefaultHead,
   HeadSnippet,
 }

--- a/packages/runtime/src/next/components/framework-provider/index.tsx
+++ b/packages/runtime/src/next/components/framework-provider/index.tsx
@@ -4,7 +4,10 @@ import { type PropsWithChildren, useMemo } from 'react'
 import NextImage from 'next/image'
 
 import { useIsPagesRouter } from '../../hooks/use-is-pages-router'
-import { FrameworkContext } from '../../../runtimes/react/components/framework-context'
+import {
+  type FrameworkContext,
+  FrameworkContextProvider,
+} from '../../../runtimes/react/components/framework-context'
 
 import { context as appRouterContext } from './app-router'
 import { context as pagesRouterContext } from './pages-router'
@@ -15,7 +18,7 @@ export function FrameworkProvider({
   forcePagesRouter,
 }: PropsWithChildren<{ forcePagesRouter?: boolean }>) {
   const isPagesRouter = useIsPagesRouter() || forcePagesRouter
-  const context = useMemo<FrameworkContext>(
+  const context = useMemo<Partial<FrameworkContext>>(
     () => ({
       ...(isPagesRouter ? pagesRouterContext : appRouterContext),
       Image: NextImage,
@@ -24,5 +27,5 @@ export function FrameworkProvider({
     [isPagesRouter],
   )
 
-  return <FrameworkContext.Provider value={context}>{children}</FrameworkContext.Provider>
+  return <FrameworkContextProvider value={context}>{children}</FrameworkContextProvider>
 }

--- a/packages/runtime/src/next/components/tests/makeswift-page-snippets-rendering.test.tsx
+++ b/packages/runtime/src/next/components/tests/makeswift-page-snippets-rendering.test.tsx
@@ -1,9 +1,10 @@
 /** @jest-environment jsdom */
 
 import '@testing-library/jest-dom'
-import { type Snippet } from '../../../client'
 
 import { createMakeswiftPageSnapshot, testMakeswiftPageHeadRendering } from '../../testing'
+
+import { createSnippet } from '../../../testing/fixtures'
 
 import { pageDocument } from './__fixtures__/page-document'
 
@@ -20,15 +21,6 @@ jest.mock('next/script', () => ({
     </script>
   )),
 }))
-
-const createSnippet = ({ id, code }: { id: string; code: string }): Snippet => ({
-  id,
-  code,
-  location: 'HEAD',
-  liveEnabled: true,
-  builderEnabled: true,
-  cleanup: null,
-})
 
 const getPageSnippetTags = (container: HTMLElement) =>
   Array.from(container.querySelectorAll('*[data-makeswift-snippet-id]'))

--- a/packages/runtime/src/runtimes/react/components/__tests__/__snapshots__/framework-context.test.tsx.snap
+++ b/packages/runtime/src/runtimes/react/components/__tests__/__snapshots__/framework-context.test.tsx.snap
@@ -1,0 +1,96 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Provider values override default context 1`] = `
+<div
+  data-testid="test-id"
+>
+  <img
+    alt="example image"
+    loading="lazy"
+    src="https://example.com/image.jpg"
+  />
+  <a
+    data-test-id="custom link"
+    href="https://example.com"
+  >
+    Click here
+  </a>
+</div>
+`;
+
+exports[`Provider values override default context: head 1`] = `
+<head>
+  <title>
+    Document title
+  </title>
+  <script
+    data-makeswift-snippet-id="test-snippet"
+  >
+    console.log("hello")
+  </script>
+</head>
+`;
+
+exports[`Providers are stackable, support partial overrides 1`] = `
+<div
+  data-testid="test-id"
+>
+  <img
+    alt="example image"
+    data-test-id="custom image 2"
+    src="https://example.com/image.jpg"
+  />
+  <a
+    data-test-id="custom link"
+    href="https://example.com"
+  >
+    Click here
+  </a>
+</div>
+`;
+
+exports[`Providers are stackable, support partial overrides: head 1`] = `
+<head>
+  <meta
+    name="extra"
+  />
+  <title>
+    Document title
+  </title>
+  <script
+    data-makeswift-snippet-id="test-snippet"
+  >
+    console.log("hello")
+  </script>
+</head>
+`;
+
+exports[`useFrameworkContext without a provider returns default context 1`] = `
+<div
+  data-testid="test-id"
+>
+  <img
+    alt="example image"
+    loading="lazy"
+    src="https://example.com/image.jpg"
+  />
+  <a
+    href="https://example.com"
+  >
+    Click here
+  </a>
+</div>
+`;
+
+exports[`useFrameworkContext without a provider returns default context: head 1`] = `
+<head>
+  <title>
+    Document title
+  </title>
+  <script
+    data-makeswift-snippet-id="test-snippet"
+  >
+    console.log("hello")
+  </script>
+</head>
+`;

--- a/packages/runtime/src/runtimes/react/components/__tests__/framework-context.test.tsx
+++ b/packages/runtime/src/runtimes/react/components/__tests__/framework-context.test.tsx
@@ -1,0 +1,88 @@
+/** @jest-environment jsdom */
+
+import { act, forwardRef } from 'react'
+import { render, screen } from '@testing-library/react'
+
+import { createSnippet } from '../../../../testing/fixtures'
+
+import {
+  type FrameworkContext,
+  FrameworkContextProvider,
+  useFrameworkContext,
+} from '../framework-context'
+
+const testId = 'test-id'
+
+const Head: FrameworkContext['Head'] = ({ children }) => (
+  <>
+    <meta name="extra" />
+    {children}
+  </>
+)
+
+const Link: FrameworkContext['Link'] = forwardRef(({ href, children }, _ref) => (
+  <a href={href} data-test-id="custom link">
+    {children}
+  </a>
+))
+
+const Image1: FrameworkContext['Image'] = forwardRef(({ src, alt }, _ref) => (
+  <img src={src} alt={alt} data-test-id="custom image 1" />
+))
+
+const Image2: FrameworkContext['Image'] = forwardRef(({ src, alt }, _ref) => (
+  <img src={src} alt={alt} data-test-id="custom image 2" />
+))
+
+const TestComponent = () => {
+  const { Head, HeadSnippet, Image, Link } = useFrameworkContext()
+  return (
+    <div data-testid={testId}>
+      <Head>
+        <title>Document title</title>
+      </Head>
+      <HeadSnippet
+        snippet={createSnippet({
+          id: 'test-snippet',
+          code: '<script>console.log("hello")</script>',
+        })}
+      />
+      <Image src="https://example.com/image.jpg" alt="example image" />
+      <Link href="https://example.com">Click here</Link>
+    </div>
+  )
+}
+
+test('useFrameworkContext without a provider returns default context', async () => {
+  await act(async () => render(<TestComponent />))
+  expect(screen.getByTestId(testId)).toMatchSnapshot()
+  expect(document.head).toMatchSnapshot('head')
+})
+
+test('Provider values override default context', async () => {
+  await act(async () =>
+    render(
+      <FrameworkContextProvider value={{ Link }}>
+        <TestComponent />
+      </FrameworkContextProvider>,
+    ),
+  )
+  expect(screen.getByTestId(testId)).toMatchSnapshot()
+  expect(document.head).toMatchSnapshot('head')
+})
+
+test('Providers are stackable, support partial overrides', async () => {
+  await act(async () =>
+    render(
+      <FrameworkContextProvider value={{ Link, Image: Image1 }}>
+        <FrameworkContextProvider value={{ Image: Image2 }}>
+          <FrameworkContextProvider value={{ Head }}>
+            <TestComponent />
+          </FrameworkContextProvider>
+        </FrameworkContextProvider>
+      </FrameworkContextProvider>,
+    ),
+  )
+  expect(screen.getByTestId(testId)).toMatchSnapshot()
+  expect(document.head).toMatchSnapshot('head')
+})

--- a/packages/runtime/src/runtimes/react/components/framework-context.tsx
+++ b/packages/runtime/src/runtimes/react/components/framework-context.tsx
@@ -1,5 +1,4 @@
 import {
-  createContext,
   type ReactNode,
   type PropsWithChildren,
   type CSSProperties,
@@ -8,6 +7,9 @@ import {
   type ForwardRefExoticComponent,
   type RefAttributes,
   forwardRef,
+  createContext,
+  useContext,
+  useMemo,
 } from 'react'
 
 import { type LinkData } from '@makeswift/prop-controllers'
@@ -44,11 +46,11 @@ export type FrameworkContext = {
 }
 
 // React 19 automatically hoists metadata tags to the <head>
-export const DefaultHead = ({ children }: PropsWithChildren) => <>{children}</>
+const DefaultHead = ({ children }: PropsWithChildren) => <>{children}</>
 
-export const DefaultHeadSnippet = BaseHeadSnippet
+const DefaultHeadSnippet = BaseHeadSnippet
 
-export const DefaultImage: ImageComponent = ({ priority, fill, style, ...props }) => (
+const DefaultImage: ImageComponent = ({ priority, fill, style, ...props }) => (
   <img
     {...props}
     style={{
@@ -65,13 +67,29 @@ export const DefaultImage: ImageComponent = ({ priority, fill, style, ...props }
   />
 )
 
-export const DefaultLink: LinkComponent = forwardRef<HTMLAnchorElement, LinkProps>(
+const DefaultLink: LinkComponent = forwardRef<HTMLAnchorElement, LinkProps>(
   ({ linkType, ...props }, ref) => <a {...props} ref={ref} />,
 )
 
-export const FrameworkContext = createContext<FrameworkContext>({
+const FrameworkContext = createContext<Partial<FrameworkContext>>({})
+
+export const FrameworkContextProvider = ({
+  value,
+  children,
+}: PropsWithChildren<{ value: Partial<FrameworkContext> }>) => {
+  const parentContext = useContext(FrameworkContext)
+  const mergedContext = useMemo(() => ({ ...parentContext, ...value }), [parentContext, value])
+
+  return <FrameworkContext.Provider value={mergedContext}>{children}</FrameworkContext.Provider>
+}
+
+const defaultContext: FrameworkContext = {
   Head: DefaultHead,
   HeadSnippet: DefaultHeadSnippet,
   Image: DefaultImage,
   Link: DefaultLink,
-})
+}
+
+export function useFrameworkContext(): FrameworkContext {
+  return { ...defaultContext, ...useContext(FrameworkContext) }
+}

--- a/packages/runtime/src/runtimes/react/components/hooks/use-framework-context.tsx
+++ b/packages/runtime/src/runtimes/react/components/hooks/use-framework-context.tsx
@@ -1,7 +1,1 @@
-import { useContext } from 'react'
-
-import { FrameworkContext } from '../framework-context'
-
-export function useFrameworkContext() {
-  return useContext(FrameworkContext)
-}
+export { useFrameworkContext } from '../framework-context'

--- a/packages/runtime/src/testing/fixtures/index.ts
+++ b/packages/runtime/src/testing/fixtures/index.ts
@@ -1,3 +1,4 @@
 export * from './origins'
-export * from './site-version'
 export * from './resources'
+export * from './site-version'
+export * from './snippet'

--- a/packages/runtime/src/testing/fixtures/snippet.ts
+++ b/packages/runtime/src/testing/fixtures/snippet.ts
@@ -1,0 +1,10 @@
+import { type Snippet } from '../../client/page-snapshot'
+
+export const createSnippet = ({ id, code }: { id: string; code: string }): Snippet => ({
+  id,
+  code,
+  location: 'HEAD',
+  liveEnabled: true,
+  builderEnabled: true,
+  cleanup: null,
+})

--- a/packages/runtime/src/unstable-framework-support/index.ts
+++ b/packages/runtime/src/unstable-framework-support/index.ts
@@ -20,10 +20,8 @@ export { MakeswiftClient } from '../client'
 export { type BreakpointsInput as Breakpoints } from '../state/modules/breakpoints'
 
 export {
-  FrameworkContext,
-  DefaultHead,
-  DefaultHeadSnippet,
-  DefaultImage,
+  type FrameworkContext,
+  FrameworkContextProvider,
 } from '../runtimes/react/components/framework-context'
 
 export { MakeswiftComponent } from '../runtimes/react/components/MakeswiftComponent'


### PR DESCRIPTION
Stackable `FrameworkContextProvider` with support for partial overrides.

As the framework context expands to cover more orthogonal concerns, we need to support selective, partial overrides without replacing unrelated defaults.