### PR TITLE
APPSEC-1963: config to prevent supply chain attacks

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 packages:
   - 'packages/*'
   - 'apps/*'
+
+minimumReleaseAge: 2880


### PR DESCRIPTION
Adding config to prevent NPM packages that are at less than 2 days old to reduce the possible of supply chain attacks.