### PR TITLE
fix: warn when resolving image without dimensions

### DIFF
--- a/.changeset/bumpy-months-bow.md
+++ b/.changeset/bumpy-months-bow.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/controls': patch
+---
+
+In an `Image` control using the `Image.Format.WithDimensions` format, show a warning when resolving an image without dimensions

--- a/packages/controls/src/controls/image/image.ts
+++ b/packages/controls/src/controls/image/image.ts
@@ -352,12 +352,17 @@ class Definition<C extends Config = DefaultConfig> extends ControlDefinition<
       return url
     }
 
-    return width != null && height != null
-      ? {
-          url,
-          dimensions: { width, height },
-        }
-      : undefined
+    if (width == null || height == null) {
+      console.warn(
+        `Image control: cannot resolve image with \`Image.Format.WithDimensions\` format because it is missing dimensions (url: ${url}).`,
+      )
+      return undefined
+    }
+
+    return {
+      url,
+      dimensions: { width, height },
+    }
   }
 
   createInstance(sendMessage: SendMessage<any>) {


### PR DESCRIPTION
Show a warning in the Image control when the following are both true:

1. The control format is `Image.Format.WithDimensions`
2. The image being resolved does not have both dimensions defined.