### PR TITLE
feat: add `instanceKey` (`elementKey` + `propPath`) to control instances

### DIFF
--- a/.changeset/common-sheep-walk.md
+++ b/.changeset/common-sheep-walk.md
@@ -1,0 +1,6 @@
+---
+'@makeswift/controls': patch
+'@makeswift/runtime': patch
+---
+
+feat: add `instanceKey` (`elementKey` + `propPath`) to control instances

--- a/packages/controls/src/controls/checkbox/checkbox.ts
+++ b/packages/controls/src/controls/checkbox/checkbox.ts
@@ -12,7 +12,7 @@ import {
   type Resolvable,
   type SchemaType,
 } from '../definition'
-import { DefaultControlInstance, type SendMessage } from '../instance'
+import { DefaultControlInstance, type ControlInstanceArgs } from '../instance'
 import { ControlDefinitionVisitor } from '../visitor'
 
 type Config = z.infer<typeof Definition.schema.relaxed.config>
@@ -166,8 +166,8 @@ class Definition<C extends Config> extends ControlDefinition<
     }
   }
 
-  createInstance(sendMessage: SendMessage<any>) {
-    return new DefaultControlInstance(sendMessage)
+  createInstance(args: ControlInstanceArgs) {
+    return new DefaultControlInstance(args)
   }
 
   accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {

--- a/packages/controls/src/controls/code/code.ts
+++ b/packages/controls/src/controls/code/code.ts
@@ -13,7 +13,7 @@ import {
   type Resolvable,
   type SchemaType,
 } from '../definition'
-import { DefaultControlInstance, type SendMessage } from '../instance'
+import { DefaultControlInstance, type ControlInstanceArgs } from '../instance'
 import { ControlDefinitionVisitor } from '../visitor'
 
 type Config = z.infer<typeof Definition.schema.relaxed.config>
@@ -184,8 +184,8 @@ class Definition<C extends Config> extends ControlDefinition<
     }
   }
 
-  createInstance(sendMessage: SendMessage) {
-    return new DefaultControlInstance(sendMessage)
+  createInstance(args: ControlInstanceArgs) {
+    return new DefaultControlInstance(args)
   }
 
   accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {

--- a/packages/controls/src/controls/color/color.ts
+++ b/packages/controls/src/controls/color/color.ts
@@ -20,7 +20,7 @@ import {
   type Resolvable,
   type SchemaType,
 } from '../definition'
-import { DefaultControlInstance, type SendMessage } from '../instance'
+import { DefaultControlInstance, type ControlInstanceArgs } from '../instance'
 import { ControlDefinitionVisitor } from '../visitor'
 
 import { safeColorString, swatchToColorString } from './conversion'
@@ -258,8 +258,8 @@ class Definition<C extends Config> extends ControlDefinition<
     }
   }
 
-  createInstance(sendMessage: SendMessage<any>) {
-    return new DefaultControlInstance(sendMessage)
+  createInstance(args: ControlInstanceArgs) {
+    return new DefaultControlInstance(args)
   }
 
   accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {

--- a/packages/controls/src/controls/combobox/combobox.ts
+++ b/packages/controls/src/controls/combobox/combobox.ts
@@ -11,7 +11,7 @@ import {
   type Resolvable,
   type SchemaType,
 } from '../definition'
-import { DefaultControlInstance, type SendMessage } from '../instance'
+import { DefaultControlInstance, type ControlInstanceArgs } from '../instance'
 import { ControlDefinitionVisitor } from '../visitor'
 
 type Option<T extends Data> = { id: string; value: T; label: string }
@@ -129,8 +129,8 @@ class Definition<C extends Config> extends ControlDefinition<
     }
   }
 
-  createInstance(sendMessage: SendMessage<any>) {
-    return new DefaultControlInstance(sendMessage)
+  createInstance(args: ControlInstanceArgs) {
+    return new DefaultControlInstance(args)
   }
 
   accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {

--- a/packages/controls/src/controls/definition.ts
+++ b/packages/controls/src/controls/definition.ts
@@ -9,7 +9,7 @@ import { type IntrospectionTarget } from '../introspection'
 import { type ResourceResolver } from '../resources/resolver'
 import { type Stylesheet } from '../stylesheet'
 
-import { ControlInstance, type SendMessage } from './instance'
+import { ControlInstance, type ControlInstanceArgs } from './instance'
 import { ControlDefinitionVisitor } from './visitor'
 
 export type SchemaType<T> = z.ZodType<T>
@@ -80,7 +80,7 @@ export abstract class ControlDefinition<
     control?: InstanceType,
   ): Resolvable<ResolvedValueType | undefined>
 
-  abstract createInstance(sendMessage: SendMessage<any>): InstanceType
+  abstract createInstance(args: ControlInstanceArgs): InstanceType
 
   abstract accept<R>(
     visitor: ControlDefinitionVisitor<R>,

--- a/packages/controls/src/controls/font/font.ts
+++ b/packages/controls/src/controls/font/font.ts
@@ -11,7 +11,7 @@ import {
   type Resolvable,
   type SchemaType,
 } from '../definition'
-import { DefaultControlInstance, type SendMessage } from '../instance'
+import { DefaultControlInstance, type ControlInstanceArgs } from '../instance'
 import { ControlDefinitionVisitor } from '../visitor'
 
 type Config = z.infer<
@@ -255,8 +255,8 @@ class Definition<C extends Config> extends ControlDefinition<
     }
   }
 
