### PR TITLE
feat(controls): unstable_Cascade control + PokéAPI demo (ARR-769)

### DIFF
--- a/apps/nextjs-app-router/src/components/cascade-demo/cascade-demo.makeswift.ts
+++ b/apps/nextjs-app-router/src/components/cascade-demo/cascade-demo.makeswift.ts
@@ -1,0 +1,116 @@
+import { runtime } from '@/makeswift/runtime'
+import { lazy } from 'react'
+
+import { Style, unstable_Cascade } from '@makeswift/runtime/controls'
+
+type Pokemon = { name: string; url: string }
+
+// Subset of PokéAPI's `sprites` object; every field is a nullable image URL.
+type PokemonSprites = {
+  front_default: string | null
+  back_default: string | null
+  front_shiny: string | null
+  back_shiny: string | null
+  other?: {
+    'official-artwork'?: { front_default: string | null }
+    dream_world?: { front_default: string | null }
+    home?: { front_default: string | null }
+  }
+}
+
+// PokéAPI (free, no auth): pokemon (combobox) → sprite (images). Both
+// `getOptions` run in the builder; PokéAPI allows client-side CORS.
+const POKEAPI = 'https://pokeapi.co/api/v2'
+const MAX_COMBOBOX_RESULTS = 50
+
+// No search endpoint: fetch the list once and cache the in-flight promise so
+// keystrokes reuse it instead of refetching.
+let pokemonListPromise: Promise<Pokemon[]> | null = null
+function loadPokemonList(): Promise<Pokemon[]> {
+  pokemonListPromise ??= fetch(`${POKEAPI}/pokemon?limit=1500`)
+    .then((res) => res.json())
+    .then((data: { results: Pokemon[] }) => data.results)
+    .catch(() => {
+      // Reset so a later call can retry after a transient failure.
+      pokemonListPromise = null
+      return []
+    })
+  return pokemonListPromise
+}
+
+// Flatten the useful sprite URLs into image options, dropping any that are null.
+function spriteOptions(
+  sprites: PokemonSprites,
+): { id: string; image: string; text: string }[] {
+  const candidates: { id: string; image: string | null; text: string }[] = [
+    {
+      id: 'official-artwork',
+      image: sprites.other?.['official-artwork']?.front_default ?? null,
+      text: 'Official artwork',
+    },
+    { id: 'front-default', image: sprites.front_default, text: 'Front' },
+    { id: 'back-default', image: sprites.back_default, text: 'Back' },
+    { id: 'front-shiny', image: sprites.front_shiny, text: 'Front (shiny)' },
+    { id: 'back-shiny', image: sprites.back_shiny, text: 'Back (shiny)' },
+    {
+      id: 'dream-world',
+      image: sprites.other?.dream_world?.front_default ?? null,
+      text: 'Dream World',
+    },
+    {
+      id: 'home',
+      image: sprites.other?.home?.front_default ?? null,
+      text: 'Home',
+    },
+  ]
+  return candidates.filter(
+    (o): o is { id: string; image: string; text: string } => o.image != null,
+  )
+}
+
+runtime.registerComponent(
+  lazy(() => import('./cascade-demo')),
+  {
+    type: 'Cascade Control Demo',
+    label: 'Custom / Cascade Control Demo',
+    props: {
+      className: Style(),
+      selection: unstable_Cascade({
+        label: 'Pokémon sprite',
+        stages: [
+          {
+            key: 'pokemon',
+            display: 'combobox',
+            getOptions: async (query: string) => {
+              const list = await loadPokemonList()
+              const q = query.toLowerCase()
+              return list
+                .filter((p) => p.name.includes(q))
+                .slice(0, MAX_COMBOBOX_RESULTS)
+                .map((p) => ({ id: p.name, value: p, label: p.name }))
+            },
+          },
+          {
+            key: 'sprite',
+            display: 'images',
+            getOptions: async (ctx) => {
+              const pokemon = ctx?.selections.pokemon as
+                | { value?: Pokemon }
+                | undefined
+              const name = pokemon?.value?.name
+              if (name == null) return { options: [] }
+
+              try {
+                const res = await fetch(`${POKEAPI}/pokemon/${name}`)
+                const data: { sprites: PokemonSprites } = await res.json()
+                return { options: spriteOptions(data.sprites) }
+              } catch {
+                return { options: [] }
+              }
+            },
+          },
+        ],
+      }),
+    },
+  },
+)

