### PR TITLE
fix: tighten `deepEqual`/`shallowEqual` typings, fix corner-case false positives

### DIFF
--- a/.changeset/frank-apes-knock.md
+++ b/.changeset/frank-apes-knock.md
@@ -1,0 +1,6 @@
+---
+'@makeswift/controls': patch
+'@makeswift/runtime': patch
+---
+
+Tighten `deepEqual`/`shallowEqual` typings, fix corner-case false positives on object-to-array comparisons

--- a/packages/controls/src/lib/predicates/__tests__/shallow-deep-equal.test.ts
+++ b/packages/controls/src/lib/predicates/__tests__/shallow-deep-equal.test.ts
@@ -1,0 +1,159 @@
+import { deepEqual } from '../deepEqual'
+import { shallowEqual } from '../shallowEqual'
+
+const scalars = [
+  undefined,
+  null,
+  true,
+  false,
+  0,
+  -0,
+  NaN,
+  Infinity,
+  -Infinity,
+  17,
+  '',
+  'hello',
+]
+
+const scalarsObj = scalars.reduce(
+  (obj, s) => ({ [`${String(s)}`]: s, ...obj }),
+  {},
+)
+
+const equalityOp = {
+  shallowEqual: shallowEqual,
+  deepEqual: deepEqual,
+} as const
+
+describe.each(['shallowEqual', 'deepEqual'] as const)(
+  '%s returns true for identical values',
+  (op) => {
+    test.each(scalars)('%s', (a) => {
+      expect(equalityOp[op](a, a)).toBe(true)
+    })
+  },
+)
+
+describe.each(['shallowEqual', 'deepEqual'] as const)(
+  '%s returns false',
+  (op) => {
+    test.each([
+      [undefined, null],
+      [null, false],
+      [null, 0],
+      [false, 0],
+      [false, true],
+      [0, -0],
+      [NaN, Infinity],
+      [Infinity, -Infinity],
+      [[], {}],
+      [[17], { '0': 17 }],
+      [{ a: [17] }, { a: { '0': 17 } }],
+      [[null, undefined], { '0': null, '1': undefined }],
+    ])('%s vs %s', (a, b) => {
+      expect(equalityOp[op](a, b)).toBe(false)
+    })
+  },
+)
+
+describe.each(['shallowEqual', 'deepEqual'] as const)(
+  '%s object comparison',
+  (op) => {
+    const isDeep = op === 'deepEqual'
+    test.each([
+      [{}, {}, true],
+      [{ a: 1 }, { a: 1 }, true],
+      [{ a: 'hello' }, { a: 'hello' }, true],
+      [{ a: 'hello' }, { a: 'hello', b: undefined }, false],
+      [{ a: 1 }, { a: '1' }, false],
+      [{ a: 1 }, { a: 2 }, false],
+      [{ a: 1, b: 2 }, { a: 1 }, false],
+      [{ a: 1, b: 'hello' }, { b: 'hello', a: 1 }, true],
+      [{ a: 1 }, { b: 1 }, false],
+      [{ a: 0 }, { a: -0 }, false],
+      [{ a: NaN }, { a: NaN }, true],
+      [{ a: [] }, { a: [] }, isDeep],
+      [{ a: {} }, { a: {} }, isDeep],
+      [{ a: scalars }, { a: scalars }, true],
+      [{ a: scalars }, { a: [...scalars] }, isDeep],
+      [scalarsObj, { ...scalarsObj }, true],
+      [{ a: scalarsObj }, { a: scalarsObj }, true],
+      [{ a: scalarsObj }, { a: { ...scalarsObj } }, isDeep],
+      [{ a: [{ b: 1 }] }, { a: [{ b: 1 }] }, isDeep],
+    ])('%o vs %o => %s', (a, b, expected) => {
+      expect(equalityOp[op](a, b)).toBe(expected)
+    })
+
+    test('non-enumerable props are ignored', () => {
+      const a = {}
+      const b = {}
+
+      Object.defineProperty(a, 'hidden', {
+        enumerable: false,
+        value: 17,
+      })
+
+      Object.defineProperty(b, 'hidden', {
+        enumerable: false,
+        value: 'hello',
+      })
+
+      expect(equalityOp[op](a, b)).toBe(true)
+    })
+  },
+)
+
+describe.each(['shallowEqual', 'deepEqual'] as const)(
+  '%s array comparisons',
+  (op) => {
+    const isDeep = op === 'deepEqual'
+    test.each([
+      [[], [], true],
+      [scalars, [...scalars], true],
+      [scalars, [...scalars, undefined], false],
+      [[1, 2], [1], false],
+      [[1, 2], [2, 1], false],
+      [[1, 2], [1, 3], false],
+      [[0], [-0], false],
+      [[NaN], [NaN], true],
+      [[scalarsObj], [scalarsObj], true],
+      [[scalarsObj], [{ ...scalarsObj }], isDeep],
+      [
+        [{ a: [{ b: 1 }] }, { c: [...scalars] }],
+        [{ a: [{ b: 1 }] }, { c: [...scalars] }],
+        isDeep,
+      ],
+      [Array.from<string>({ length: 3 }), [], false],
+      [
+        Array.from<string>({ length: 3 }),
+        Array.from<string>({ length: 3 }),
+        true,
+      ],
+      [
+        Array.from<string>({ length: 3 }),
+        [undefined, undefined, undefined],
+        true,
+      ],
+    ])('%o vs %o => %s', (a, b, expected) => {
+      expect(equalityOp[op](a, b)).toBe(expected)
+    })
+
+    test('non-enumerable props are ignored', () => {
+      const a = [17, 0, -5]
+      const b = [17, 0, -5]
+
+      Object.defineProperty(a, 'hidden', {
+        enumerable: false,
+        value: 17,
+      })
+
+      Object.defineProperty(b, 'hidden', {
+        enumerable: false,
+        value: 'hello',
+      })
+
+      expect(equalityOp[op](a, b)).toBe(true)
+    })
+  },
+)