-  createInstance(sendMessage: SendMessage) {
-    return new DefaultControlInstance(sendMessage)
+  createInstance(args: ControlInstanceArgs) {
+    return new DefaultControlInstance(args)
   }
 
   accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {

--- a/packages/controls/src/controls/gallery/gallery.ts
+++ b/packages/controls/src/controls/gallery/gallery.ts
@@ -11,7 +11,7 @@ import {
   type Resolvable,
   type SchemaType,
 } from '../definition'
-import { DefaultControlInstance, type SendMessage } from '../instance'
+import { DefaultControlInstance, type ControlInstanceArgs } from '../instance'
 import { ControlDefinitionVisitor } from '../visitor'
 
 export type GalleryOption<T extends Data = Data> = {
@@ -141,8 +141,8 @@ class Definition<C extends Config> extends ControlDefinition<
     }
   }
 
-  createInstance(sendMessage: SendMessage<any>) {
-    return new DefaultControlInstance(sendMessage)
+  createInstance(args: ControlInstanceArgs) {
+    return new DefaultControlInstance(args)
   }
 
   accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {

--- a/packages/controls/src/controls/group/group-control.ts
+++ b/packages/controls/src/controls/group/group-control.ts
@@ -1,8 +1,8 @@
 import { ControlDefinition } from '../definition'
 import {
   ControlInstance,
+  type ControlInstanceArgs,
   type ControlMessage,
-  type SendMessage,
 } from '../instance'
 
 import { type GroupDefinition } from './group'
@@ -22,9 +22,9 @@ export class GroupControl<
 
   constructor(
     private readonly definition: Def,
-    sendMessage: SendMessage<Message>,
+    args: ControlInstanceArgs,
   ) {
-    super(sendMessage)
+    super(args)
     this.childControls = new Map(
       Object.entries(this.definition.propDefs).map(([key, def]) => [
         key,
@@ -44,11 +44,17 @@ export class GroupControl<
   child = (key: string) => this.childControls.get(key)
 
   createChildControl = (def: ControlDefinition, key: string) => {
-    return def.createInstance((message) =>
-      this.sendMessage({
-        type: GroupControl.CHILD_CONTROL_MESSAGE,
-        payload: { message, key },
-      }),
-    )
+    const { elementKey, propPath } = this.instanceKey
+    return def.createInstance({
+      instanceKey: {
+        elementKey,
+        propPath: `${propPath}.${key}`,
+      },
+      sendMessage: (message) =>
+        this.sendMessage({
+          type: GroupControl.CHILD_CONTROL_MESSAGE,
+          payload: { message, key },
+        }),
+    })
   }
 }

--- a/packages/controls/src/controls/group/group.test.ts
+++ b/packages/controls/src/controls/group/group.test.ts
@@ -177,6 +177,45 @@ describe('Group', () => {
     })
   })
 
+  describe('prop resolution', () => {
+    const group = Group({
+      props: {
+        color: Color({ defaultValue: 'red' }),
+        checkbox: Checkbox(),
+        text: TextInput(),
+      },
+    })
+
+    const groupKeys = Object.keys(group.propDefs)
+    const instanceKey = { elementKey: '[test-element]', propPath: 'group-prop' }
+
+    const fixtures = () => {
+      const groupInstance = group.createInstance({
+        instanceKey,
+        sendMessage: () => {},
+      })
+
+      return { groupInstance }
+    }
+
+    test('group instance constructor creates a set of child controls with correct instance keys', async () => {
+      const { groupInstance } = fixtures()
+      const childControls = groupKeys.map((key) => groupInstance.child(key))
+
+      expect(
+        childControls
+          .map((c) => c?.elementKey)
+          .every((key) => key === instanceKey.elementKey),
+      ).toBe(true)
+
+      expect(childControls.map((c) => c?.propPath)).toStrictEqual([
+        'group-prop.color',
+        'group-prop.checkbox',
+        'group-prop.text',
+      ])
+    })
+  })
+
   describe('introspection', () => {
     test('Group data is correctly delegated to subcontrols', () => {
       const group = Group({

--- a/packages/controls/src/controls/group/group.ts
+++ b/packages/controls/src/controls/group/group.ts
@@ -24,7 +24,7 @@ import {
   type Resolvable,
   type SchemaType,
 } from '../definition'
-import { type SendMessage } from '../instance'
+import { type ControlInstanceArgs } from '../instance'
 import { ShapeDefinition } from '../shape/v1'
 import { ShapeV2Definition } from '../shape/v2'
 import { ControlDefinitionVisitor } from '../visitor'
@@ -279,8 +279,8 @@ class Definition<C extends Config> extends ControlDefinition<
     }
   }
 
-  createInstance(sendMessage: SendMessage): InstanceType<C> {
-    return new GroupControl(this, sendMessage)
+  createInstance(args: ControlInstanceArgs): GroupControl<Definition<C>> {
+    return new GroupControl(this, args)
   }
 
   accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {

--- a/packages/controls/src/controls/icon-radio-group/icon-radio-group.ts
+++ b/packages/controls/src/controls/icon-radio-group/icon-radio-group.ts
@@ -11,7 +11,7 @@ import {
   type Resolvable,
   type SchemaType,
 } from '../definition'
-import { DefaultControlInstance, type SendMessage } from '../instance'
+import { DefaultControlInstance, type ControlInstanceArgs } from '../instance'
 import { ControlDefinitionVisitor } from '../visitor'
 
 import { icons, legacyIcons } from './icons'
@@ -174,8 +174,8 @@ class Definition<C extends Config> extends ControlDefinition<
     }
   }
 
-  createInstance(sendMessage: SendMessage<any>) {
-    return new DefaultControlInstance(sendMessage)
+  createInstance(args: ControlInstanceArgs) {
+    return new DefaultControlInstance(args)
   }
 
   accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {

--- a/packages/controls/src/controls/image/image.ts
+++ b/packages/controls/src/controls/image/image.ts
@@ -19,7 +19,7 @@ import {
   type Resolvable,
   type SchemaType,
 } from '../definition'
-import { DefaultControlInstance, type SendMessage } from '../instance'
+import { DefaultControlInstance, type ControlInstanceArgs } from '../instance'
 import { ControlDefinitionVisitor } from '../visitor'
 
 type Config = z.infer<typeof Definition.schema.config>
@@ -365,8 +365,8 @@ class Definition<C extends Config = DefaultConfig> extends ControlDefinition<
     }
   }
 
-  createInstance(sendMessage: SendMessage<any>) {
-    return new DefaultControlInstance(sendMessage)
+  createInstance(args: ControlInstanceArgs) {
+    return new DefaultControlInstance(args)
   }
 
   accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {

--- a/packages/controls/src/controls/instance.ts
+++ b/packages/controls/src/controls/instance.ts
@@ -7,6 +7,16 @@ export type ControlMessage<Payload = Data> = {
   payload?: Payload
 }
 
+export type ControlInstanceKey = {
+  elementKey: string
+  propPath: string
+}
+
+export type ControlInstanceArgs<M extends ControlMessage = ControlMessage> = {
+  instanceKey: ControlInstanceKey
+  sendMessage: SendMessage<M>
+}
+
 export type SendMessage<M extends ControlMessage = ControlMessage> = (
   message: M,
 ) => void
@@ -14,7 +24,21 @@ export type SendMessage<M extends ControlMessage = ControlMessage> = (
 export abstract class ControlInstance<
   M extends ControlMessage = ControlMessage,
 > {
-  constructor(protected readonly sendMessage: SendMessage<M>) {}
+  public readonly instanceKey: ControlInstanceKey
+  protected readonly sendMessage: SendMessage<M>
+
+  constructor({ instanceKey, sendMessage }: ControlInstanceArgs<M>) {
+    this.instanceKey = instanceKey
+    this.sendMessage = sendMessage
+  }
+
+  get elementKey() {
+    return this.instanceKey.elementKey
+  }
+
+  get propPath() {
+    return this.instanceKey.propPath
+  }
 
   abstract recv(message: M): void
   abstract child(key: string): ControlInstance | undefined

--- a/packages/controls/src/controls/link/link.ts
+++ b/packages/controls/src/controls/link/link.ts
@@ -17,7 +17,7 @@ import {
   type Resolvable,
   type SchemaType,
 } from '../definition'
-import { DefaultControlInstance, type SendMessage } from '../instance'
+import { DefaultControlInstance, type ControlInstanceArgs } from '../instance'
 import { ControlDefinitionVisitor } from '../visitor'
 
 import { type GenericMouseEvent } from './mouse-event'
@@ -255,8 +255,8 @@ class Definition<
     }
   }
 
-  createInstance(sendMessage: SendMessage<any>) {
-    return new DefaultControlInstance(sendMessage)
+  createInstance(args: ControlInstanceArgs) {
+    return new DefaultControlInstance(args)
   }
 
   accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {

--- a/packages/controls/src/controls/list/list-control.ts
+++ b/packages/controls/src/controls/list/list-control.ts
@@ -1,9 +1,9 @@
-import { hasAllKeys } from '../../lib/functional'
+import { shallowEqual } from '../../lib/predicates'
 
 import {
   ControlInstance,
+  type ControlInstanceArgs,
   type ControlMessage,
-  type SendMessage,
 } from '../instance'
 
 import { type ListDefinition } from './list'
@@ -23,9 +23,9 @@ export class ListControl<
 
   constructor(
     private readonly definition: Def,
-    sendMessage: SendMessage<Message>,
+    args: ControlInstanceArgs<Message>,
   ) {
-    super(sendMessage)
+    super(args)
   }
 
   recv = (message: Message) => {
@@ -38,13 +38,20 @@ export class ListControl<
 
   child = (key: string) => this.itemControls.get(key)
 
-  childControls = (ids: string[] | undefined) => {
-    if (ids == null || hasAllKeys(this.itemControls, ids)) {
+  childControls = (ids: string[] | undefined): Map<string, ControlInstance> => {
+    const orderedIds: string[] = [...this.itemControls.keys()]
+    // return existing controls if we have a full set of them and they are
+    // already correctly ordered
+    if (ids == null || shallowEqual(ids, orderedIds)) {
       return this.itemControls
     }
 
+    // otherwise recreate controls for new/updated items as needed
     return new Map(
-      ids.map((id) => [id, this.child(id) ?? this.createItemControl(id)]),
+      ids.map((id, index) => {
+        const matchingChild = id === orderedIds[index] ? this.child(id) : null
+        return [id, matchingChild ?? this.createItemControl(index, id)]
+      }),
     )
   }
 
@@ -52,12 +59,18 @@ export class ListControl<
     this.itemControls = children
   }
 
-  createItemControl = (id: string) => {
-    return this.definition.itemDef.createInstance((message) =>
-      this.sendMessage({
-        type: ListControl.ITEM_CONTROL_MESSAGE,
-        payload: { message, itemId: id },
-      }),
-    )
+  createItemControl = (index: number, itemId: string): ControlInstance => {
+    const { elementKey, propPath } = this.instanceKey
+    return this.definition.itemDef.createInstance({
+      instanceKey: {
+        elementKey,
+        propPath: `${propPath}.${index}`,
+      },
+      sendMessage: (message) =>
+        this.sendMessage({
+          type: ListControl.ITEM_CONTROL_MESSAGE,
+          payload: { message, itemId },
+        }),
+    })
   }
 }

--- a/packages/controls/src/controls/list/list.test.ts
+++ b/packages/controls/src/controls/list/list.test.ts
@@ -1,3 +1,5 @@
+import { noOpResourceResolver } from '../../testing/mocks/resource-resolver'
+import { noOpStylesheet } from '../../testing/mocks/stylesheet'
 import { TestSerializationVisitor } from '../../testing/test-serialization-visitor'
 
 import { ControlDataTypeKey } from '../../common'
@@ -123,6 +125,123 @@ describe('List', () => {
         (data) => ListDefinition.deserialize(data, ColorDefinition.deserialize),
       )
       expect(deserialized).toEqual(list)
+    })
+  })
+
+  describe('prop resolution', () => {
+    const list = List({
+      type: Checkbox(),
+    })
+
+    const listData = list.toData([false, false, true, false])
+    const instanceKey = { elementKey: '[test-element]', propPath: 'list-prop' }
+
+    const fixtures = () => {
+      const listInstance = list.createInstance({
+        instanceKey,
+        sendMessage: () => {},
+      })
+
+      const resolveValueContext = [
+        noOpResourceResolver,
+        noOpStylesheet,
+        listInstance,
+      ] as const
+
+      return { listInstance, resolveValueContext }
+    }
+
+    test('resolveValue creates a list of child controls with correct instance keys', async () => {
+      const { listInstance, resolveValueContext } = fixtures()
+
+      expect(
+        listData
+          .map(({ id }) => listInstance.child(id))
+          .filter((c) => c != null),
+      ).toEqual([])
+
+      const resolved = list.resolveValue(listData, ...resolveValueContext)
+      await resolved.triggerResolve()
+
+      const childControls = listData.map(({ id }) => listInstance.child(id))
+
+      expect(
+        childControls
+          .map((c) => c?.elementKey)
+          .every((key) => key === instanceKey.elementKey),
+      ).toBe(true)
+
+      expect(childControls.map((c) => c?.propPath)).toStrictEqual([
+        'list-prop.0',
+        'list-prop.1',
+        'list-prop.2',
+        'list-prop.3',
+      ])
+    })
+
+    test('resolveValue on unchanged list maintains child control identity', async () => {
+      const { listInstance, resolveValueContext } = fixtures()
+
+      const resolved = list.resolveValue(listData, ...resolveValueContext)
+      await resolved.triggerResolve()
+      const childControls = listData.map(({ id }) => listInstance.child(id))
+
+      const resolved2 = list.resolveValue(listData, ...resolveValueContext)
+      await resolved2.triggerResolve()
+      const childControls2 = listData.map(({ id }) => listInstance.child(id))
+
+      childControls2.forEach((item, i) => expect(item).toBe(childControls[i]))
+    })
+
+    test('reordering list data recreates child controls with correct prop paths', async () => {
+      const { listInstance, resolveValueContext } = fixtures()
+
+      const resolved = list.resolveValue(listData, ...resolveValueContext)
+      await resolved.triggerResolve()
+      const childControls = listData.map(({ id }) => listInstance.child(id))
+
+      const listData2 = [...listData].sort((a, b) => b.id.localeCompare(a.id))
+      const resolved2 = list.resolveValue(listData2, ...resolveValueContext)
+      await resolved2.triggerResolve()
+      const childControls2 = listData2.map(({ id }) => listInstance.child(id))
+
+      childControls2.forEach((item, i) =>
+        expect(item).not.toBe(childControls[i]),
+      )
+
+      expect(childControls2.map((c) => c?.propPath)).toStrictEqual([
+        'list-prop.0',
+        'list-prop.1',
+        'list-prop.2',
+        'list-prop.3',
+      ])
+    })
+
+    test('partial reordering of list data recreates only affected child controls', async () => {
+      const { listInstance, resolveValueContext } = fixtures()
+
+      const resolved = list.resolveValue(listData, ...resolveValueContext)
+      await resolved.triggerResolve()
+      const childControls = listData.map(({ id }) => listInstance.child(id))
+
+      const listData2 = [listData[0], listData[2], listData[1], listData[3]]
+      const resolved2 = list.resolveValue(listData2, ...resolveValueContext)
+      await resolved2.triggerResolve()
+      const childControls2 = listData2.map(({ id }) => listInstance.child(id))
+
+      expect(childControls2[0]).toBe(childControls[0])
+      expect(childControls2[1]).not.toBe(childControls[1])
+      expect(childControls2[1]).not.toBe(childControls[2])
+      expect(childControls2[2]).not.toBe(childControls[2])
+      expect(childControls2[2]).not.toBe(childControls[1])
+      expect(childControls2[3]).toBe(childControls[3])
+
+      expect(childControls2.map((c) => c?.propPath)).toStrictEqual([
+        'list-prop.0',
+        'list-prop.1',
+        'list-prop.2',
+        'list-prop.3',
+      ])
     })
   })
 

--- a/packages/controls/src/controls/list/list.ts
+++ b/packages/controls/src/controls/list/list.ts
@@ -26,7 +26,7 @@ import {
   type SchemaType,
   type SchemaTypeAny,
 } from '../definition'
-import { type SendMessage } from '../instance'
+import { type ControlInstanceArgs } from '../instance'
 import { ControlDefinitionVisitor } from '../visitor'
 
 import { ListControl } from './list-control'
@@ -216,8 +216,8 @@ class Definition<C extends Config> extends ControlDefinition<
     }
   }
 
-  createInstance(sendMessage: SendMessage<any>): InstanceType<C> {
-    return new ListControl(this, sendMessage)
+  createInstance(args: ControlInstanceArgs): ListControl<Definition<C>> {
+    return new ListControl(this, args)
   }
 
   introspect<R>(data: DataType<C> | undefined, target: IntrospectionTarget<R>) {

--- a/packages/controls/src/controls/number/number.ts
+++ b/packages/controls/src/controls/number/number.ts
@@ -13,7 +13,7 @@ import {
   type Resolvable,
   type SchemaType,
 } from '../definition'
-import { DefaultControlInstance, type SendMessage } from '../instance'
+import { DefaultControlInstance, type ControlInstanceArgs } from '../instance'
 import { ControlDefinitionVisitor } from '../visitor'
 
 type Config = z.infer<typeof Definition.schema.relaxed.config>
@@ -177,8 +177,8 @@ class Definition<C extends Config> extends ControlDefinition<
     }
   }
 
-  createInstance(sendMessage: SendMessage<any>) {
-    return new DefaultControlInstance(sendMessage)
+  createInstance(args: ControlInstanceArgs) {
+    return new DefaultControlInstance(args)
   }
 
   accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {

--- a/packages/controls/src/controls/rich-text/v2/testing.ts
+++ b/packages/controls/src/controls/rich-text/v2/testing.ts
@@ -5,7 +5,7 @@ import { type Resolvable } from '../../definition'
 import {
   ControlInstance,
   DefaultControlInstance,
-  type SendMessage,
+  type ControlInstanceArgs,
 } from '../../instance'
 
 import { RichTextPluginControl } from './plugin'
@@ -29,8 +29,8 @@ class Definition extends RichTextDefinition<RenderedNode> {
     }
   }
 
-  createInstance(sendMessage: SendMessage<any>): ControlInstance<any> {
-    return new DefaultControlInstance(sendMessage)
+  createInstance(args: ControlInstanceArgs): ControlInstance<any> {
+    return new DefaultControlInstance(args)
   }
 
   toText(_data: DataType<RichTextDefinition<string>>): string {

--- a/packages/controls/src/controls/select/select.ts
+++ b/packages/controls/src/controls/select/select.ts
@@ -11,7 +11,7 @@ import {
   type Resolvable,
   type SchemaType,
 } from '../definition'
-import { DefaultControlInstance, type SendMessage } from '../instance'
+import { DefaultControlInstance, type ControlInstanceArgs } from '../instance'
 import { ControlDefinitionVisitor } from '../visitor'
 
 type Option<T extends string> = { readonly value: T; readonly label: string }
@@ -157,8 +157,8 @@ class Definition<C extends Config> extends ControlDefinition<
     }
   }
 
-  createInstance(sendMessage: SendMessage) {
-    return new DefaultControlInstance(sendMessage)
+  createInstance(args: ControlInstanceArgs) {
+    return new DefaultControlInstance(args)
   }
 
   accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {

--- a/packages/controls/src/controls/shape/v1/shape-control.ts
+++ b/packages/controls/src/controls/shape/v1/shape-control.ts
@@ -1,8 +1,8 @@
 import { ControlDefinition } from '../../definition'
 import {
   ControlInstance,
+  type ControlInstanceArgs,
   type ControlMessage,
-  type SendMessage,
 } from '../../instance'
 
 import { ShapeDefinition } from './shape'
@@ -22,9 +22,9 @@ export class ShapeControl<
 
   constructor(
     private readonly definition: Def,
-    sendMessage: SendMessage<Message>,
+    args: ControlInstanceArgs<Message>,
   ) {
-    super(sendMessage)
+    super(args)
     this.childControls = new Map(
       Object.entries(this.definition.keyDefs).map(([key, def]) => [
         key,
@@ -44,11 +44,17 @@ export class ShapeControl<
   child = (key: string) => this.childControls.get(key)
 
   createChildControl = (def: ControlDefinition, key: string) => {
-    return def.createInstance((message) =>
-      this.sendMessage({
-        type: ShapeControl.CHILD_CONTROL_MESSAGE,
-        payload: { message, key },
-      }),
-    )
+    const { elementKey, propPath } = this.instanceKey
+    return def.createInstance({
+      instanceKey: {
+        elementKey,
+        propPath: `${propPath}.${key}`,
+      },
+      sendMessage: (message) =>
+        this.sendMessage({
+          type: ShapeControl.CHILD_CONTROL_MESSAGE,
+          payload: { message, key },
+        }),
+    })
   }
 }

--- a/packages/controls/src/controls/shape/v1/shape.ts
+++ b/packages/controls/src/controls/shape/v1/shape.ts
@@ -23,7 +23,7 @@ import {
   type Resolvable,
   type SchemaType,
 } from '../../definition'
-import { type SendMessage } from '../../instance'
+import { type ControlInstanceArgs } from '../../instance'
 import { ControlDefinitionVisitor } from '../../visitor'
 
 import { ShapeControl } from './shape-control'
@@ -191,8 +191,8 @@ class Definition<C extends Config> extends ControlDefinition<
     }
   }
 
-  createInstance(sendMessage: SendMessage): InstanceType<C> {
-    return new ShapeControl(this, sendMessage)
+  createInstance(args: ControlInstanceArgs): ShapeControl<Definition<C>> {
+    return new ShapeControl(this, args)
   }
 
   introspect<R>(data: DataType<C> | undefined, target: IntrospectionTarget<R>) {

--- a/packages/controls/src/controls/slider/slider.ts
+++ b/packages/controls/src/controls/slider/slider.ts
@@ -13,7 +13,7 @@ import {
   type Resolvable,
   type SchemaType,
 } from '../definition'
-import { DefaultControlInstance, type SendMessage } from '../instance'
+import { DefaultControlInstance, type ControlInstanceArgs } from '../instance'
 import { ControlDefinitionVisitor } from '../visitor'
 
 type Config = z.infer<typeof Definition.schema.relaxed.config>
@@ -179,8 +179,8 @@ class Definition<C extends Config> extends ControlDefinition<
     }
   }
 
-  createInstance(sendMessage: SendMessage<any>) {
-    return new DefaultControlInstance(sendMessage)
+  createInstance(args: ControlInstanceArgs) {
+    return new DefaultControlInstance(args)
   }
 
   accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {

--- a/packages/controls/src/controls/slot/slot.ts
+++ b/packages/controls/src/controls/slot/slot.ts
@@ -12,7 +12,7 @@ import {
 import { Targets, type IntrospectionTarget } from '../../introspection'
 
 import { ControlDefinition, type SchemaType } from '../definition'
-import { type SendMessage } from '../instance'
+import { type ControlInstanceArgs } from '../instance'
 import { ControlDefinitionVisitor } from '../visitor'
 
 import { SlotControl } from './slot-control'
@@ -141,8 +141,8 @@ abstract class Definition<
     return { columns: mergedColumns, elements: mergedElements }
   }
 
-  createInstance(sendMessage: SendMessage) {
-    return new SlotControl(sendMessage)
+  createInstance(args: ControlInstanceArgs) {
+    return new SlotControl(args)
   }
 
   accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {

--- a/packages/controls/src/controls/style/v1/style.ts
+++ b/packages/controls/src/controls/style/v1/style.ts
@@ -23,7 +23,7 @@ import {
   type Resolvable,
   type SchemaType,
 } from '../../definition'
-import { type SendMessage } from '../../instance'
+import { type ControlInstanceArgs } from '../../instance'
 import { ControlDefinitionVisitor } from '../../visitor'
 
 import * as StyleSchema from './schema'
@@ -215,8 +215,8 @@ class Definition<C extends Config> extends ControlDefinition<
     }
   }
 
-  createInstance(sendMessage: SendMessage) {
-    return new StyleControl(sendMessage)
+  createInstance(args: ControlInstanceArgs) {
+    return new StyleControl(args)
   }
 
   accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {

--- a/packages/controls/src/controls/style/v2/style-v2-control.ts
+++ b/packages/controls/src/controls/style/v2/style-v2-control.ts
@@ -1,6 +1,10 @@
 import { type BoxDisplayModel } from '../../../common'
 import { ControlDefinition } from '../../definition'
-import { ControlInstance, ControlMessage, SendMessage } from '../../instance'
+import {
+  ControlInstance,
+  ControlMessage,
+  type ControlInstanceArgs,
+} from '../../instance'
 
 type ItemBoxModelChangeMessage = {
   type: typeof StyleV2Control.CHANGE_BOX_MODEL
@@ -22,14 +26,16 @@ export class StyleV2Control extends ControlInstance<Message> {
 
   private readonly control: ControlInstance
 
-  constructor(propDef: ControlDefinition, sendMessage: SendMessage<Message>) {
-    super(sendMessage)
-    this.control = propDef.createInstance((message) =>
-      this.sendMessage({
-        type: StyleV2Control.CHILD_CONTROL_MESSAGE,
-        payload: { message },
-      }),
-    )
+  constructor(propDef: ControlDefinition, args: ControlInstanceArgs<Message>) {
+    super(args)
+    this.control = propDef.createInstance({
+      ...args,
+      sendMessage: (message) =>
+        this.sendMessage({
+          type: StyleV2Control.CHILD_CONTROL_MESSAGE,
+          payload: { message },
+        }),
+    })
   }
 
   child(_key?: string): ControlInstance | undefined {

--- a/packages/controls/src/controls/style/v2/style-v2.ts
+++ b/packages/controls/src/controls/style/v2/style-v2.ts
@@ -25,7 +25,7 @@ import {
   type SchemaType,
   type SchemaTypeAny,
 } from '../../definition'
-import { type SendMessage } from '../../instance'
+import { type ControlInstanceArgs } from '../../instance'
 import { ControlDefinitionVisitor } from '../../visitor'
 
 import { StyleV2Control } from './style-v2-control'
@@ -195,8 +195,8 @@ class Definition<
     }))
   }
 
-  createInstance(sendMessage: SendMessage) {
-    return new StyleV2Control(this.typeDef, sendMessage)
+  createInstance(args: ControlInstanceArgs) {
+    return new StyleV2Control(this.typeDef, args)
   }
 
   accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {

--- a/packages/controls/src/controls/text-area/text-area.ts
+++ b/packages/controls/src/controls/text-area/text-area.ts
@@ -17,7 +17,7 @@ import {
   type Resolvable,
   type SchemaType,
 } from '../definition'
-import { DefaultControlInstance, type SendMessage } from '../instance'
+import { DefaultControlInstance, type ControlInstanceArgs } from '../instance'
 import { ControlDefinitionVisitor } from '../visitor'
 
 type Config = z.infer<typeof Definition.schema.relaxed.config>
@@ -180,8 +180,8 @@ class Definition<C extends Config> extends ControlDefinition<
     }
   }
 
-  createInstance(sendMessage: SendMessage) {
-    return new DefaultControlInstance(sendMessage)
+  createInstance(args: ControlInstanceArgs) {
+    return new DefaultControlInstance(args)
   }
 
   accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {

--- a/packages/controls/src/controls/text-input/text-input.ts
+++ b/packages/controls/src/controls/text-input/text-input.ts
@@ -17,7 +17,7 @@ import {
   type Resolvable,
   type SchemaType,
 } from '../definition'
-import { DefaultControlInstance, type SendMessage } from '../instance'
+import { DefaultControlInstance, type ControlInstanceArgs } from '../instance'
 import { ControlDefinitionVisitor } from '../visitor'
 
 type Config = z.infer<typeof Definition.schema.relaxed.config>
@@ -180,8 +180,8 @@ class Definition<C extends Config> extends ControlDefinition<
     }
   }
 
-  createInstance(sendMessage: SendMessage) {
-    return new DefaultControlInstance(sendMessage)
+  createInstance(args: ControlInstanceArgs) {
+    return new DefaultControlInstance(args)
   }
 
   accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {

--- a/packages/controls/src/controls/typography/typography.ts
+++ b/packages/controls/src/controls/typography/typography.ts
@@ -21,7 +21,7 @@ import { type Stylesheet } from '../../stylesheet'
 
 import { Color } from '../color'
 import { ControlDefinition, type Resolvable } from '../definition'
-import { DefaultControlInstance, type SendMessage } from '../instance'
+import { DefaultControlInstance, type ControlInstanceArgs } from '../instance'
 import { ControlDefinitionVisitor } from '../visitor'
 
 import * as Schema from './schema'
@@ -233,8 +233,8 @@ class Definition extends ControlDefinition<
     }
   }
 
-  createInstance(sendMessage: SendMessage) {
-    return new DefaultControlInstance(sendMessage)
+  createInstance(args: ControlInstanceArgs) {
+    return new DefaultControlInstance(args)
   }
 
   accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {

--- a/packages/runtime/src/controls/rich-text-v2/control.ts
+++ b/packages/runtime/src/controls/rich-text-v2/control.ts
@@ -8,7 +8,7 @@ import {
   Slate,
   type BoxDisplayModel,
   type DataType,
-  type SendMessage,
+  type ControlInstanceArgs,
   type Data,
 } from '@makeswift/controls'
 
@@ -91,10 +91,10 @@ export class RichTextV2Control extends ControlInstance<Message> {
   private defaultValue: Slate.Descendant[] | null = null
 
   constructor(
-    send: SendMessage<Message>,
     private readonly descriptor: RichTextV2Definition,
+    args: ControlInstanceArgs<Message>,
   ) {
-    super(send)
+    super(args)
   }
 
   recv = (message: Message): void => {

--- a/packages/runtime/src/controls/rich-text-v2/rich-text-v2.ts
+++ b/packages/runtime/src/controls/rich-text-v2/rich-text-v2.ts
@@ -11,7 +11,7 @@ import {
   StableValue,
   type Data,
   type Resolvable,
-  type SendMessage,
+  type ControlInstanceArgs,
   type DeserializedRecord,
   type SchemaType,
   type SchemaTypeAny,
@@ -114,8 +114,8 @@ class Definition extends BaseRichTextDefinition<ReactNode, Config, InstanceType>
     return Definition.fullSchema({ pluginDef: z.any() as SchemaType<ControlDefinition> }).config
   }
 
-  createInstance(sendMessage: SendMessage): InstanceType {
-    return new RichTextV2Control(sendMessage, this)
+  createInstance(args: ControlInstanceArgs) {
+    return new RichTextV2Control(this, args)
   }
 
   resolveValue(

--- a/packages/runtime/src/controls/rich-text/rich-text.ts
+++ b/packages/runtime/src/controls/rich-text/rich-text.ts
@@ -1,9 +1,9 @@
 import { ReactNode } from 'react'
 import {
   RichTextV1Definition,
-  SendMessage,
   StableValue,
   type DeserializedRecord,
+  type ControlInstanceArgs,
   type ResourceResolver,
   type Stylesheet,
   type Resolvable,
@@ -42,8 +42,8 @@ class Definition extends BaseDefinition {
     }
   }
 
-  createInstance(sendMessage: SendMessage<any>) {
-    return new RichTextControl(sendMessage)
+  createInstance(args: ControlInstanceArgs) {
+    return new RichTextControl(args)
   }
 }
 

--- a/packages/runtime/src/prop-controllers/instances.ts
+++ b/packages/runtime/src/prop-controllers/instances.ts
@@ -3,8 +3,8 @@ import { Types as PropControllerTypes } from '@makeswift/prop-controllers'
 
 import {
   type BoxDisplayModel,
+  type ControlInstanceArgs,
   type ControlMessage,
-  type SendMessage,
   type InstanceType,
   ControlInstance,
   DefaultControlInstance,
@@ -60,19 +60,21 @@ export type DescriptorsPropControllers<T extends Record<string, Descriptor>> = {
 
 export type AnyPropController = ControlInstance<any> | TableFormFieldsPropController
 
-export function createPropController(
-  descriptor: Descriptor,
-  send: SendMessage<PropControllerMessage>,
-): AnyPropController {
+export function createPropController({
+  descriptor,
+  ...args
+}: {
+  descriptor: Descriptor
+} & ControlInstanceArgs): AnyPropController {
   if (!isLegacyDescriptor(descriptor)) {
-    return descriptor.createInstance(send)
+    return descriptor.createInstance(args)
   }
 
   switch (descriptor.type) {
     case PropControllerTypes.TableFormFields:
-      return new TableFormFieldsPropController(send as SendMessage<TableFormFieldsMessage>)
+      return new TableFormFieldsPropController(args)
 
     default:
-      return new DefaultControlInstance(send as SendMessage)
+      return new DefaultControlInstance(args)
   }
 }

--- a/packages/runtime/src/state/middleware/read-write/prop-controller-handles.ts
+++ b/packages/runtime/src/state/middleware/read-write/prop-controller-handles.ts
@@ -34,11 +34,14 @@ function createAndRegisterPropControllers(
 
     const propControllers = Object.entries(descriptors).reduce(
       (acc, [propName, descriptor]) => {
-        const propController = createPropController(descriptor, message =>
-          dispatch(
-            Builder.messageBuilderPropController(documentKey, elementKey, propName, message),
-          ),
-        ) as ControlInstance
+        const propController = createPropController({
+          descriptor,
+          instanceKey: { elementKey, propPath: propName },
+          sendMessage: message =>
+            dispatch(
+              Builder.messageBuilderPropController(documentKey, elementKey, propName, message),
+            ),
+        }) as ControlInstance
 
         return { ...acc, [propName]: propController }
       },


### PR DESCRIPTION
This allows us to properly identify & look up control instances at runtime.