--- a/apps/nextjs-app-router/src/components/cascade-demo/cascade-demo.tsx
+++ b/apps/nextjs-app-router/src/components/cascade-demo/cascade-demo.tsx
@@ -1,0 +1,41 @@
+import { Ref, forwardRef } from 'react'
+
+// The cascade resolves to its last (images) stage: the selected image option.
+type ImageSelection = { id: string; image: string; text?: string }
+
+type Props = {
+  className?: string
+  selection?: ImageSelection
+}
+
+export const CascadeDemo = forwardRef(function CascadeDemo(
+  { className, selection }: Props,
+  ref: Ref<HTMLDivElement>,
+) {
+  return (
+    <div
+      className={`flex flex-col gap-4 p-4 w-full ${className ?? ''}`}
+      ref={ref}
+    >
+      <h3 className="text-sm font-semibold">Cascade Control Demo</h3>
+
+      <section>
+        <h4 className="text-xs uppercase tracking-wide text-gray-500 mb-1">
+          Selected image
+        </h4>
+        {selection != null ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={selection.image}
+            alt={selection.text ?? 'Selected image'}
+            className="rounded border border-gray-200 max-w-xs h-auto"
+          />
+        ) : (
+          <p className="text-sm text-gray-400">No image selected</p>
+        )}
+      </section>
+    </div>
+  )
+})
+
+export default CascadeDemo

--- a/apps/nextjs-app-router/src/makeswift/components.ts
+++ b/apps/nextjs-app-router/src/makeswift/components.ts
@@ -1,3 +1,4 @@
+import '@/components/cascade-demo/cascade-demo.makeswift'
 import '@/components/code-demo/code-demo.makeswift'
 import '@/components/font-control-demo/font-control-demo.makeswift'
 import '@/components/group-demo/group-demo.makeswift'