--- a/packages/controls/src/lib/predicates/deepEqual.ts
+++ b/packages/controls/src/lib/predicates/deepEqual.ts
@@ -18,6 +18,8 @@ export const deepEqual = (a: Data, b: Data): boolean => {
   )
     return false
 
+  if (Array.isArray(a) !== Array.isArray(b)) return false
+
   const keysA = Object.keys(a)
   const keysB = Object.keys(b)
 

--- a/packages/controls/src/lib/predicates/deepEqual.ts
+++ b/packages/controls/src/lib/predicates/deepEqual.ts
@@ -1,8 +1,13 @@
+import { type Data } from '../../common/types'
+
 import { shallowEqual } from './shallowEqual'
 
 const { hasOwnProperty } = Object.prototype
 
-export const deepEqual = (a: unknown, b: unknown): boolean => {
+/**
+ * Deep equality for scalars, arrays and plain objects.
+ */
+export const deepEqual = (a: Data, b: Data): boolean => {
   if (shallowEqual(a, b)) return true
 
   if (

--- a/packages/controls/src/lib/predicates/index.ts
+++ b/packages/controls/src/lib/predicates/index.ts
@@ -1,3 +1,2 @@
 export * from './deepEqual'
-export * from './is'
 export * from './shallowEqual'

--- a/packages/controls/src/lib/predicates/is.ts
+++ b/packages/controls/src/lib/predicates/is.ts
@@ -1,5 +1,0 @@
-export function is(x: unknown, y: unknown): boolean {
-  if (x === y) return x !== 0 || y !== 0 || 1 / x === 1 / y
-
-  return x !== x && y !== y
-}

--- a/packages/controls/src/lib/predicates/shallowEqual.ts
+++ b/packages/controls/src/lib/predicates/shallowEqual.ts
@@ -1,14 +1,12 @@
 import { type Data } from '../../common/types'
 
-import { is } from './is'
-
 const { hasOwnProperty } = Object.prototype
 
 /**
  * Shallow equality for scalars, arrays and plain objects.
  */
 export const shallowEqual = (a: Data, b: Data): boolean => {
-  if (is(a, b)) return true
+  if (Object.is(a, b)) return true
 
   if (
     typeof a !== 'object' ||
@@ -26,8 +24,11 @@ export const shallowEqual = (a: Data, b: Data): boolean => {
   if (keysA.length !== keysB.length) return false
 
   for (let i = 0; i < keysA.length; i += 1) {
-    // @ts-expect-error: {}[string] is OK.
-    if (!hasOwnProperty.call(b, keysA[i]) || !is(a[keysA[i]], b[keysA[i]]))
+    if (
+      !hasOwnProperty.call(b, keysA[i]) ||
+      // @ts-expect-error: {}[string] is OK.
+      !Object.is(a[keysA[i]], b[keysA[i]])
+    )
       return false
   }
 

--- a/packages/controls/src/lib/predicates/shallowEqual.ts
+++ b/packages/controls/src/lib/predicates/shallowEqual.ts
@@ -1,8 +1,13 @@
+import { type Data } from '../../common/types'
+
 import { is } from './is'
 
 const { hasOwnProperty } = Object.prototype
 
-export const shallowEqual = (a: unknown, b: unknown): boolean => {
+/**
+ * Shallow equality for scalars, arrays and plain objects.
+ */
+export const shallowEqual = (a: Data, b: Data): boolean => {
   if (is(a, b)) return true
 
   if (

--- a/packages/controls/src/lib/predicates/shallowEqual.ts
+++ b/packages/controls/src/lib/predicates/shallowEqual.ts
@@ -18,6 +18,8 @@ export const shallowEqual = (a: Data, b: Data): boolean => {
   )
     return false
 
+  if (Array.isArray(a) !== Array.isArray(b)) return false
+
   const keysA = Object.keys(a)
   const keysB = Object.keys(b)
 

--- a/packages/runtime/src/runtimes/react/controls/rich-text/EditableText/useSyncWithBuilder.tsx
+++ b/packages/runtime/src/runtimes/react/controls/rich-text/EditableText/useSyncWithBuilder.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import { Editor } from 'slate'
+import { Editor, Range } from 'slate'
 import { type RichTextDTO, richTextDTOtoDAO, richTextDTOtoSelection } from '@makeswift/controls'
 
 import { useIsInBuilder } from '../../../hooks/use-is-in-builder'
@@ -19,13 +19,18 @@ export function useSyncWithBuilder(editor: Editor, text?: RichTextDTO) {
     if (shouldCommit && text && isInBuilder) {
       const nextValue = richTextDTOtoDAO(text)
       const nextSelection = richTextDTOtoSelection(text)
-      if (!deepEqual(editor.children, nextValue) || !deepEqual(editor.selection, nextSelection)) {
+      const sameSelection =
+        editor.selection == null || nextSelection == null
+          ? editor.selection == nextSelection
+          : Range.equals(editor.selection, nextSelection)
+
+      if (!deepEqual(editor.children, nextValue) || !sameSelection) {
         editor.children = nextValue
         editor.selection = nextSelection
         editor.onChange()
       }
     }
-  }, [editor, shouldCommit, text])
+  }, [editor, isInBuilder, shouldCommit, text])
 
   useEffect(() => {
     if (shouldCommit) return

--- a/packages/runtime/src/slate/TypographyPlugin/normalizeTypographyUp.ts
+++ b/packages/runtime/src/slate/TypographyPlugin/normalizeTypographyUp.ts
@@ -1,12 +1,12 @@
 import { Editor, Element, NodeEntry, Transforms, Node, Text } from 'slate'
-import { RichTextTypography } from '@makeswift/controls'
+import { type Data, RichTextTypography } from '@makeswift/controls'
 
 import { MakeswiftEditor } from '../types'
 import keys from '../../utils/keys'
 import deepEqual from '../../utils/deepEqual'
 import { shallowMergeTypographies } from './normalizeTypographyDown'
 
-function shallowAnd<A extends Record<string, unknown>, B extends Record<string, unknown>>(
+function shallowAnd<A extends Record<string, Data>, B extends Record<string, Data>>(
   a: A,
   b: B,
 ): A & B {
@@ -60,7 +60,7 @@ function shallowAndTypographies(...typographies: RichTextTypography[]): RichText
   }
 }
 
-function shallowInverseAnd<A extends Record<string, unknown>, B extends Record<string, unknown>>(
+function shallowInverseAnd<A extends Record<string, Data>, B extends Record<string, Data>>(
   a: A,
   b: B,
 ): A & B {
@@ -70,7 +70,7 @@ function shallowInverseAnd<A extends Record<string, unknown>, B extends Record<s
   const xor = {} as A & B
 
   bKeys.forEach(key => {
-    if (!deepEqual(aPrime[key], bPrime[key as any])) xor[key] = aPrime[key]
+    if (!deepEqual(aPrime[key], bPrime[key])) xor[key] = aPrime[key]
   })
 
   return xor

--- a/packages/runtime/src/slate/selectors.ts
+++ b/packages/runtime/src/slate/selectors.ts
@@ -2,6 +2,7 @@ import { Editor, NodeEntry, Range, Text } from 'slate'
 import {
   type Breakpoints,
   type BreakpointId,
+  type Data,
   findBreakpointOverride,
   Slate,
 } from '@makeswift/controls'
@@ -87,10 +88,10 @@ const concat = (a: unknown[], b: unknown[]) => a.concat(b)
  * This is a c/p of the intersection of the utils from the root utils folder.
  * The only change is defaulting to undefined instead of to null.
  */
-export default function intersection<A extends Record<string, unknown>, B extends A>(
+export default function intersection<A extends Record<string, Data>, B extends A>(
   a: A,
   b: B,
-  isEqual: (a: unknown, b: unknown) => boolean = deepEqual,
+  isEqual: (a: Data, b: Data) => boolean = deepEqual,
 ): { [K in keyof A]: A[K] | undefined } {
   const allKeys = [...new Set([...keys(a), ...keys(b)])] as (keyof A)[]
 

--- a/packages/runtime/src/utils/intersection.ts
+++ b/packages/runtime/src/utils/intersection.ts
@@ -1,10 +1,12 @@
+import { type Data } from '@makeswift/controls'
+
 import deepEqual from './deepEqual'
 import keys from './keys'
 
-export default function intersection<A extends Record<string, unknown>, B extends A>(
+export default function intersection<A extends Record<string, Data>, B extends A>(
   a: A,
   b: B,
-  isEqual: (a: unknown, b: unknown) => boolean = deepEqual,
+  isEqual: (a: Data, b: Data) => boolean = deepEqual,
 ): { [K in keyof A]: A[K] | null } {
   const allKeys = [...new Set([...keys(a), ...keys(b)])] as (keyof A)[]
 

--- a/packages/runtime/src/utils/is.ts
+++ b/packages/runtime/src/utils/is.ts
@@ -1,3 +1,0 @@
-import { is } from '@makeswift/controls'
-
-export default is


### PR DESCRIPTION
Our `deepEqual`/`shallowEqual` utils were typed too broadly for their intended plain-data semantics, had no tests, and contained a cross-shape bug where arrays and objects with compatible enumerable keys could compare as equal.

See inline comments for details. Best reviewed commit-by-commit.