### PR TITLE
feat(controls): add `resolvesToRenderableNode` method to control instances

### DIFF
--- a/.changeset/brave-moments-change.md
+++ b/.changeset/brave-moments-change.md
@@ -1,0 +1,6 @@
+---
+'@makeswift/controls': patch
+'@makeswift/runtime': patch
+---
+
+feat: add `resolvesToRenderableNode` method to control instances

--- a/packages/controls/src/controls/group/group-control.ts
+++ b/packages/controls/src/controls/group/group-control.ts
@@ -43,6 +43,8 @@ export class GroupControl<
 
   child = (key: string) => this.childControls.get(key)
 
+  resolvesToRenderableNode = () => false
+
   createChildControl = (def: ControlDefinition, key: string) => {
     const { elementKey, propPath } = this.instanceKey
     return def.createInstance({

--- a/packages/controls/src/controls/instance.ts
+++ b/packages/controls/src/controls/instance.ts
@@ -42,6 +42,14 @@ export abstract class ControlInstance<
 
   abstract recv(message: M): void
   abstract child(key: string): ControlInstance | undefined
+
+  /**
+   * Returns true if the control resolves to a renderable node.
+   *
+   * In React, that means the resolved value is a `ReactNode`. In other renderers, it is the equivalent
+   * renderable node type.
+   */
+  abstract resolvesToRenderableNode(): boolean
 }
 
 export class DefaultControlInstance extends ControlInstance {
@@ -51,6 +59,10 @@ export class DefaultControlInstance extends ControlInstance {
 
   child(_key: string) {
     return undefined
+  }
+
+  resolvesToRenderableNode(): boolean {
+    return false
   }
 }
 

--- a/packages/controls/src/controls/list/list-control.ts
+++ b/packages/controls/src/controls/list/list-control.ts
@@ -38,6 +38,8 @@ export class ListControl<
 
   child = (key: string) => this.itemControls.get(key)
 
+  resolvesToRenderableNode = () => false
+
   childControls = (ids: string[] | undefined): Map<string, ControlInstance> => {
     const orderedIds: string[] = [...this.itemControls.keys()]
     // return existing controls if we have a full set of them and they are

--- a/packages/controls/src/controls/shape/v1/shape-control.ts
+++ b/packages/controls/src/controls/shape/v1/shape-control.ts
@@ -43,6 +43,8 @@ export class ShapeControl<
 
   child = (key: string) => this.childControls.get(key)
 
+  resolvesToRenderableNode = () => false
+
   createChildControl = (def: ControlDefinition, key: string) => {
     const { elementKey, propPath } = this.instanceKey
     return def.createInstance({

--- a/packages/controls/src/controls/slot/slot-control.ts
+++ b/packages/controls/src/controls/slot/slot-control.ts
@@ -26,6 +26,10 @@ export class SlotControl extends ControlInstance<Message> {
     return undefined
   }
 
+  resolvesToRenderableNode(): boolean {
+    return true
+  }
+
   changeContainerBoxModel(boxModel: BoxDisplayModel | null): void {
     this.sendMessage({
       type: SlotControl.CONTAINER_BOX_MODEL_CHANGE,

--- a/packages/controls/src/controls/style/v1/style-control.ts
+++ b/packages/controls/src/controls/style/v1/style-control.ts
@@ -16,6 +16,10 @@ export class StyleControl extends ControlInstance<Message> {
     return undefined
   }
 
+  resolvesToRenderableNode(): boolean {
+    return false
+  }
+
   changeBoxModel(boxModel: BoxDisplayModel | null): void {
     this.sendMessage({
       type: StyleControl.CHANGE_BOX_MODEL,

--- a/packages/controls/src/controls/style/v2/style-v2-control.ts
+++ b/packages/controls/src/controls/style/v2/style-v2-control.ts
@@ -51,6 +51,10 @@ export class StyleV2Control extends ControlInstance<Message> {
     }
   }
 
+  resolvesToRenderableNode(): boolean {
+    return false
+  }
+
   changeBoxModel(boxModel: BoxDisplayModel | null): void {
     this.sendMessage({
       type: StyleV2Control.CHANGE_BOX_MODEL,

--- a/packages/runtime/src/controls/rich-text-v2/control.ts
+++ b/packages/runtime/src/controls/rich-text-v2/control.ts
@@ -127,6 +127,10 @@ export class RichTextV2Control extends ControlInstance<Message> {
     return undefined
   }
 
+  resolvesToRenderableNode(): boolean {
+    return true
+  }
+
   setEditor(editor: Editor) {
     this.editor = editor
     this.sendMessage({

--- a/packages/runtime/src/controls/rich-text/control.ts
+++ b/packages/runtime/src/controls/rich-text/control.ts
@@ -91,6 +91,10 @@ export class RichTextControl extends ControlInstance<Message> {
     }
   }
 
+  resolvesToRenderableNode(): boolean {
+    return true
+  }
+
   setSlateEditor(editor: Editor) {
     this.editor = editor
 

--- a/packages/runtime/src/prop-controllers/instances.ts
+++ b/packages/runtime/src/prop-controllers/instances.ts
@@ -37,6 +37,10 @@ export class TableFormFieldsPropController extends ControlInstance<TableFormFiel
     return undefined
   }
 
+  resolvesToRenderableNode(): boolean {
+    return false
+  }
+
   tableFormLayoutChange(payload: { layout: BoxDisplayModel }) {
     this.sendMessage({ type: TableFormFieldsMessageType.TABLE_FORM_LAYOUT_CHANGE, payload })
   }


### PR DESCRIPTION
Pure addition. Returns true for `Slot` and `RichText`, false for all other controls.