--- a/packages/controls/src/controls/cascade/cascade.test.ts
+++ b/packages/controls/src/controls/cascade/cascade.test.ts
@@ -1,0 +1,212 @@
+import { noOpResourceResolver } from '../../testing/mocks/resource-resolver'
+import { noOpStylesheet } from '../../testing/mocks/stylesheet'
+
+import { CascadeDefinition, unstable_Cascade } from './cascade'
+
+type Product = { id: string; name: string }
+
+function productImageDef() {
+  return unstable_Cascade({
+    label: 'Product image',
+    stages: [
+      {
+        key: 'product',
+        display: 'combobox',
+        getOptions: (_query: string) =>
+          [] as { id: string; value: Product; label: string }[],
+      },
+      {
+        key: 'image',
+        display: 'images',
+        getOptions: async (_ctx) => ({
+          options: [] as { id: string; image: string; text?: string }[],
+        }),
+      },
+    ],
+  })
+}
+
+const fullSelection = {
+  product: { id: 'p1', value: { id: 'p1', name: 'Shirt' }, label: 'Shirt' },
+  image: { id: 'i9', image: 'https://cdn/x.jpg', text: 'front' },
+}
+
+describe('Cascade', () => {
+  describe('safeParse', () => {
+    test('parses a full keyed selection', () => {
+      const def = productImageDef()
+      expect(def.safeParse(fullSelection)).toEqual({
+        success: true,
+        data: fullSelection,
+      })
+    })
+
+    test('parses a partial selection (product only)', () => {
+      const def = productImageDef()
+      const partial = { product: fullSelection.product }
+      expect(def.safeParse(partial)).toEqual({ success: true, data: partial })
+    })
+
+    test('parses undefined', () => {
+      const def = productImageDef()
+      expect(def.safeParse(undefined)).toEqual({
+        success: true,
+        data: undefined,
+      })
+    })
+
+    test.each([null, 17, 'nope', { product: { id: 'p1' } }])(
+      'refuses invalid input `%s`',
+      (invalid) => {
+        const def = productImageDef()
+        expect(def.safeParse(invalid)).toEqual({
+          success: false,
+          error: expect.any(String),
+        })
+      },
+    )
+  })
+
+  describe('fromData / toData', () => {
+    test('round-trips identity', () => {
+      const def = productImageDef()
+      expect(def.toData(fullSelection)).toEqual(fullSelection)
+      expect(def.fromData(fullSelection)).toEqual(fullSelection)
+    })
+  })
+
+  describe('resolveValue', () => {
+    test('resolves to the last stage selection (the full image option)', () => {
+      const def = productImageDef()
+      const resolved = def
+        .resolveValue(fullSelection, noOpResourceResolver, noOpStylesheet)
+        .readStable()
+      expect(resolved).toEqual({
+        id: 'i9',
+        image: 'https://cdn/x.jpg',
+        text: 'front',
+      })
+    })
+
+    test('resolves to undefined when the last stage is unselected', () => {
+      const def = productImageDef()
+      const resolved = def
+        .resolveValue(
+          { product: fullSelection.product },
+          noOpResourceResolver,
+          noOpStylesheet,
+        )
+        .readStable()
+      expect(resolved).toBeUndefined()
+    })
+
+    test('resolves undefined data to undefined', () => {
+      const def = productImageDef()
+      expect(
+        def
+          .resolveValue(undefined, noOpResourceResolver, noOpStylesheet)
+          .readStable(),
+      ).toBeUndefined()
+    })
+
+    // Regression: readStable feeds useSyncExternalStore, so it must be
+    // referentially stable across calls for unchanged data or the consumer loops.
+    test('readStable is referentially stable across calls (full selection)', () => {
+      const def = productImageDef()
+      const resolvable = def.resolveValue(
+        fullSelection,
+        noOpResourceResolver,
+        noOpStylesheet,
+      )
+      expect(resolvable.readStable()).toBe(resolvable.readStable())
+    })
+
+    test('readStable is referentially stable with only the first stage selected (the loop trigger)', () => {
+      const def = productImageDef()
+      const resolvable = def.resolveValue(
+        { product: fullSelection.product },
+        noOpResourceResolver,
+        noOpStylesheet,
+      )
+      // Both undefined (last stage unselected) — stable, no loop.
+      expect(resolvable.readStable()).toBe(resolvable.readStable())
+    })
+
+    test('resolves a combobox terminal stage to its full option object (not the bare value)', () => {
+      const def = unstable_Cascade({
+        label: 'Category',
+        stages: [
+          {
+            key: 'category',
+            display: 'combobox',
+            getOptions: (_query: string) =>
+              [] as { id: string; value: Product; label: string }[],
+          },
+        ],
+      })
+      const selection = {
+        category: {
+          id: 'c1',
+          value: { id: 'c1', name: 'Shoes' },
+          label: 'Shoes',
+        },
+      }
+      const resolved = def
+        .resolveValue(selection, noOpResourceResolver, noOpStylesheet)
+        .readStable()
+      expect(resolved).toEqual({
+        id: 'c1',
+        value: { id: 'c1', name: 'Shoes' },
+        label: 'Shoes',
+      })
+    })
+  })
+
+  describe('copyData', () => {
+    test('is identity (no file-resource machinery)', () => {
+      const def = productImageDef()
+      const ctx = {} as any
+      expect(def.copyData(fullSelection, ctx)).toEqual(fullSelection)
+      expect(def.copyData(undefined, ctx)).toBeUndefined()
+    })
+  })
+})
+
+describe('Cascade deserialize', () => {
+  test('round-trips type and stages from a v0 record', () => {
+    const def = unstable_Cascade({
+      label: 'Product image',
+      stages: [
+        {
+          key: 'product',
+          display: 'combobox',
+          getOptions: (_q: string) =>
+            [] as { id: string; value: Product; label: string }[],
+        },
+        {
+          key: 'image',
+          display: 'images',
+          getOptions: async () => ({ options: [] as any[] }),
+        },
+      ],
+    })
+
+    const record = { type: CascadeDefinition.type, config: def.config }
+    const roundTripped = CascadeDefinition.deserialize(record as any)
+
+    expect(roundTripped).toBeInstanceOf(CascadeDefinition)
+    expect(roundTripped.controlType).toBe('makeswift::controls::cascade')
+    expect(roundTripped.config.stages).toHaveLength(2)
+    expect(roundTripped.config.stages[1].key).toBe('image')
+    expect(typeof roundTripped.config.stages[0].getOptions).toBe('function')
+  })
+
+  test('throws on a mismatched type', () => {
+    expect(() =>
+      CascadeDefinition.deserialize({
+        type: 'makeswift::controls::combobox',
+        config: {},
+      } as any),
+    ).toThrow(/expected type makeswift::controls::cascade/)
+  })
+})

