### PR TITLE
refactor(runtime): decouple/tidy up `useResolvedProps`

### DIFF
--- a/packages/runtime/src/runtimes/react/components/resolve-props.tsx
+++ b/packages/runtime/src/runtimes/react/components/resolve-props.tsx
@@ -4,6 +4,7 @@ import { type ElementData } from '../../../state/read-only-state'
 
 import { useControlDefs } from '../hooks/use-control-defs'
 import { useResolvedProps } from '../hooks/use-resolved-props'
+import { useStylesheetFactory } from '../hooks/use-stylesheet-factory'
 
 import { resolveLegacyDescriptorProp } from '../legacy-controls'
 
@@ -16,7 +17,13 @@ export function ResolveProps({
 }): ReactNode {
   const [legacyDescriptors, definitions] = useControlDefs({ elementType: element.type })
 
-  const resolvedProps = useResolvedProps(definitions, element.props, element.key)
+  const stylesheetFactory = useStylesheetFactory()
+  const resolvedProps = useResolvedProps({
+    propDefs: definitions,
+    propData: element.props,
+    elementKey: element.key,
+    stylesheetFactory,
+  })
 
   const renderFn = Object.entries(legacyDescriptors).reduceRight(
     (renderFn, [propName, descriptor]) =>

--- a/packages/runtime/src/runtimes/react/hooks/use-control-instances.ts
+++ b/packages/runtime/src/runtimes/react/hooks/use-control-instances.ts
@@ -1,0 +1,15 @@
+import { ControlInstance } from '@makeswift/controls'
+
+import { getPropControllers } from '../../../state/read-only-state'
+import { useDocumentKey } from './use-document-context'
+import { useSelector } from './use-selector'
+
+export function useControlInstances(elementKey: string): Record<string, ControlInstance> | null {
+  const documentKey = useDocumentKey()
+
+  return useSelector(state => {
+    if (documentKey == null) return null
+
+    return getPropControllers(state, { documentKey, elementKey })
+  })
+}

--- a/packages/runtime/src/runtimes/react/hooks/use-resolved-props.ts
+++ b/packages/runtime/src/runtimes/react/hooks/use-resolved-props.ts
@@ -7,25 +7,13 @@ import {
   type Resolvable,
 } from '@makeswift/controls'
 
-import * as ReactPage from '../../../state/read-only-state'
 import { useResourceResolver } from './use-resource-resolver'
-import { useDocumentKey } from './use-document-context'
-import { useSelector } from './use-selector'
 
-import { useStylesheetFactory } from './use-stylesheet-factory'
-
-import { useResolvableRecord } from './use-resolvable-record'
+import { type StylesheetFactory } from '../stylesheet-factory'
 import { propErrorHandlingProxy } from '../utils/prop-error-handling-proxy'
 
-function useControlInstances(elementKey: string): Record<string, ControlInstance> | null {
-  const documentKey = useDocumentKey()
-
-  return useSelector(state => {
-    if (documentKey == null) return null
-
-    return ReactPage.getPropControllers(state, { documentKey, elementKey })
-  })
-}
+import { useControlInstances } from './use-control-instances'
+import { useResolvableRecord } from './use-resolvable-record'
 
 type CacheItem = {
   data: Data
@@ -33,19 +21,24 @@ type CacheItem = {
   resolvedValue: Resolvable<unknown>
 }
 
-export function useResolvedProps(
-  propDefs: Record<string, ControlDefinition>,
-  elementData: Record<string, Data>,
-  elementKey: string,
-): Record<string, unknown> {
-  const stylesheetFactory = useStylesheetFactory()
+export function useResolvedProps({
+  propDefs,
+  propData,
+  elementKey,
+  stylesheetFactory,
+}: {
+  propDefs: Record<string, ControlDefinition>
+  propData: Record<string, Data>
+  elementKey: string
+  stylesheetFactory: StylesheetFactory
+}): Record<string, unknown> {
   const resourceResolver = useResourceResolver()
   const controls = useControlInstances(elementKey)
 
   const cache = useRef<Record<string, CacheItem>>({}).current
   const resolveProp = useCallback(
     (def: ControlDefinition, propName: string) => {
-      const data = elementData[propName]
+      const data = propData[propName]
       const control = controls?.[propName]
 
       if (
@@ -66,7 +59,7 @@ export function useResolvedProps(
       cache[propName] = { data, control, resolvedValue }
       return resolvedValue
     },
-    [controls, elementData, resourceResolver, stylesheetFactory],
+    [controls, propData, resourceResolver, stylesheetFactory],
   )
 
   const resolvables = useMemo<Record<string, Resolvable<unknown>>>(

--- a/packages/runtime/src/runtimes/react/hooks/use-stylesheet-factory.ts
+++ b/packages/runtime/src/runtimes/react/hooks/use-stylesheet-factory.ts
@@ -11,18 +11,14 @@ import {
   isNotNil,
 } from '@makeswift/controls'
 
-import { useCache } from '../root-style-registry'
 import { resolvedStyleToCss } from '../lib/resolved-style-to-css'
+import { pollBoxModel } from '../poll-box-model'
+import { useCache } from '../root-style-registry'
+import { type StylesheetFactory } from '../stylesheet-factory'
+import { useStyles, serializedStyleClassName } from '../use-style'
 
 import { useBreakpoints } from './use-breakpoints'
 import { useCssId } from './use-css-id'
-import { useStyles, serializedStyleClassName } from '../use-style'
-import { pollBoxModel } from '../poll-box-model'
-
-export type StylesheetFactory = {
-  get(propName: string): Stylesheet
-  useDefinedStyles(): void
-}
 
 export function useStylesheetFactory(): StylesheetFactory {
   const breakpoints = useBreakpoints()

--- a/packages/runtime/src/runtimes/react/stylesheet-factory.ts
+++ b/packages/runtime/src/runtimes/react/stylesheet-factory.ts
@@ -1,0 +1,6 @@
+import { type Stylesheet } from '@makeswift/controls'
+
+export type StylesheetFactory = {
+  get(propName: string): Stylesheet
+  useDefinedStyles(): void
+}


### PR DESCRIPTION
Pure refactoring, no semantic changes, see inline comments for details.