### PR TITLE
fix: explicitly include Jest types in package globals

### DIFF
--- a/.changeset/swift-squids-wink.md
+++ b/.changeset/swift-squids-wink.md
@@ -1,0 +1,7 @@
+---
+'@makeswift/prop-controllers': patch
+'@makeswift/controls': patch
+'@makeswift/runtime': patch
+---
+
+fix: explicitly include Jest types in package globals

--- a/packages/controls/tsconfig.json
+++ b/packages/controls/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "ESNext",
     "lib": ["ESNext", "DOM"],
     "moduleResolution": "Node",
+    "types": ["jest"],
     "strict": true,
     "sourceMap": true,
     "resolveJsonModule": true,

--- a/packages/prop-controllers/tsconfig.json
+++ b/packages/prop-controllers/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "ESNext",
     "lib": ["ESNext", "DOM"],
     "moduleResolution": "Node",
+    "types": ["jest"],
     "strict": true,
     "sourceMap": true,
     "resolveJsonModule": true,

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "ESNext",
     "lib": ["ESNext", "DOM"],
     "moduleResolution": "Node",
+    "types": ["jest"],
     "strict": true,
     "sourceMap": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
Make sure the IDE can find type definitions for the `describe`/`test`/`expect` et al. globals coming from Jest. These used to be discovered automatically, but are no longer resolved consistently; adding them to `tsconfig` to restore consistency.