--- a/packages/controls/src/controls/cascade/cascade.test.types.ts
+++ b/packages/controls/src/controls/cascade/cascade.test.types.ts
@@ -1,0 +1,90 @@
+import { expectTypeOf } from 'expect-type'
+
+import {
+  type DataType,
+  type ResolvedValueType,
+  type ValueType,
+} from '../associated-types'
+
+import { unstable_Cascade } from './cascade'
+
+describe('Cascade Types', () => {
+  type Product = { id: string; name: string }
+  type ImageOpt = { id: string; image: string; text?: string }
+
+  const def = unstable_Cascade({
+    label: 'Product image',
+    stages: [
+      {
+        key: 'product',
+        display: 'combobox',
+        getOptions: (_query: string) =>
+          [] as { id: string; value: Product; label: string }[],
+      },
+      {
+        key: 'image',
+        display: 'images',
+        getOptions: async (_ctx) => ({
+          options: [] as ImageOpt[],
+        }),
+      },
+    ],
+  })
+
+  test('data preserves the full stored option per stage', () => {
+    type Data = DataType<typeof def>
+    expectTypeOf<Data>().toEqualTypeOf<{
+      product?: { id: string; value: Product; label: string }
+      image?: ImageOpt
+    }>()
+  })
+
+  test('value equals data (identity)', () => {
+    type Value = ValueType<typeof def>
+    expectTypeOf<Value>().toEqualTypeOf<DataType<typeof def>>()
+  })
+
+  test('resolves to the last stage option object (the image)', () => {
+    type Resolved = ResolvedValueType<typeof def>
+    expectTypeOf<Resolved>().toEqualTypeOf<ImageOpt | undefined>()
+  })
+
+  test('image stage preserves extra option fields in Data/Resolved types', () => {
+    // Regression: StoredStage must infer the image option structurally so extra
+    // fields like `sku` survive (not collapse to bare ImageOption).
+    type RichImageOpt = {
+      id: string
+      image: string
+      text?: string
+      sku: string
+    }
+
+    const richDef = unstable_Cascade({
+      label: 'Product image',
+      stages: [
+        {
+          key: 'product',
+          display: 'combobox',
+          getOptions: (_query: string) =>
+            [] as { id: string; value: Product; label: string }[],
+        },
+        {
+          key: 'image',
+          display: 'images',
+          getOptions: async (_ctx) => ({
+            options: [] as RichImageOpt[],
+          }),
+        },
+      ],
+    })
+
+    type RichData = DataType<typeof richDef>
+    expectTypeOf<RichData>().toEqualTypeOf<{
+      product?: { id: string; value: Product; label: string }
+      image?: RichImageOpt
+    }>()
+
+    type RichResolved = ResolvedValueType<typeof richDef>
+    expectTypeOf<RichResolved>().toEqualTypeOf<RichImageOpt | undefined>()
+  })
+})

