### PR TITLE
fix: builtin embed resetting DOM mutations in builder

### DIFF
--- a/.changeset/puny-monkeys-talk.md
+++ b/.changeset/puny-monkeys-talk.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Fixes an issue where scripts within the builtin `Embed` component may not have properly persisted DOM manipulations in the builder.

--- a/packages/runtime/src/components/builtin/Embed/Embed.tsx
+++ b/packages/runtime/src/components/builtin/Embed/Embed.tsx
@@ -2,7 +2,7 @@
 
 /* eslint-env browser */
 
-import { useState, useEffect, forwardRef, Ref, useImperativeHandle } from 'react'
+import { useState, useEffect, useMemo, forwardRef, Ref, useImperativeHandle } from 'react'
 
 import { useIsomorphicLayoutEffect } from '../../hooks/useIsomorphicLayoutEffect'
 import { useStyle } from '../../../runtimes/react/use-style'
@@ -107,6 +107,13 @@ const Embed = forwardRef(function Embed(
 
   const className = useStyle({ minHeight: 15 })
 
+  // React 19+ resets `innerHTML` whenever the `dangerouslySetInnerHTML`
+  // object's identity changes, even if `__html` is the same string. Memoize
+  // the object so unrelated re-renders don't wipe out DOM produced by the
+  // executed scripts above. See https://github.com/facebook/react/issues/31660
+  // and https://github.com/react/react/issues/31600
+  const dangerouslySetInnerHTML = useMemo(() => ({ __html: html }), [html])
+
   if (shouldRender === false) return null
 
   return (
@@ -114,7 +121,7 @@ const Embed = forwardRef(function Embed(
       ref={setContainer}
       id={id}
       className={cx(className, width, margin)}
-      dangerouslySetInnerHTML={{ __html: html }}
+      dangerouslySetInnerHTML={dangerouslySetInnerHTML}
     />
   )
 })


### PR DESCRIPTION
A new behavior in React 19 wipes any changes to the DOM that were introduced via `dangerouslySetInnerHtml` if the prop identity changes.

For the builtin embed component, this would manifest in the builder for components that contained a script that modified the  DOM.

1. Page initially renders in builder
2. Embed renders, script runs, modifying the DOM created by the Embed.
3. Builder connection initializes, re-render occurs. The `dangerouslySetInnerHTML` inline object prop has a new identity, causing the Embed's div innerHtml to be reset.
4. The Embed scripts don't re-execute since the HTML string itself didn't change, so the DOM remains stale.

https://github.com/user-attachments/assets/cd03ac02-3c1e-4b29-8c47-9ab8a387e9c8