### PR TITLE
feat(controls): add `children`, `isCompositeProp` methods

### DIFF
--- a/.changeset/funny-apples-clap.md
+++ b/.changeset/funny-apples-clap.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/controls': patch
+---
+
+feat: add `children`, `isCompositeProp` methods to `ControlInstance`

--- a/packages/controls/src/controls/group/group-control.ts
+++ b/packages/controls/src/controls/group/group-control.ts
@@ -41,6 +41,10 @@ export class GroupControl<
     }
   }
 
+  isCompositeProp = () => true
+
+  children = () => [...this.childControls.values()]
+
   child = (key: string) => this.childControls.get(key)
 
   resolvesToRenderableNode = () => false

--- a/packages/controls/src/controls/group/group.test.ts
+++ b/packages/controls/src/controls/group/group.test.ts
@@ -214,6 +214,18 @@ describe('Group', () => {
         'group-prop.text',
       ])
     })
+
+    test('`children` returns a list of the child controls', async () => {
+      const { groupInstance } = fixtures()
+      const childControls = groupKeys.map((key) => groupInstance.child(key))
+
+      const children = groupInstance.children()
+      expect(children.length).toBe(childControls.length)
+
+      childControls.forEach((c, index) => {
+        expect(children[index]).toBe(c)
+      })
+    })
   })
 
   describe('introspection', () => {

--- a/packages/controls/src/controls/instance.ts
+++ b/packages/controls/src/controls/instance.ts
@@ -43,7 +43,18 @@ export abstract class ControlInstance<
   abstract recv(message: M): void
 
   /**
+   * Returns true if the control represents a composite prop value (a prop that contains other props).
    *
+   * In contrast with `children()`, this return value doesn't change over the control lifetime.
+   */
+  abstract isCompositeProp(): boolean
+
+  /**
+   * Returns a list of child control instances for this control's immediate nested props.
+   */
+  abstract children(): ControlInstance[]
+
+  /**
    * Returns the control instance for the nested prop identified by `key`.
    *
    * For list controls, `key` is a stringified item index.
@@ -62,6 +73,14 @@ export abstract class ControlInstance<
 export class DefaultControlInstance extends ControlInstance {
   recv(_message: ControlMessage) {
     // Do nothing
+  }
+
+  isCompositeProp(): boolean {
+    return false
+  }
+
+  children(): ControlInstance[] {
+    return []
   }
 
   child(_key: string) {

--- a/packages/controls/src/controls/list/list-control.ts
+++ b/packages/controls/src/controls/list/list-control.ts
@@ -38,6 +38,10 @@ export class ListControl<
     }
   }
 
+  isCompositeProp = () => true
+
+  children = () => [...this.itemControlsList]
+
   /**
    *  Returns the control instance for the nested prop identified by `key`,
    *  where `key` is a stringified list item index.

--- a/packages/controls/src/controls/list/list.test.ts
+++ b/packages/controls/src/controls/list/list.test.ts
@@ -180,11 +180,11 @@ describe('List', () => {
 
       const resolved = list.resolveValue(listData, ...resolveValueContext)
       await resolved.triggerResolve()
-      const childControls = [...listInstance.childControls().values()]
+      const childControls = listInstance.children()
 
       const resolved2 = list.resolveValue(listData, ...resolveValueContext)
       await resolved2.triggerResolve()
-      const childControls2 = [...listInstance.childControls().values()]
+      const childControls2 = listInstance.children()
 
       childControls2.forEach((item, i) => expect(item).toBe(childControls[i]))
     })
@@ -194,12 +194,12 @@ describe('List', () => {
 
       const resolved = list.resolveValue(listData, ...resolveValueContext)
       await resolved.triggerResolve()
-      const childControls = [...listInstance.childControls().values()]
+      const childControls = listInstance.children()
 
       const listData2 = [...listData].sort((a, b) => b.id.localeCompare(a.id))
       const resolved2 = list.resolveValue(listData2, ...resolveValueContext)
       await resolved2.triggerResolve()
-      const childControls2 = [...listInstance.childControls().values()]
+      const childControls2 = listInstance.children()
 
       childControls2.forEach((item, i) =>
         expect(item).not.toBe(childControls[i]),
@@ -218,12 +218,12 @@ describe('List', () => {
 
       const resolved = list.resolveValue(listData, ...resolveValueContext)
       await resolved.triggerResolve()
-      const childControls = [...listInstance.childControls().values()]
+      const childControls = listInstance.children()
 
       const listData2 = [listData[0], listData[2], listData[1], listData[3]]
       const resolved2 = list.resolveValue(listData2, ...resolveValueContext)
       await resolved2.triggerResolve()
-      const childControls2 = [...listInstance.childControls().values()]
+      const childControls2 = listInstance.children()
 
       expect(childControls2[0]).toBe(childControls[0])
       expect(childControls2[1]).not.toBe(childControls[1])
@@ -245,13 +245,29 @@ describe('List', () => {
 
       const resolved = list.resolveValue(listData, ...resolveValueContext)
       await resolved.triggerResolve()
-      const childControls = [...listInstance.childControls().values()]
+      const childControls = listInstance.children()
 
       childControls.forEach((c, index) => {
         expect(listInstance.child(`${index}`)).toBe(c)
         expect(listInstance.child(`${index}`)?.propPath).toBe(
           `list-prop.${index}`,
         )
+      })
+    })
+
+    test('`children` returns a copy of the child controls list', async () => {
+      const { listInstance, resolveValueContext } = fixtures()
+
+      const resolved = list.resolveValue(listData, ...resolveValueContext)
+      await resolved.triggerResolve()
+
+      const children = listInstance.children()
+      expect(children.length).toBe(listInstance.childControls().size)
+
+      expect(listInstance.children()).not.toBe(children)
+
+      listInstance.children().forEach((c, index) => {
+        expect(children[index]).toBe(c)
       })
     })
   })

--- a/packages/controls/src/controls/shape/v1/shape-control.ts
+++ b/packages/controls/src/controls/shape/v1/shape-control.ts
@@ -41,6 +41,10 @@ export class ShapeControl<
     }
   }
 
+  isCompositeProp = () => true
+
+  children = () => [...this.childControls.values()]
+
   child = (key: string) => this.childControls.get(key)
 
   resolvesToRenderableNode = () => false

--- a/packages/controls/src/controls/slot/slot-control.ts
+++ b/packages/controls/src/controls/slot/slot-control.ts
@@ -22,6 +22,15 @@ export class SlotControl extends ControlInstance<Message> {
     'makeswift::controls::slot::message::item-box-model-change'
 
   recv = (_message: Message) => {}
+
+  isCompositeProp(): boolean {
+    return false
+  }
+
+  children(): ControlInstance[] {
+    return []
+  }
+
   child(_key: string): ControlInstance | undefined {
     return undefined
   }

--- a/packages/controls/src/controls/style/v1/style-control.ts
+++ b/packages/controls/src/controls/style/v1/style-control.ts
@@ -12,6 +12,14 @@ export class StyleControl extends ControlInstance<Message> {
 
   recv = (_message: Message) => {}
 
+  isCompositeProp(): boolean {
+    return false
+  }
+
+  children(): ControlInstance[] {
+    return []
+  }
+
   child(_key: string): ControlInstance | undefined {
     return undefined
   }

--- a/packages/controls/src/controls/style/v2/style-v2-control.ts
+++ b/packages/controls/src/controls/style/v2/style-v2-control.ts
@@ -38,6 +38,14 @@ export class StyleV2Control extends ControlInstance<Message> {
     })
   }
 
+  isCompositeProp(): boolean {
+    return false
+  }
+
+  children(): ControlInstance[] {
+    return []
+  }
+
   child(_key: string): ControlInstance | undefined {
     return undefined
   }

--- a/packages/runtime/src/controls/rich-text-v2/control.ts
+++ b/packages/runtime/src/controls/rich-text-v2/control.ts
@@ -123,6 +123,14 @@ export class RichTextV2Control extends ControlInstance<Message> {
     }
   }
 
+  isCompositeProp(): boolean {
+    return false
+  }
+
+  children(): ControlInstance[] {
+    return []
+  }
+
   child(_key: string): ControlInstance | undefined {
     return undefined
   }

--- a/packages/runtime/src/controls/rich-text/control.ts
+++ b/packages/runtime/src/controls/rich-text/control.ts
@@ -67,10 +67,6 @@ export class RichTextControl extends ControlInstance<Message> {
 
   private editor: Editor | null = null
 
-  child(_key: string): ControlInstance | undefined {
-    return undefined
-  }
-
   recv = (message: Message): void => {
     if (!this.editor) return
 
@@ -89,6 +85,18 @@ export class RichTextControl extends ControlInstance<Message> {
         break
       }
     }
+  }
+
+  isCompositeProp(): boolean {
+    return false
+  }
+
+  children(): ControlInstance[] {
+    return []
+  }
+
+  child(_key: string): ControlInstance | undefined {
+    return undefined
   }
 
   resolvesToRenderableNode(): boolean {

--- a/packages/runtime/src/prop-controllers/instances.ts
+++ b/packages/runtime/src/prop-controllers/instances.ts
@@ -33,6 +33,15 @@ export type TableFormFieldsMessage =
 
 export class TableFormFieldsPropController extends ControlInstance<TableFormFieldsMessage> {
   recv = () => {}
+
+  isCompositeProp(): boolean {
+    return false
+  }
+
+  children(): ControlInstance[] {
+    return []
+  }
+
   child(_key: string): ControlInstance | undefined {
     return undefined
   }


### PR DESCRIPTION
`children` gives us a generic way to iterate over all control instances corresponding to the props of a given element; `isCompositeProp` gives us the ability to differentiate between "scalar" and "composite" props, including cases where a control is composite but exposes no child control instances.

See inline comments for details.