--- a/packages/controls/src/controls/cascade/cascade.ts
+++ b/packages/controls/src/controls/cascade/cascade.ts
@@ -1,0 +1,239 @@
+import { z } from 'zod'
+
+import { safeParse, type ParseResult } from '../../lib/zod'
+
+import { Schema, type Data } from '../../common'
+import { type CopyContext } from '../../context'
+import { type ResourceResolver } from '../../resources/resolver'
+import { type DeserializedRecord } from '../../serialization'
+import { type Stylesheet } from '../../stylesheet'
+
+import {
+  ControlDefinition,
+  type Resolvable,
+  type SchemaType,
+} from '../definition'
+import { DefaultControlInstance, type SendMessage } from '../instance'
+import { ControlDefinitionVisitor } from '../visitor'
+
+export type ComboboxOption<T extends Data> = {
+  id: string
+  value: T
+  label: string
+}
+export type ImageOption = { id: string; image: string; text?: string }
+
+// StageCtx uses `unknown` for selection values to avoid a circular type.
+export type StageCtx = { selections: Record<string, unknown> }
+
+export type ComboboxStage<T extends Data = Data> = {
+  key: string
+  display: 'combobox'
+  getOptions: (
+    query: string,
+    ctx?: StageCtx,
+  ) => ComboboxOption<T>[] | Promise<ComboboxOption<T>[]>
+}
+
+export type ImagesPage<O extends ImageOption = ImageOption> = {
+  options: O[]
+}
+export type ImagesStage<O extends ImageOption = ImageOption> = {
+  key: string
+  display: 'images'
+  getOptions: (ctx?: StageCtx) => ImagesPage<O> | Promise<ImagesPage<O>>
+}
+
+export type AnyStage = ComboboxStage<any> | ImagesStage<any>
+
+export type CascadeConfig<S extends readonly AnyStage[] = readonly AnyStage[]> =
+  {
+    label?: string
+    description?: string
+    stages: S
+  }
+
+type Config<S extends readonly AnyStage[] = readonly AnyStage[]> =
+  CascadeConfig<S>
+
+// The stored option per stage, inferred structurally from `getOptions` so extra
+// fields survive: images unwrap `{ options: O[] }`, combobox unwraps a bare array.
+export type StoredStage<S extends AnyStage> = S extends {
+  display: 'combobox'
+  getOptions: (...args: any[]) => infer R
+}
+  ? Awaited<R> extends readonly (infer O)[]
+    ? O
+    : never
+  : S extends {
+        display: 'images'
+        getOptions: (...args: any[]) => infer R
+      }
+    ? Awaited<R> extends { options: readonly (infer O)[] }
+      ? O
+      : ImageOption
+    : never
+
+// Forces TS to materialise the mapped type into explicit named properties.
+type Expand<T> = { [K in keyof T]: T[K] }
+type StagesToData<S extends readonly AnyStage[]> = Expand<{
+  [K in S[number] as K['key']]?: StoredStage<K>
+}>
+
+// The terminal stage of the ordered tuple — the stage the control resolves to.
+type LastStage<S extends readonly AnyStage[]> = S extends readonly [
+  ...AnyStage[],
+  infer L extends AnyStage,
+]
+  ? L
+  : AnyStage
+
+type StagesOf<C extends Config> =
+  C extends Config<infer S> ? S : readonly AnyStage[]
+
+type CascadeDataType<C extends Config> = StagesToData<StagesOf<C>>
+// Resolves to the last stage's full option object, or undefined if unselected.
+type CascadeResolvedValueType<C extends Config> =
+  | StoredStage<LastStage<StagesOf<C>>>
+  | undefined
+
+class Definition<C extends Config> extends ControlDefinition<
+  typeof Definition.type,
+  C,
+  CascadeDataType<C>,
+  CascadeDataType<C>,
+  CascadeResolvedValueType<C>
+> {
+  static readonly type = 'makeswift::controls::cascade' as const
+
+  static schema<T extends Data>(item: SchemaType<T>) {
+    const type = z.literal(Definition.type)
+
+    const comboboxOption = z.object({
+      id: z.string(),
+      value: item,
+      label: z.string(),
+    })
+    const imageOption = z.object({
+      id: z.string(),
+      image: z.string(),
+      text: z.string().optional(),
+    })
+
+    const storedSelection = z.union([comboboxOption, imageOption])
+    const data = z.record(z.string(), storedSelection)
+    const value = data
+    const resolvedValue = z.union([comboboxOption, imageOption]).optional()
+
+    const stage = z.object({
+      key: z.string(),
+      display: z.union([z.literal('combobox'), z.literal('images')]),
+      getOptions: z.function(),
+    })
+
+    const config = z.object({
+      label: z.string().optional(),
+      description: z.string().optional(),
+      stages: z.array(stage),
+    })
+
+    const definition = z.object({ type, config })
+
+    return { type, data, value, resolvedValue, config, definition }
+  }
+
+  static deserialize(data: DeserializedRecord): CascadeDefinition {
+    if (data.type !== Definition.type) {
+      throw new Error(
+        `Cascade: expected type ${Definition.type}, got ${data.type}`,
+      )
+    }
+    const { config } = Definition.schema(Schema.data).definition.parse(data)
+    return new CascadeDefinition(config as Config)
+  }
+
+  get controlType() {
+    return Definition.type
+  }
+
+  get schema() {
+    return Definition.schema(Schema.data as SchemaType<Data>) as unknown as {
+      type: SchemaType<typeof Definition.type>
+      data: SchemaType<CascadeDataType<C>>
+      value: SchemaType<CascadeDataType<C>>
+      resolvedValue: SchemaType<CascadeResolvedValueType<C>>
+      config: ReturnType<typeof Definition.schema>['config']
+      definition: SchemaType<unknown>
+    }
+  }
+
+  safeParse(
+    data: unknown | undefined,
+  ): ParseResult<CascadeDataType<C> | undefined> {
+    return safeParse(this.schema.data, data) as ParseResult<
+      CascadeDataType<C> | undefined
+    >
+  }
+
+  fromData(
+    data: CascadeDataType<C> | undefined,
+  ): CascadeDataType<C> | undefined {
+    return data
+  }
+
+  toData(value: CascadeDataType<C>): CascadeDataType<C> {
+    return value
+  }
+
+  copyData(
+    data: CascadeDataType<C> | undefined,
+    _context: CopyContext,
+  ): CascadeDataType<C> | undefined {
+    return data
+  }
+
+  resolveValue(
+    data: CascadeDataType<C> | undefined,
+    _resolver: ResourceResolver,
+    _stylesheet: Stylesheet,
+  ): Resolvable<CascadeResolvedValueType<C> | undefined> {
+    const stages = this.config.stages
+    return {
+      name: Definition.type,
+      readStable: () => {
+        if (data == null) return undefined
+        const record = data as Record<string, unknown>
+        const out: Record<string, unknown> = {}
+        for (const stage of stages) {
+          const selection = record[stage.key]
+          if (selection == null) continue
+          out[stage.key] = selection
+        }
+        const lastStage = stages[stages.length - 1]
+        return lastStage == null
+          ? undefined
+          : (out[lastStage.key] as CascadeResolvedValueType<C>)
+      },
+      subscribe: () => () => {},
+      triggerResolve: async () => {},
+    }
+  }
+
+  createInstance(sendMessage: SendMessage<any>) {
+    return new DefaultControlInstance(sendMessage)
+  }
+
+  accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {
+    return visitor.visitCascade(this, ...args)
+  }
+}
+
+export class CascadeDefinition<
+  C extends Config = Config,
+> extends Definition<C> {}
+
+export function unstable_Cascade<const S extends readonly AnyStage[]>(
+  config: Config<S>,
+): CascadeDefinition<Config<S>> {
+  return new CascadeDefinition(config)
+}

