### PR TITLE
feat(runtime): unstable API to migrate components

### DIFF
--- a/.changeset/curly-tools-slide.md
+++ b/.changeset/curly-tools-slide.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Add unstable_migration API to component registration

--- a/packages/runtime/src/runtimes/react/react-runtime-core.ts
+++ b/packages/runtime/src/runtimes/react/react-runtime-core.ts
@@ -37,6 +37,7 @@ export class ReactRuntimeCore extends RuntimeCore {
       hidden = false,
       description,
       builtinSuspense,
+      unstable_migration,
       props,
     }: {
       type: string
@@ -50,6 +51,12 @@ export class ReactRuntimeCore extends RuntimeCore {
        * Defaults to `true`.
        */
       builtinSuspense?: boolean
+      /**
+       * Marks this registration as superseded by `replacementType`. When
+       * `replacementType` differs from `type`, the builder offers a way to
+       * update existing instances.
+       */
+      unstable_migration?: { replacementType: string }
       props?: P
     },
   ): () => void {
@@ -58,7 +65,7 @@ export class ReactRuntimeCore extends RuntimeCore {
     const unregisterComponent = this.protoStore.dispatch(
       registerComponentEffect(
         type,
-        { label, icon, hidden, description, builtinSuspense },
+        { label, icon, hidden, description, builtinSuspense, unstable_migration },
         props ?? {},
       ),
     )

--- a/packages/runtime/src/state/modules/components-meta.ts
+++ b/packages/runtime/src/state/modules/components-meta.ts
@@ -43,6 +43,9 @@ export type ComponentMeta = {
   hidden: boolean
   description?: string
   builtinSuspense?: boolean
+  unstable_migration?: {
+    replacementType: string
+  }
 }
 
 export type State = Map<string, ComponentMeta>


### PR DESCRIPTION
Introduce unstable API as part of component registrations that allows users to point to a "successor" component registration.