--- a/packages/controls/src/controls/cascade/index.ts
+++ b/packages/controls/src/controls/cascade/index.ts
@@ -1,0 +1,1 @@
+export * from './cascade'

--- a/packages/controls/src/controls/index.ts
+++ b/packages/controls/src/controls/index.ts
@@ -1,3 +1,4 @@
+export * from './cascade'
 export * from './checkbox'
 export * from './code'
 export * from './color'

--- a/packages/controls/src/controls/visitor/control-serialization-visitor.ts
+++ b/packages/controls/src/controls/visitor/control-serialization-visitor.ts
@@ -4,6 +4,7 @@ import {
   serializeObject,
 } from '../../serialization'
 
+import { CascadeDefinition } from '../cascade'
 import { CheckboxDefinition } from '../checkbox'
 import { CodeDefinition } from '../code'
 import { ColorDefinition } from '../color'
@@ -50,6 +51,9 @@ export abstract class ControlSerializationVisitor extends ControlDefinitionVisit
     } as unknown as SerializedRecord
   }
 
+  visitCascade(def: CascadeDefinition): SerializedRecord {
+    return this.serializeConfig(def)
+  }
   visitCode(def: CodeDefinition): SerializedRecord {
     return this.serializeConfig(def, { version: def.version })
   }

--- a/packages/controls/src/controls/visitor/definition-visitor.ts
+++ b/packages/controls/src/controls/visitor/definition-visitor.ts
@@ -1,3 +1,4 @@
+import { CascadeDefinition } from '../cascade'
 import { CheckboxDefinition } from '../checkbox'
 import { CodeDefinition } from '../code'
 import { ColorDefinition } from '../color'
@@ -24,6 +25,7 @@ import { TextInputDefinition } from '../text-input'
 import { unstable_TypographyDefinition } from '../typography'
 
 abstract class ControlDefinitionVisitor<R> {
+  abstract visitCascade(def: CascadeDefinition, ...args: unknown[]): R
   abstract visitCode(def: CodeDefinition, ...args: unknown[]): R
   abstract visitCheckbox(def: CheckboxDefinition, ...args: unknown[]): R
   abstract visitColor(def: ColorDefinition, ...args: unknown[]): R

--- a/packages/controls/src/controls/visitor/merge-translations-visitor.ts
+++ b/packages/controls/src/controls/visitor/merge-translations-visitor.ts
@@ -4,6 +4,7 @@ import { Data } from '../../common'
 import { MergeTranslatableDataContext } from '../../context'
 
 import { DataType } from '../associated-types'
+import { CascadeDefinition } from '../cascade'
 import { CheckboxDefinition } from '../checkbox'
 import { CodeDefinition } from '../code'
 import { ColorDefinition } from '../color'
@@ -46,6 +47,14 @@ abstract class MergeTranslationsVisitor extends ControlDefinitionVisitor<Data> {
   private defaultMerge(data: Data, translatedData: Data): Data {
     if (data == null || translatedData == null) return data
     return translatedData
+  }
+
+  visitCascade(
+    _def: CascadeDefinition,
+    data: DataType<CascadeDefinition> | undefined,
+    translatedData: Data,
+  ): Data {
+    return this.noOpMerge(data, translatedData)
   }
 
   visitCode(

--- a/packages/runtime/src/controls/index.ts
+++ b/packages/runtime/src/controls/index.ts
@@ -2,6 +2,8 @@ export * from './control'
 
 export {
   ControlDefinition,
+  unstable_Cascade,
+  CascadeDefinition,
   Checkbox,
   CheckboxDefinition,
   Code,

--- a/packages/runtime/src/controls/serialization/base/cascade.test.ts
+++ b/packages/runtime/src/controls/serialization/base/cascade.test.ts
@@ -1,0 +1,11 @@
+import { CascadeDefinition } from '@makeswift/controls'
+import { deserializeUnifiedControlDef } from './index'
+
+test('deserializeUnifiedControlDef routes a cascade record to CascadeDefinition', () => {
+  const record = {
+    type: CascadeDefinition.type,
+    config: { label: 'x', stages: [] },
+  }
+  const def = deserializeUnifiedControlDef(record as any)
+  expect(def).toBeInstanceOf(CascadeDefinition)
+})

--- a/packages/runtime/src/controls/serialization/base/index.ts
+++ b/packages/runtime/src/controls/serialization/base/index.ts
@@ -8,6 +8,7 @@ import {
 } from '@makeswift/controls'
 
 import {
+  CascadeDefinition,
   CheckboxDefinition,
   CodeDefinition,
   ColorDefinition,
@@ -64,6 +65,7 @@ export function deserializeControl(
 export function deserializeUnifiedControlDef(record: DeserializedRecord): ControlDefinition {
   type DeserializeMethod = (data: DeserializedRecord) => ControlDefinition
   const deserializeMethod: Record<string, DeserializeMethod> = {
+    [CascadeDefinition.type]: CascadeDefinition.deserialize,
     [CheckboxDefinition.type]: CheckboxDefinition.deserialize,
     [CodeDefinition.type]: CodeDefinition.deserialize,
     [ColorDefinition.type]: ColorDefinition.deserialize,


### PR DESCRIPTION
First spin at implementing the Cascade control. Details can be found in this [linear doc](https://linear.app/commerce/document/cascade-control-d7b7eaa3b4e1).