### PR TITLE
feat(controls): unstable_Cascade composable spike (ARR-970)

### DIFF
--- a/apps/nextjs-app-router/src/components/cascade-demo/cascade-demo.makeswift.ts
+++ b/apps/nextjs-app-router/src/components/cascade-demo/cascade-demo.makeswift.ts
@@ -5,6 +5,7 @@ import {
   Combobox,
   Style,
   unstable_Cascade,
+  unstable_Gallery,
   TextInput,
   List,
   Color,
@@ -52,6 +53,20 @@ async function categoryOptions(showDiscountsOnly: boolean) {
   }))
 }
 
+async function productImageOptions(product: Product) {
+  return {
+    options: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((n) => {
+      const url = `https://picsum.photos/seed/${product.id}-${n}/300/300`
+      return {
+        id: `${product.id}-image-${n}`,
+        thumbnailUrl: url,
+        label: `${product.label} ${n}`,
+        value: { src: url, label: `${product.label} ${n}` },
+      }
+    }),
+  }
+}
+
 async function productOptions(category: Category) {
   return products
     .filter((product) => product.categoryId === category.id)
@@ -96,6 +111,11 @@ runtime.registerComponent(
             Combobox({
               label: 'Product',
               getOptions: () => productOptions(category),
+            }),
+          (product: Product) =>
+            unstable_Gallery({
+              label: 'Product image',
+              getOptions: () => productImageOptions(product),
             }),
         ],
       }),

--- a/apps/nextjs-app-router/src/components/cascade-demo/cascade-demo.makeswift.ts
+++ b/apps/nextjs-app-router/src/components/cascade-demo/cascade-demo.makeswift.ts
@@ -1,0 +1,104 @@
+import { lazy } from 'react'
+
+import {
+  Checkbox,
+  Combobox,
+  Style,
+  unstable_Cascade,
+  TextInput,
+  List,
+  Color,
+} from '@makeswift/runtime/controls'
+
+import { runtime } from '@/makeswift/runtime'
+
+type Category = { id: string; label: string }
+type Product = {
+  id: string
+  label: string
+  categoryId: string
+  discounted: boolean
+}
+
+const categories: Category[] = [
+  { id: 'shirts', label: 'Shirts' },
+  { id: 'shoes', label: 'Shoes' },
+]
+
+const products: Product[] = [
+  { id: 'p1', label: 'Classic Tee', categoryId: 'shirts', discounted: false },
+  { id: 'p2', label: 'Clearance Tee', categoryId: 'shirts', discounted: true },
+  { id: 'p3', label: 'Running Shoe', categoryId: 'shoes', discounted: false },
+  {
+    id: 'p4',
+    label: 'Clearance Sandal',
+    categoryId: 'shoes',
+    discounted: true,
+  },
+]
+
+async function categoryOptions(showDiscountsOnly: boolean) {
+  const withProducts = categories.filter((category) =>
+    products.some(
+      (product) =>
+        product.categoryId === category.id &&
+        (!showDiscountsOnly || product.discounted),
+    ),
+  )
+  return withProducts.map((category) => ({
+    id: category.id,
+    label: category.label,
+    value: category,
+  }))
+}
+
+async function productOptions(category: Category) {
+  return products
+    .filter((product) => product.categoryId === category.id)
+    .map((product) => ({
+      id: product.id,
+      label: product.label,
+      value: product,
+    }))
+}
+
+runtime.registerComponent(
+  lazy(() => import('./cascade-demo')),
+  {
+    type: 'Cascade Demo',
+    label: 'Custom / Cascade Demo',
+    props: {
+      className: Style(),
+      test: List({
+        label: 'Texts',
+        type: TextInput({ label: 'Text', defaultValue: 'Text Title' }),
+        getItemLabel: (item) => item ?? 'Text',
+      }),
+      product: unstable_Cascade({
+        label: 'Product',
+        steps: [
+          () => Checkbox({ label: 'Show discounts only' }),
+          // // () =>
+          // //   List({
+          // //     label: 'Texts',
+          // //     type: TextInput({ label: 'Text', defaultValue: 'Text Title' }),
+          // //     getItemLabel: (item) => item ?? 'Text',
+          // //   }),
+          // () => Color({ label: 'Color' }),
+          (showDiscounts: boolean) => {
+            console.log({ showDiscounts })
+            return Combobox({
+              label: 'Category',
+              getOptions: () => categoryOptions(true),
+            })
+          },
+          (category: Category) =>
+            Combobox({
+              label: 'Product',
+              getOptions: () => productOptions(category),
+            }),
+        ],
+      }),
+    },
+  },
+)

--- a/apps/nextjs-app-router/src/components/cascade-demo/cascade-demo.tsx
+++ b/apps/nextjs-app-router/src/components/cascade-demo/cascade-demo.tsx
@@ -1,10 +1,17 @@
 import { Ref, forwardRef } from 'react'
 
+type ProductImage = { src: string; label?: string }
 type Product = { id: string; label: string }
 
 type Props = {
   className?: string
-  product?: Product
+  // The cascade resolves to the last defined step: the selected Gallery image
+  // once one is picked, otherwise the deepest upstream selection (product).
+  product?: ProductImage | Product
+}
+
+function isImage(value: ProductImage | Product): value is ProductImage {
+  return 'src' in value
 }
 
 export const CascadeDemo = forwardRef(function CascadeDemo(
@@ -15,6 +22,12 @@ export const CascadeDemo = forwardRef(function CascadeDemo(
     <div className={`p-4 text-lg ${className ?? ''}`} ref={ref}>
       {product == null ? (
         <span>No product selected</span>
+      ) : isImage(product) ? (
+        <figure>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={product.src} alt={product.label ?? ''} width={300} height={300} />
+          {product.label && <figcaption>{product.label}</figcaption>}
+        </figure>
       ) : (
         <span>
           Selected product: <strong>{product.label}</strong> ({product.id})

--- a/apps/nextjs-app-router/src/components/cascade-demo/cascade-demo.tsx
+++ b/apps/nextjs-app-router/src/components/cascade-demo/cascade-demo.tsx
@@ -1,0 +1,27 @@
+import { Ref, forwardRef } from 'react'
+
+type Product = { id: string; label: string }
+
+type Props = {
+  className?: string
+  product?: Product
+}
+
+export const CascadeDemo = forwardRef(function CascadeDemo(
+  { className, product }: Props,
+  ref: Ref<HTMLDivElement>,
+) {
+  return (
+    <div className={`p-4 text-lg ${className ?? ''}`} ref={ref}>
+      {product == null ? (
+        <span>No product selected</span>
+      ) : (
+        <span>
+          Selected product: <strong>{product.label}</strong> ({product.id})
+        </span>
+      )}
+    </div>
+  )
+})
+
+export default CascadeDemo

--- a/apps/nextjs-app-router/src/makeswift/components.ts
+++ b/apps/nextjs-app-router/src/makeswift/components.ts
@@ -1,3 +1,4 @@
+import '@/components/cascade-demo/cascade-demo.makeswift'
 import '@/components/code-demo/code-demo.makeswift'
 import '@/components/font-control-demo/font-control-demo.makeswift'
 import '@/components/gallery-demo/gallery-demo.makeswift'

--- a/packages/controls/src/controls/cascade/cascade-control.ts
+++ b/packages/controls/src/controls/cascade/cascade-control.ts
@@ -1,0 +1,56 @@
+import { ControlDefinition } from '../definition'
+import {
+  ControlInstance,
+  type ControlMessage,
+  type SendMessage,
+} from '../instance'
+
+import { type CascadeDefinition } from './cascade'
+
+type Message = {
+  type: typeof CascadeControl.CHILD_CONTROL_MESSAGE
+  payload: { message: ControlMessage; key: string }
+}
+
+export class CascadeControl<
+  Def extends CascadeDefinition = CascadeDefinition,
+> extends ControlInstance<Message> {
+  static readonly CHILD_CONTROL_MESSAGE =
+    'makeswift::controls::cascade::message::child-control-message'
+
+  private readonly childControls: Map<string, ControlInstance> = new Map()
+
+  constructor(
+    private readonly definition: Def,
+    sendMessage: SendMessage<Message>,
+  ) {
+    super(sendMessage)
+    // Only step 0 is statically known (it takes no upstream value). Downstream
+    // step controls are materialized dynamically from upstream selections by
+    // the builder — deferred with the serialization protocol — so they are not
+    // wired here.
+    const step0 = this.definition.steps[0]?.()
+    if (step0 != null) {
+      this.childControls.set('0', this.createChildControl(step0, '0'))
+    }
+  }
+
+  recv = (message: Message) => {
+    switch (message.type) {
+      case CascadeControl.CHILD_CONTROL_MESSAGE: {
+        this.child(message.payload.key)?.recv(message.payload.message)
+      }
+    }
+  }
+
+  child = (key: string) => this.childControls.get(key)
+
+  createChildControl = (def: ControlDefinition, key: string) => {
+    return def.createInstance((message) =>
+      this.sendMessage({
+        type: CascadeControl.CHILD_CONTROL_MESSAGE,
+        payload: { message, key },
+      }),
+    )
+  }
+}

--- a/packages/controls/src/controls/cascade/cascade-control.ts
+++ b/packages/controls/src/controls/cascade/cascade-control.ts
@@ -1,8 +1,8 @@
 import { ControlDefinition } from '../definition'
 import {
   ControlInstance,
+  type ControlInstanceArgs,
   type ControlMessage,
-  type SendMessage,
 } from '../instance'
 
 import { type CascadeDefinition } from './cascade'
@@ -22,9 +22,9 @@ export class CascadeControl<
 
   constructor(
     private readonly definition: Def,
-    sendMessage: SendMessage<Message>,
+    args: ControlInstanceArgs,
   ) {
-    super(sendMessage)
+    super(args)
     // Only step 0 is statically known (it takes no upstream value). Downstream
     // step controls are materialized dynamically from upstream selections by
     // the builder — deferred with the serialization protocol — so they are not
@@ -43,14 +43,26 @@ export class CascadeControl<
     }
   }
 
+  isCompositeProp = () => true
+
+  children = () => [...this.childControls.values()]
+
   child = (key: string) => this.childControls.get(key)
 
+  resolvesToRenderableNode = () => false
+
   createChildControl = (def: ControlDefinition, key: string) => {
-    return def.createInstance((message) =>
-      this.sendMessage({
-        type: CascadeControl.CHILD_CONTROL_MESSAGE,
-        payload: { message, key },
-      }),
-    )
+    const { elementKey, propPath } = this.instanceKey
+    return def.createInstance({
+      instanceKey: {
+        elementKey,
+        propPath: `${propPath}.${key}`,
+      },
+      sendMessage: (message) =>
+        this.sendMessage({
+          type: CascadeControl.CHILD_CONTROL_MESSAGE,
+          payload: { message, key },
+        }),
+    })
   }
 }

--- a/packages/controls/src/controls/cascade/cascade.test.ts
+++ b/packages/controls/src/controls/cascade/cascade.test.ts
@@ -1,3 +1,4 @@
+import { ControlDataTypeKey } from '../../common'
 import { type ResourceResolver } from '../../resources/resolver'
 import { type Stylesheet } from '../../stylesheet'
 
@@ -20,6 +21,24 @@ describe('unstable_Cascade (steps as control factories)', () => {
     const cascade = unstable_Cascade({ steps: [() => Checkbox()] })
     expect(cascade.controlType).toBe(CascadeDefinition.type)
     expect(CascadeDefinition.type).toBe('makeswift::controls::cascade')
+  })
+
+  test('toData emits cascade::v1 tagged data', () => {
+    const cascade = unstable_Cascade({ steps: [() => Checkbox()] })
+    const data = cascade.toData([true])
+    expect(data).toEqual({
+      [ControlDataTypeKey]: 'cascade::v1',
+      value: [Checkbox().toData(true)],
+    })
+  })
+
+  test('fromData reads both v0 arrays and v1 tagged data', () => {
+    const cascade = unstable_Cascade({ steps: [() => Checkbox()] })
+    const v0 = [Checkbox().toData(true)]
+    expect(cascade.fromData(v0)).toEqual([true])
+    expect(
+      cascade.fromData({ [ControlDataTypeKey]: 'cascade::v1', value: v0 }),
+    ).toEqual([true])
   })
 
   test('threads step 0 resolved value into the step 1 factory', () => {
@@ -61,7 +80,10 @@ describe('unstable_Cascade (steps as control factories)', () => {
     })
     const data = [Checkbox({ defaultValue: false }).toData(true), optionP1]
     const value = cascade.fromData(data)
-    expect(cascade.toData(value!)).toEqual(data)
+    expect(cascade.toData(value!)).toEqual({
+      [ControlDataTypeKey]: 'cascade::v1',
+      value: data,
+    })
   })
 
   test('copyData delegates to each materialized child', () => {
@@ -161,7 +183,10 @@ describe('unstable_Cascade (steps as control factories)', () => {
     const value = cascade.fromData(data)
     received.length = 0 // ignore the fromData materialization; measure toData
     const roundTripped = cascade.toData(value!)
-    expect(roundTripped).toEqual(data)
+    expect(roundTripped).toEqual({
+      [ControlDataTypeKey]: 'cascade::v1',
+      value: data,
+    })
     expect(received).toEqual([true]) // toData's walk threaded checkbox=true into step 1
   })
 
@@ -208,6 +233,42 @@ describe('unstable_Cascade (steps as control factories)', () => {
 
 describe('step-control allowlist', () => {
   const colorStep = (() => Color()) as unknown as Step
+
+  test('resolveValue degrades an invalid slot to undefined instead of throwing', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const cascade = unstable_Cascade({
+      steps: [
+        () => Combobox({ getOptions: async () => [] }),
+        (_p: { id: string }) => Combobox({ getOptions: async () => [] }),
+      ],
+    })
+    // valid product, garbage variant slot → resolves to the product (deepest defined)
+    expect(
+      cascade
+        .resolveValue([optionP1, true as never], resolver, stylesheet)
+        .readStable(),
+    ).toEqual({ id: 'p1' })
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('step 1 data does not match control'),
+    )
+    warn.mockRestore()
+  })
+
+  test('materializeForSerialization is also lenient', () => {
+    const cascade = unstable_Cascade({
+      steps: [() => Checkbox({ defaultValue: true })],
+    })
+    expect(() =>
+      cascade.materializeForSerialization([optionP1 as never]),
+    ).not.toThrow()
+  })
+
+  test('fromData stays strict', () => {
+    const cascade = unstable_Cascade({ steps: [() => Checkbox()] })
+    expect(() => cascade.fromData([optionP1])).toThrow(
+      /step 0 data does not match control/,
+    )
+  })
 
   test('fromData throws a descriptive error for an unsupported step control', () => {
     const cascade = unstable_Cascade({ steps: [colorStep] })

--- a/packages/controls/src/controls/cascade/cascade.test.ts
+++ b/packages/controls/src/controls/cascade/cascade.test.ts
@@ -98,7 +98,7 @@ describe('unstable_Cascade (steps as control factories)', () => {
     expect(copied).toEqual(data)
   })
 
-  test('resolveValue returns the deepest step with a defined value', () => {
+  test('resolveValue returns the final step’s value when the chain is complete', () => {
     const cascade = unstable_Cascade({
       steps: [
         () => Combobox({ getOptions: async () => [] }),
@@ -110,17 +110,17 @@ describe('unstable_Cascade (steps as control factories)', () => {
     ).toEqual({ id: 'v1' })
   })
 
-  test('an unselected step terminates the chain (resolves to last selected)', () => {
+  test('an unselected final step resolves to undefined (no fallback to earlier steps)', () => {
     const cascade = unstable_Cascade({
       steps: [
         () => Combobox({ getOptions: async () => [] }),
         (_p: { id: string }) => Combobox({ getOptions: async () => [] }),
       ],
     })
-    // product selected, variant not → resolves to product's value
+    // product selected, variant (final step) not → cascade resolves to undefined
     expect(
       cascade.resolveValue([optionP1], resolver, stylesheet).readStable(),
-    ).toEqual({ id: 'p1' })
+    ).toBeUndefined()
   })
 
   test('resolveValue is undefined when step 0 is unselected', () => {
@@ -242,12 +242,13 @@ describe('step-control allowlist', () => {
         (_p: { id: string }) => Combobox({ getOptions: async () => [] }),
       ],
     })
-    // valid product, garbage variant slot → resolves to the product (deepest defined)
+    // valid product, garbage variant (final step) → dropped to undefined, so the
+    // cascade resolves to undefined rather than falling back to the product
     expect(
       cascade
         .resolveValue([optionP1, true as never], resolver, stylesheet)
         .readStable(),
-    ).toEqual({ id: 'p1' })
+    ).toBeUndefined()
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining('step 1 data does not match control'),
     )

--- a/packages/controls/src/controls/cascade/cascade.test.ts
+++ b/packages/controls/src/controls/cascade/cascade.test.ts
@@ -2,9 +2,11 @@ import { type ResourceResolver } from '../../resources/resolver'
 import { type Stylesheet } from '../../stylesheet'
 
 import { Checkbox } from '../checkbox'
+import { Color } from '../color'
 import { Combobox } from '../combobox'
+import { Image } from '../image'
 
-import { unstable_Cascade, CascadeDefinition } from './cascade'
+import { unstable_Cascade, CascadeDefinition, type Step } from './cascade'
 
 // Checkbox/Combobox resolveValue ignore resolver/stylesheet, so stubs are safe.
 const resolver = {} as ResourceResolver
@@ -201,5 +203,68 @@ describe('unstable_Cascade (steps as control factories)', () => {
     })
     const controls = cascade.materializeForSerialization([])
     expect(controls).toHaveLength(1)
+  })
+})
+
+describe('step-control allowlist', () => {
+  const colorStep = (() => Color()) as unknown as Step
+
+  test('fromData throws a descriptive error for an unsupported step control', () => {
+    const cascade = unstable_Cascade({ steps: [colorStep] })
+    expect(() => cascade.fromData([undefined])).toThrow(
+      "unstable_Cascade: step 0 returned unsupported control 'makeswift::controls::color'",
+    )
+  })
+
+  test('resolveValue throws the same error', () => {
+    const cascade = unstable_Cascade({ steps: [colorStep] })
+    expect(() =>
+      cascade.resolveValue([undefined], resolver, stylesheet),
+    ).toThrow(/returned unsupported control/)
+  })
+
+  test('the error names the supported control types', () => {
+    const cascade = unstable_Cascade({ steps: [colorStep] })
+    expect(() => cascade.toData([undefined])).toThrow(
+      /Supported controls: .*makeswift::controls::checkbox.*makeswift::controls::combobox/,
+    )
+  })
+
+  test('rejects Image, including as a downstream step', () => {
+    const cascade = unstable_Cascade({
+      steps: [
+        () => Checkbox({ defaultValue: true }),
+        (() => Image()) as unknown as Step,
+      ],
+    })
+    expect(() => cascade.fromData([])).toThrow(
+      "unstable_Cascade: step 1 returned unsupported control 'makeswift::controls::image'",
+    )
+  })
+
+  test('type-level: slots only accept allowed-control data shapes', () => {
+    const cascade = unstable_Cascade({ steps: [() => Checkbox()] })
+    expect(() =>
+      // @ts-expect-error — not a data shape of any allowed step control
+      cascade.fromData([{ random: 'object' }]),
+    ).toThrow(/step 0 data does not match/)
+  })
+
+  test('throws when a slot’s data does not match its step control', () => {
+    const cascade = unstable_Cascade({ steps: [() => Checkbox()] })
+    expect(() => cascade.fromData([optionP1])).toThrow(
+      /step 0 data does not match control 'makeswift::controls::checkbox'/,
+    )
+  })
+
+  test('type-level: rejects steps that return unsupported controls', () => {
+    expect(() =>
+      unstable_Cascade({
+        steps: [
+          // @ts-expect-error — Color is not a cascade-compatible step control
+          () => Color(),
+        ],
+      }),
+    ).not.toThrow()
   })
 })

--- a/packages/controls/src/controls/cascade/cascade.test.ts
+++ b/packages/controls/src/controls/cascade/cascade.test.ts
@@ -1,0 +1,205 @@
+import { type ResourceResolver } from '../../resources/resolver'
+import { type Stylesheet } from '../../stylesheet'
+
+import { Checkbox } from '../checkbox'
+import { Combobox } from '../combobox'
+
+import { unstable_Cascade, CascadeDefinition } from './cascade'
+
+// Checkbox/Combobox resolveValue ignore resolver/stylesheet, so stubs are safe.
+const resolver = {} as ResourceResolver
+const stylesheet = { child: () => stylesheet } as unknown as Stylesheet
+
+const optionP1 = { id: 'p1', label: 'Product 1', value: { id: 'p1' } }
+const optionV1 = { id: 'v1', label: 'Variant 1', value: { id: 'v1' } }
+
+describe('unstable_Cascade (steps as control factories)', () => {
+  test('exposes the cascade control type', () => {
+    const cascade = unstable_Cascade({ steps: [() => Checkbox()] })
+    expect(cascade.controlType).toBe(CascadeDefinition.type)
+    expect(CascadeDefinition.type).toBe('makeswift::controls::cascade')
+  })
+
+  test('threads step 0 resolved value into the step 1 factory', () => {
+    const received: unknown[] = []
+    const cascade = unstable_Cascade({
+      steps: [
+        () => Checkbox({ defaultValue: true }),
+        (showDiscounts: boolean) => {
+          received.push(showDiscounts)
+          return Combobox({ getOptions: async () => [] })
+        },
+      ],
+    })
+    cascade.resolveValue([], resolver, stylesheet).readStable()
+    expect(received).toEqual([true])
+  })
+
+  test('threads a combobox selection (option value) into the next factory', () => {
+    const received: unknown[] = []
+    const cascade = unstable_Cascade({
+      steps: [
+        () => Combobox({ getOptions: async () => [] }),
+        (product: { id: string }) => {
+          received.push(product)
+          return Combobox({ getOptions: async () => [] })
+        },
+      ],
+    })
+    cascade.resolveValue([optionP1], resolver, stylesheet).readStable()
+    expect(received).toEqual([{ id: 'p1' }])
+  })
+
+  test('fromData → toData round-trips through the materialized chain', () => {
+    const cascade = unstable_Cascade({
+      steps: [
+        () => Checkbox({ defaultValue: false }),
+        (_showDiscounts: boolean) => Combobox({ getOptions: async () => [] }),
+      ],
+    })
+    const data = [Checkbox({ defaultValue: false }).toData(true), optionP1]
+    const value = cascade.fromData(data)
+    expect(cascade.toData(value!)).toEqual(data)
+  })
+
+  test('copyData delegates to each materialized child', () => {
+    const cascade = unstable_Cascade({
+      steps: [
+        () => Checkbox({ defaultValue: false }),
+        (_s: boolean) => Combobox({ getOptions: async () => [] }),
+      ],
+    })
+    const data = [Checkbox({ defaultValue: false }).toData(true), optionP1]
+    const copied = cascade.copyData(data, { replacementContext: {} } as any)
+    expect(copied).toEqual(data)
+  })
+
+  test('resolveValue returns the deepest step with a defined value', () => {
+    const cascade = unstable_Cascade({
+      steps: [
+        () => Combobox({ getOptions: async () => [] }),
+        (_p: { id: string }) => Combobox({ getOptions: async () => [] }),
+      ],
+    })
+    expect(
+      cascade.resolveValue([optionP1, optionV1], resolver, stylesheet).readStable(),
+    ).toEqual({ id: 'v1' })
+  })
+
+  test('an unselected step terminates the chain (resolves to last selected)', () => {
+    const cascade = unstable_Cascade({
+      steps: [
+        () => Combobox({ getOptions: async () => [] }),
+        (_p: { id: string }) => Combobox({ getOptions: async () => [] }),
+      ],
+    })
+    // product selected, variant not → resolves to product's value
+    expect(
+      cascade.resolveValue([optionP1], resolver, stylesheet).readStable(),
+    ).toEqual({ id: 'p1' })
+  })
+
+  test('resolveValue is undefined when step 0 is unselected', () => {
+    const cascade = unstable_Cascade({
+      steps: [
+        () => Combobox({ getOptions: async () => [] }),
+        (_p: { id: string }) => Combobox({ getOptions: async () => [] }),
+      ],
+    })
+    expect(
+      cascade.resolveValue([], resolver, stylesheet).readStable(),
+    ).toBeUndefined()
+  })
+
+  test('type: cascade ResolvedValue matches the last step control', () => {
+    const cascade = unstable_Cascade({
+      steps: [
+        () => Combobox({ getOptions: async () => [] }),
+        (_p: unknown) => Checkbox({ defaultValue: false }),
+      ] as const,
+    })
+    const rv = cascade.resolveValue([], resolver, stylesheet).readStable()
+    // Last step is Checkbox → ResolvedValue is boolean | undefined.
+    const typed: boolean | undefined = rv
+    expect(typed).toBeUndefined()
+  })
+
+  test('deserialize accepts the live materialize-chain shape (a function)', () => {
+    const materializeChain = async (_data: unknown[]) => []
+    const cascade = CascadeDefinition.deserialize({
+      type: CascadeDefinition.type,
+      config: { label: 'Product', steps: materializeChain },
+    } as any)
+
+    expect(cascade.controlType).toBe(CascadeDefinition.type)
+    expect(cascade.config.label).toBe('Product')
+  })
+
+  test('deserialize still throws for a detached record with no live port', () => {
+    expect(() =>
+      CascadeDefinition.deserialize({
+        type: CascadeDefinition.type,
+        config: { steps: [] },
+      } as any),
+    ).toThrow(/not yet supported/i)
+  })
+
+  test('toData threads the correct prev into the downstream factory (round-trip)', () => {
+    const received: unknown[] = []
+    const cascade = unstable_Cascade({
+      steps: [
+        () => Checkbox({ defaultValue: false }),
+        (showDiscounts: boolean) => {
+          received.push(showDiscounts)
+          return Combobox({ getOptions: async () => [] })
+        },
+      ],
+    })
+    const data = [Checkbox({ defaultValue: false }).toData(true), optionP1]
+    const value = cascade.fromData(data)
+    received.length = 0 // ignore the fromData materialization; measure toData
+    const roundTripped = cascade.toData(value!)
+    expect(roundTripped).toEqual(data)
+    expect(received).toEqual([true]) // toData's walk threaded checkbox=true into step 1
+  })
+
+  test('a populated downstream with an unselected upstream stays terminated', () => {
+    const cascade = unstable_Cascade({
+      steps: [
+        () => Combobox({ getOptions: async () => [] }),
+        (_p: { id: string }) => Combobox({ getOptions: async () => [] }),
+      ],
+    })
+    // step 0 unselected but step 1 has data → chain terminates at step 0 → undefined
+    expect(
+      cascade.resolveValue([undefined, optionV1], resolver, stylesheet).readStable(),
+    ).toBeUndefined()
+  })
+
+  test('materializeForSerialization returns the reachable chain of controls', () => {
+    const cascade = unstable_Cascade({
+      steps: [
+        () => Checkbox({ defaultValue: true }),
+        (showDiscounts: boolean) => {
+          expect(showDiscounts).toBe(true)
+          return Combobox({ getOptions: async () => [] })
+        },
+      ],
+    })
+    const controls = cascade.materializeForSerialization([])
+    expect(controls).toHaveLength(2)
+    expect(controls[0].controlType).toBe('makeswift::controls::checkbox')
+    expect(controls[1].controlType).toBe('makeswift::controls::combobox')
+  })
+
+  test('materializeForSerialization stops at an unselected step', () => {
+    const cascade = unstable_Cascade({
+      steps: [
+        () => Combobox({ getOptions: async () => [] }),
+        (_p: { id: string }) => Combobox({ getOptions: async () => [] }),
+      ],
+    })
+    const controls = cascade.materializeForSerialization([])
+    expect(controls).toHaveLength(1)
+  })
+})

--- a/packages/controls/src/controls/cascade/cascade.ts
+++ b/packages/controls/src/controls/cascade/cascade.ts
@@ -3,7 +3,6 @@ import { z } from 'zod'
 import { StableValue } from '../../lib/stable-value'
 import { safeParse, type ParseResult } from '../../lib/zod'
 
-import { type Data } from '../../common'
 import { type CopyContext } from '../../context'
 import { type IntrospectionTarget } from '../../introspection'
 import { type ResourceResolver } from '../../resources/resolver'
@@ -11,22 +10,55 @@ import { type DeserializedRecord } from '../../serialization'
 import { isFunction } from '../../serialization/function'
 import { type Stylesheet } from '../../stylesheet'
 
-import { type ResolvedValueType as ResolvedValueType_ } from '../associated-types'
+import {
+  type DataType as DataType_,
+  type ResolvedValueType as ResolvedValueType_,
+  type ValueType as ValueType_,
+} from '../associated-types'
+import { CheckboxDefinition } from '../checkbox'
+import { CodeDefinition } from '../code'
+import { ComboboxDefinition } from '../combobox'
 import {
   ControlDefinition,
   type Resolvable,
   type SchemaType,
 } from '../definition'
+import { IconRadioGroupDefinition } from '../icon-radio-group'
 import { type SendMessage } from '../instance'
+import { NumberDefinition } from '../number'
+import { SelectDefinition } from '../select'
+import { SliderDefinition } from '../slider'
+import { TextAreaDefinition } from '../text-area'
+import { TextInputDefinition } from '../text-input'
 import { ControlDefinitionVisitor } from '../visitor'
 
 import { CascadeControl } from './cascade-control'
 
-type StepControl = ControlDefinition<string, unknown, any, any, any>
+type StepControl =
+  | CheckboxDefinition<any>
+  | CodeDefinition<any>
+  | ComboboxDefinition<any>
+  | IconRadioGroupDefinition<any>
+  | NumberDefinition<any>
+  | SelectDefinition<any>
+  | SliderDefinition<any>
+  | TextAreaDefinition<any>
+  | TextInputDefinition<any>
 
-// A step produces a control from the previous step's ResolvedValue. Step 0
-// takes no argument; step n (n>=1) takes step n-1's ResolvedValue. Inputs are
-// author-annotated (loosely typed).
+type MaterializedStepControl = ControlDefinition<string, unknown, any, any, any>
+
+const COMPATIBLE_STEP_TYPES: ReadonlySet<string> = new Set([
+  CheckboxDefinition.type,
+  CodeDefinition.type,
+  ComboboxDefinition.type,
+  IconRadioGroupDefinition.type,
+  NumberDefinition.type,
+  SelectDefinition.type,
+  SliderDefinition.type,
+  TextAreaDefinition.type,
+  TextInputDefinition.type,
+])
+
 export type Step<D extends StepControl = StepControl> = (prev?: any) => D
 
 export type Steps = readonly Step[]
@@ -37,15 +69,12 @@ type Config<S extends Steps = Steps> = {
   readonly steps: S
 }
 
-// Cascade Data/Value are arrays indexed by step; entry n is step n's control
-// Data/Value. Loosely typed (elements are `Data`, matching `ControlDefinition`'s
-// `DataType extends Data`/`ValueType extends Data` bounds) because the control
-// at each step is materialized dynamically from upstream selections.
-type DataType = Data[]
-type ValueType = Data[]
+type StepData = DataType_<StepControl> | undefined
+type StepValue = ValueType_<StepControl> | undefined
 
-// The last step's control (the return type of the last factory) drives the
-// cascade's ResolvedValue.
+type DataType = StepData[]
+type ValueType = StepValue[]
+
 type LastStep<S extends Steps> = S extends readonly [...any[], infer L]
   ? L extends Step
     ? L
@@ -58,10 +87,6 @@ type ResolvedValueType<S extends Steps> =
 
 type InstanceType<S extends Steps> = CascadeControl<Definition<S>>
 
-// Stub resolver/stylesheet for the data-shaping methods (fromData/toData/
-// copyData), which must materialize the chain to know each step's control but
-// receive no resolver. Valid for the spike because the proven stage controls
-// (Checkbox, Combobox) resolve synchronously and ignore both.
 const NOOP_RESOLVER = {} as ResourceResolver
 const NOOP_STYLESHEET: Stylesheet = {
   child: () => NOOP_STYLESHEET,
@@ -80,21 +105,17 @@ class Definition<S extends Steps> extends ControlDefinition<
   static deserialize(data: DeserializedRecord): CascadeDefinition {
     const steps = (data.config as { steps?: unknown } | undefined)?.steps
 
-    if (isFunction(steps)) {
-      return new CascadeDefinition({
-        label: (data.config as { label?: string }).label,
-        description: (data.config as { description?: string }).description,
-        // Builder-side-only shape: a single callable "materialize chain"
-        // function, not an array of step factories. This instance is never
-        // used for fromData/toData/resolveValue (runtime-only concerns) —
-        // only the builder's cascade controller calls `.steps` as a function.
-        steps: steps as unknown as Steps,
-      })
+    if (!isFunction(steps)) {
+      throw new Error(
+        'unstable_Cascade: serialization is not yet supported (deferred to the builder-integration follow-up)',
+      )
     }
 
-    throw new Error(
-      'unstable_Cascade: serialization is not yet supported (deferred to the builder-integration follow-up)',
-    )
+    return new CascadeDefinition({
+      label: (data.config as { label?: string }).label,
+      description: (data.config as { description?: string }).description,
+      steps: steps as unknown as Steps,
+    })
   }
 
   get steps(): S {
@@ -116,7 +137,6 @@ class Definition<S extends Steps> extends ControlDefinition<
     const config = z.object({
       label: z.string().optional(),
       description: z.string().optional(),
-      // Spike: steps are factory functions, not statically schematizable.
       steps: z.array(z.any()),
     })
 
@@ -129,13 +149,9 @@ class Definition<S extends Steps> extends ControlDefinition<
     return safeParse(this.schema.data, data)
   }
 
-  // Walk the reachable step chain: build each step's control from the previous
-  // step's ResolvedValue, run `visitStep` to collect an entry, and thread that
-  // step's ResolvedValue into the next factory. Stops before a step whose
-  // predecessor resolved to `undefined`.
   private walkSteps<T>(
     visitStep: (
-      control: StepControl,
+      control: MaterializedStepControl,
       index: number,
     ) => { entry: T; resolvedValue: unknown },
   ): T[] {
@@ -143,7 +159,13 @@ class Definition<S extends Steps> extends ControlDefinition<
     let prev: unknown = undefined
     for (let i = 0; i < this.config.steps.length; i++) {
       if (i > 0 && prev === undefined) break
-      const control = this.config.steps[i](prev)
+      const control: MaterializedStepControl = this.config.steps[i](prev)
+      if (!COMPATIBLE_STEP_TYPES.has(control.controlType)) {
+        throw new Error(
+          `unstable_Cascade: step ${i} returned unsupported control ` +
+            `'${control.controlType}' — Supported controls: ${[...COMPATIBLE_STEP_TYPES].join(', ')}`,
+        )
+      }
       const { entry, resolvedValue } = visitStep(control, i)
       entries.push(entry)
       prev = resolvedValue
@@ -151,15 +173,25 @@ class Definition<S extends Steps> extends ControlDefinition<
     return entries
   }
 
-  // Walk the reachable chain from Data: for each step, build its control from
-  // the previous step's ResolvedValue, then compute this step's Resolvable.
-  // Stops before a step whose predecessor resolved to `undefined`.
   private materialize(
     data: DataType | undefined,
     resolver: ResourceResolver,
     stylesheet: Stylesheet,
-  ): Array<{ control: StepControl; resolvable: Resolvable<unknown> }> {
+  ): Array<{
+    control: MaterializedStepControl
+    resolvable: Resolvable<unknown>
+  }> {
     return this.walkSteps((control, i) => {
+      const stepData = data?.[i]
+      if (stepData !== undefined) {
+        const parsed = control.safeParse(stepData)
+        if (!parsed.success) {
+          throw new Error(
+            `unstable_Cascade: step ${i} data does not match control ` +
+              `'${control.controlType}': ${parsed.error}`,
+          )
+        }
+      }
       const resolvable = control.resolveValue(
         data?.[i],
         resolver,
@@ -169,7 +201,6 @@ class Definition<S extends Steps> extends ControlDefinition<
         entry: { control, resolvable },
         resolvedValue: resolvable.readStable(),
       }
-      // why do we need to accumulate all the entries, why can't we just read the last value?
     })
   }
 
@@ -220,8 +251,6 @@ class Definition<S extends Steps> extends ControlDefinition<
     const stableValue = StableValue({
       name: Definition.type,
       read: () => {
-        // Deepest step with a defined resolved value = the "last selected"
-        // step. Terminated/unselected downstream steps read `undefined`.
         for (let i = chain.length - 1; i >= 0; i--) {
           const rv = chain[i].resolvable.readStable()
           if (rv !== undefined) return rv as ResolvedValueType<S>

--- a/packages/controls/src/controls/cascade/cascade.ts
+++ b/packages/controls/src/controls/cascade/cascade.ts
@@ -1,0 +1,264 @@
+import { z } from 'zod'
+
+import { StableValue } from '../../lib/stable-value'
+import { safeParse, type ParseResult } from '../../lib/zod'
+
+import { type Data } from '../../common'
+import { type CopyContext } from '../../context'
+import { type IntrospectionTarget } from '../../introspection'
+import { type ResourceResolver } from '../../resources/resolver'
+import { type DeserializedRecord } from '../../serialization'
+import { isFunction } from '../../serialization/function'
+import { type Stylesheet } from '../../stylesheet'
+
+import { type ResolvedValueType as ResolvedValueType_ } from '../associated-types'
+import {
+  ControlDefinition,
+  type Resolvable,
+  type SchemaType,
+} from '../definition'
+import { type SendMessage } from '../instance'
+import { ControlDefinitionVisitor } from '../visitor'
+
+import { CascadeControl } from './cascade-control'
+
+type StepControl = ControlDefinition<string, unknown, any, any, any>
+
+// A step produces a control from the previous step's ResolvedValue. Step 0
+// takes no argument; step n (n>=1) takes step n-1's ResolvedValue. Inputs are
+// author-annotated (loosely typed).
+export type Step<D extends StepControl = StepControl> = (prev?: any) => D
+
+export type Steps = readonly Step[]
+
+type Config<S extends Steps = Steps> = {
+  readonly label?: string
+  readonly description?: string
+  readonly steps: S
+}
+
+// Cascade Data/Value are arrays indexed by step; entry n is step n's control
+// Data/Value. Loosely typed (elements are `Data`, matching `ControlDefinition`'s
+// `DataType extends Data`/`ValueType extends Data` bounds) because the control
+// at each step is materialized dynamically from upstream selections.
+type DataType = Data[]
+type ValueType = Data[]
+
+// The last step's control (the return type of the last factory) drives the
+// cascade's ResolvedValue.
+type LastStep<S extends Steps> = S extends readonly [...any[], infer L]
+  ? L extends Step
+    ? L
+    : never
+  : Step
+
+type ResolvedValueType<S extends Steps> =
+  | ResolvedValueType_<ReturnType<LastStep<S>>>
+  | undefined
+
+type InstanceType<S extends Steps> = CascadeControl<Definition<S>>
+
+// Stub resolver/stylesheet for the data-shaping methods (fromData/toData/
+// copyData), which must materialize the chain to know each step's control but
+// receive no resolver. Valid for the spike because the proven stage controls
+// (Checkbox, Combobox) resolve synchronously and ignore both.
+const NOOP_RESOLVER = {} as ResourceResolver
+const NOOP_STYLESHEET: Stylesheet = {
+  child: () => NOOP_STYLESHEET,
+} as unknown as Stylesheet
+
+class Definition<S extends Steps> extends ControlDefinition<
+  typeof Definition.type,
+  Config<S>,
+  DataType,
+  ValueType,
+  ResolvedValueType<S>,
+  InstanceType<S>
+> {
+  static readonly type = 'makeswift::controls::cascade' as const
+
+  static deserialize(data: DeserializedRecord): CascadeDefinition {
+    const steps = (data.config as { steps?: unknown } | undefined)?.steps
+
+    if (isFunction(steps)) {
+      return new CascadeDefinition({
+        label: (data.config as { label?: string }).label,
+        description: (data.config as { description?: string }).description,
+        // Builder-side-only shape: a single callable "materialize chain"
+        // function, not an array of step factories. This instance is never
+        // used for fromData/toData/resolveValue (runtime-only concerns) —
+        // only the builder's cascade controller calls `.steps` as a function.
+        steps: steps as unknown as Steps,
+      })
+    }
+
+    throw new Error(
+      'unstable_Cascade: serialization is not yet supported (deferred to the builder-integration follow-up)',
+    )
+  }
+
+  get steps(): S {
+    return this.config.steps
+  }
+
+  get controlType() {
+    return Definition.type
+  }
+
+  get schema() {
+    const version = z.literal(1)
+    const type = z.literal(Definition.type)
+
+    const data = z.array(z.any()) as unknown as SchemaType<DataType>
+    const value = z.array(z.any()) as unknown as SchemaType<ValueType>
+    const resolvedValue = z.any() as unknown as SchemaType<ResolvedValueType<S>>
+
+    const config = z.object({
+      label: z.string().optional(),
+      description: z.string().optional(),
+      // Spike: steps are factory functions, not statically schematizable.
+      steps: z.array(z.any()),
+    })
+
+    const definition = z.object({ type, config })
+
+    return { type, data, value, resolvedValue, definition, version }
+  }
+
+  safeParse(data: unknown | undefined): ParseResult<DataType | undefined> {
+    return safeParse(this.schema.data, data)
+  }
+
+  // Walk the reachable step chain: build each step's control from the previous
+  // step's ResolvedValue, run `visitStep` to collect an entry, and thread that
+  // step's ResolvedValue into the next factory. Stops before a step whose
+  // predecessor resolved to `undefined`.
+  private walkSteps<T>(
+    visitStep: (
+      control: StepControl,
+      index: number,
+    ) => { entry: T; resolvedValue: unknown },
+  ): T[] {
+    const entries: T[] = []
+    let prev: unknown = undefined
+    for (let i = 0; i < this.config.steps.length; i++) {
+      if (i > 0 && prev === undefined) break
+      const control = this.config.steps[i](prev)
+      const { entry, resolvedValue } = visitStep(control, i)
+      entries.push(entry)
+      prev = resolvedValue
+    }
+    return entries
+  }
+
+  // Walk the reachable chain from Data: for each step, build its control from
+  // the previous step's ResolvedValue, then compute this step's Resolvable.
+  // Stops before a step whose predecessor resolved to `undefined`.
+  private materialize(
+    data: DataType | undefined,
+    resolver: ResourceResolver,
+    stylesheet: Stylesheet,
+  ): Array<{ control: StepControl; resolvable: Resolvable<unknown> }> {
+    return this.walkSteps((control, i) => {
+      const resolvable = control.resolveValue(
+        data?.[i],
+        resolver,
+        stylesheet.child(String(i)),
+      )
+      return {
+        entry: { control, resolvable },
+        resolvedValue: resolvable.readStable(),
+      }
+      // why do we need to accumulate all the entries, why can't we just read the last value?
+    })
+  }
+
+  materializeForSerialization(data: DataType | undefined): ControlDefinition[] {
+    return this.materialize(data, NOOP_RESOLVER, NOOP_STYLESHEET).map(
+      ({ control }) => control as unknown as ControlDefinition,
+    )
+  }
+
+  fromData(data: DataType | undefined): ValueType | undefined {
+    if (data == null) return undefined
+    return this.materialize(data, NOOP_RESOLVER, NOOP_STYLESHEET).map(
+      ({ control }, i) => control.fromData(data[i]),
+    )
+  }
+
+  toData(value: ValueType): DataType {
+    return this.walkSteps((control, i) => {
+      const data = control.toData(value[i])
+      const resolvable = control.resolveValue(
+        data,
+        NOOP_RESOLVER,
+        NOOP_STYLESHEET,
+      )
+      return { entry: data, resolvedValue: resolvable.readStable() }
+    })
+  }
+
+  copyData(
+    data: DataType | undefined,
+    context: CopyContext,
+  ): DataType | undefined {
+    if (data == null) return undefined
+    return this.materialize(data, NOOP_RESOLVER, NOOP_STYLESHEET).map(
+      ({ control }, i) => control.copyData(data[i], context),
+    )
+  }
+
+  resolveValue(
+    data: DataType | undefined,
+    resolver: ResourceResolver,
+    stylesheet: Stylesheet,
+    _control?: InstanceType<S>,
+  ): Resolvable<ResolvedValueType<S> | undefined> {
+    const chain = this.materialize(data, resolver, stylesheet)
+    const resolvables = chain.map((c) => c.resolvable)
+
+    const stableValue = StableValue({
+      name: Definition.type,
+      read: () => {
+        // Deepest step with a defined resolved value = the "last selected"
+        // step. Terminated/unselected downstream steps read `undefined`.
+        for (let i = chain.length - 1; i >= 0; i--) {
+          const rv = chain[i].resolvable.readStable()
+          if (rv !== undefined) return rv as ResolvedValueType<S>
+        }
+        return undefined
+      },
+      deps: resolvables,
+    })
+
+    return {
+      ...stableValue,
+      triggerResolve: async (_currentValue?: ResolvedValueType<S>) => {
+        await Promise.all(resolvables.map((r) => r.triggerResolve()))
+      },
+    }
+  }
+
+  createInstance(sendMessage: SendMessage): InstanceType<S> {
+    return new CascadeControl(this, sendMessage)
+  }
+
+  accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {
+    return visitor.visitCascade(this, ...args)
+  }
+
+  introspect<R>(data: DataType | undefined, target: IntrospectionTarget<R>) {
+    if (data == null) return []
+    return this.materialize(data, NOOP_RESOLVER, NOOP_STYLESHEET).flatMap(
+      ({ control }, i) => control.introspect(data[i], target) ?? [],
+    )
+  }
+}
+
+export class CascadeDefinition<S extends Steps = Steps> extends Definition<S> {}
+
+export function unstable_Cascade<const S extends Steps>(
+  config: Config<S>,
+): CascadeDefinition<S> {
+  return new CascadeDefinition<S>(config)
+}

--- a/packages/controls/src/controls/cascade/cascade.ts
+++ b/packages/controls/src/controls/cascade/cascade.ts
@@ -1,8 +1,10 @@
+import { match } from 'ts-pattern'
 import { z } from 'zod'
 
 import { StableValue } from '../../lib/stable-value'
 import { safeParse, type ParseResult } from '../../lib/zod'
 
+import { ControlDataTypeKey } from '../../common'
 import { type CopyContext } from '../../context'
 import { type IntrospectionTarget } from '../../introspection'
 import { type ResourceResolver } from '../../resources/resolver'
@@ -23,8 +25,9 @@ import {
   type Resolvable,
   type SchemaType,
 } from '../definition'
+import { unstable_GalleryDefinition } from '../gallery'
 import { IconRadioGroupDefinition } from '../icon-radio-group'
-import { type SendMessage } from '../instance'
+import { type ControlInstanceArgs } from '../instance'
 import { NumberDefinition } from '../number'
 import { SelectDefinition } from '../select'
 import { SliderDefinition } from '../slider'
@@ -38,6 +41,7 @@ type StepControl =
   | CheckboxDefinition<any>
   | CodeDefinition<any>
   | ComboboxDefinition<any>
+  | unstable_GalleryDefinition<any>
   | IconRadioGroupDefinition<any>
   | NumberDefinition<any>
   | SelectDefinition<any>
@@ -47,17 +51,34 @@ type StepControl =
 
 type MaterializedStepControl = ControlDefinition<string, unknown, any, any, any>
 
-const COMPATIBLE_STEP_TYPES: ReadonlySet<string> = new Set([
+const STEP_TYPES = [
   CheckboxDefinition.type,
   CodeDefinition.type,
   ComboboxDefinition.type,
+  unstable_GalleryDefinition.type,
   IconRadioGroupDefinition.type,
   NumberDefinition.type,
   SelectDefinition.type,
   SliderDefinition.type,
   TextAreaDefinition.type,
   TextInputDefinition.type,
-])
+] as const
+
+const COMPATIBLE_STEP_TYPES: ReadonlySet<string> = new Set(STEP_TYPES)
+
+type MutuallyAssignable<A, B> = [A] extends [B]
+  ? [B] extends [A]
+    ? true
+    : false
+  : false
+
+type Assert<T extends true> = T
+
+type _StepTypesMatchUnion = Assert<
+  MutuallyAssignable<(typeof STEP_TYPES)[number], StepControl['controlType']>
+>
+
+export type { _StepTypesMatchUnion as __assertStepTypes }
 
 export type Step<D extends StepControl = StepControl> = (prev?: any) => D
 
@@ -72,7 +93,11 @@ type Config<S extends Steps = Steps> = {
 type StepData = DataType_<StepControl> | undefined
 type StepValue = ValueType_<StepControl> | undefined
 
-type DataType = StepData[]
+type VersionedData = {
+  [ControlDataTypeKey]: typeof Definition.v1DataType
+  value: StepData[]
+}
+type DataType = StepData[] | VersionedData
 type ValueType = StepValue[]
 
 type LastStep<S extends Steps> = S extends readonly [...any[], infer L]
@@ -102,6 +127,11 @@ class Definition<S extends Steps> extends ControlDefinition<
 > {
   static readonly type = 'makeswift::controls::cascade' as const
 
+  static readonly v1DataType = 'cascade::v1' as const
+  static readonly dataSignature = {
+    v1: { [ControlDataTypeKey]: this.v1DataType },
+  } as const
+
   static deserialize(data: DeserializedRecord): CascadeDefinition {
     const steps = (data.config as { steps?: unknown } | undefined)?.steps
 
@@ -111,11 +141,27 @@ class Definition<S extends Steps> extends ControlDefinition<
       )
     }
 
-    return new CascadeDefinition({
-      label: (data.config as { label?: string }).label,
-      description: (data.config as { description?: string }).description,
-      steps: steps as unknown as Steps,
-    })
+    return new CascadeDefinition(
+      {
+        label: (data.config as { label?: string }).label,
+        description: (data.config as { description?: string }).description,
+        steps: steps as unknown as Steps,
+      },
+      (data as { version?: 1 }).version,
+    )
+  }
+
+  static slots(data: DataType | undefined): StepData[] | undefined {
+    return match(data)
+      .with(Definition.dataSignature.v1, ({ value }) => value)
+      .otherwise((value) => value)
+  }
+
+  constructor(
+    config: Config<S>,
+    readonly version?: 1,
+  ) {
+    super(config)
   }
 
   get steps(): S {
@@ -130,7 +176,15 @@ class Definition<S extends Steps> extends ControlDefinition<
     const version = z.literal(1)
     const type = z.literal(Definition.type)
 
-    const data = z.array(z.any()) as unknown as SchemaType<DataType>
+    const versionedData = z.object({
+      [ControlDataTypeKey]: z.literal(Definition.v1DataType),
+      value: z.array(z.any()),
+    })
+
+    const data = z.union([
+      z.array(z.any()),
+      versionedData,
+    ]) as unknown as SchemaType<DataType>
     const value = z.array(z.any()) as unknown as SchemaType<ValueType>
     const resolvedValue = z.any() as unknown as SchemaType<ResolvedValueType<S>>
 
@@ -163,7 +217,7 @@ class Definition<S extends Steps> extends ControlDefinition<
       if (!COMPATIBLE_STEP_TYPES.has(control.controlType)) {
         throw new Error(
           `unstable_Cascade: step ${i} returned unsupported control ` +
-            `'${control.controlType}' — Supported controls: ${[...COMPATIBLE_STEP_TYPES].join(', ')}`,
+            `'${control.controlType}' — Supported controls: ${STEP_TYPES.join(', ')}`,
         )
       }
       const { entry, resolvedValue } = visitStep(control, i)
@@ -174,26 +228,29 @@ class Definition<S extends Steps> extends ControlDefinition<
   }
 
   private materialize(
-    data: DataType | undefined,
+    slots: StepData[] | undefined,
     resolver: ResourceResolver,
     stylesheet: Stylesheet,
+    mode: 'strict' | 'lenient',
   ): Array<{
     control: MaterializedStepControl
     resolvable: Resolvable<unknown>
   }> {
     return this.walkSteps((control, i) => {
-      const stepData = data?.[i]
+      let stepData = slots?.[i]
       if (stepData !== undefined) {
         const parsed = control.safeParse(stepData)
         if (!parsed.success) {
-          throw new Error(
+          const message =
             `unstable_Cascade: step ${i} data does not match control ` +
-              `'${control.controlType}': ${parsed.error}`,
-          )
+            `'${control.controlType}': ${parsed.error}`
+          if (mode === 'strict') throw new Error(message)
+          console.warn(message)
+          stepData = undefined
         }
       }
       const resolvable = control.resolveValue(
-        data?.[i],
+        stepData,
         resolver,
         stylesheet.child(String(i)),
       )
@@ -205,20 +262,28 @@ class Definition<S extends Steps> extends ControlDefinition<
   }
 
   materializeForSerialization(data: DataType | undefined): ControlDefinition[] {
-    return this.materialize(data, NOOP_RESOLVER, NOOP_STYLESHEET).map(
-      ({ control }) => control as unknown as ControlDefinition,
-    )
+    const slots = Definition.slots(data)
+    return this.materialize(
+      slots,
+      NOOP_RESOLVER,
+      NOOP_STYLESHEET,
+      'lenient',
+    ).map(({ control }) => control as unknown as ControlDefinition)
   }
 
   fromData(data: DataType | undefined): ValueType | undefined {
-    if (data == null) return undefined
-    return this.materialize(data, NOOP_RESOLVER, NOOP_STYLESHEET).map(
-      ({ control }, i) => control.fromData(data[i]),
-    )
+    const slots = Definition.slots(data)
+    if (slots == null) return undefined
+    return this.materialize(
+      slots,
+      NOOP_RESOLVER,
+      NOOP_STYLESHEET,
+      'strict',
+    ).map(({ control }, i) => control.fromData(slots[i]))
   }
 
   toData(value: ValueType): DataType {
-    return this.walkSteps((control, i) => {
+    const slots = this.walkSteps((control, i) => {
       const data = control.toData(value[i])
       const resolvable = control.resolveValue(
         data,
@@ -227,16 +292,23 @@ class Definition<S extends Steps> extends ControlDefinition<
       )
       return { entry: data, resolvedValue: resolvable.readStable() }
     })
+    return match(this.version)
+      .with(1, () => ({ ...Definition.dataSignature.v1, value: slots }))
+      .otherwise(() => slots)
   }
 
   copyData(
     data: DataType | undefined,
     context: CopyContext,
   ): DataType | undefined {
-    if (data == null) return undefined
-    return this.materialize(data, NOOP_RESOLVER, NOOP_STYLESHEET).map(
-      ({ control }, i) => control.copyData(data[i], context),
-    )
+    const slots = Definition.slots(data)
+    if (slots == null) return undefined
+    return this.materialize(
+      slots,
+      NOOP_RESOLVER,
+      NOOP_STYLESHEET,
+      'strict',
+    ).map(({ control }, i) => control.copyData(slots[i], context))
   }
 
   resolveValue(
@@ -245,7 +317,8 @@ class Definition<S extends Steps> extends ControlDefinition<
     stylesheet: Stylesheet,
     _control?: InstanceType<S>,
   ): Resolvable<ResolvedValueType<S> | undefined> {
-    const chain = this.materialize(data, resolver, stylesheet)
+    const slots = Definition.slots(data)
+    const chain = this.materialize(slots, resolver, stylesheet, 'lenient')
     const resolvables = chain.map((c) => c.resolvable)
 
     const stableValue = StableValue({
@@ -268,8 +341,8 @@ class Definition<S extends Steps> extends ControlDefinition<
     }
   }
 
-  createInstance(sendMessage: SendMessage): InstanceType<S> {
-    return new CascadeControl(this, sendMessage)
+  createInstance(args: ControlInstanceArgs): InstanceType<S> {
+    return new CascadeControl(this, args)
   }
 
   accept<R>(visitor: ControlDefinitionVisitor<R>, ...args: unknown[]): R {
@@ -277,10 +350,14 @@ class Definition<S extends Steps> extends ControlDefinition<
   }
 
   introspect<R>(data: DataType | undefined, target: IntrospectionTarget<R>) {
-    if (data == null) return []
-    return this.materialize(data, NOOP_RESOLVER, NOOP_STYLESHEET).flatMap(
-      ({ control }, i) => control.introspect(data[i], target) ?? [],
-    )
+    const slots = Definition.slots(data)
+    if (slots == null) return []
+    return this.materialize(
+      slots,
+      NOOP_RESOLVER,
+      NOOP_STYLESHEET,
+      'strict',
+    ).flatMap(({ control }, i) => control.introspect(slots[i], target) ?? [])
   }
 }
 
@@ -289,5 +366,5 @@ export class CascadeDefinition<S extends Steps = Steps> extends Definition<S> {}
 export function unstable_Cascade<const S extends Steps>(
   config: Config<S>,
 ): CascadeDefinition<S> {
-  return new CascadeDefinition<S>(config)
+  return new CascadeDefinition<S>(config, 1)
 }

--- a/packages/controls/src/controls/cascade/cascade.ts
+++ b/packages/controls/src/controls/cascade/cascade.ts
@@ -324,11 +324,8 @@ class Definition<S extends Steps> extends ControlDefinition<
     const stableValue = StableValue({
       name: Definition.type,
       read: () => {
-        for (let i = chain.length - 1; i >= 0; i--) {
-          const rv = chain[i].resolvable.readStable()
-          if (rv !== undefined) return rv as ResolvedValueType<S>
-        }
-        return undefined
+        const lastStep = chain[this.config.steps.length - 1]
+        return lastStep?.resolvable.readStable() as ResolvedValueType<S> | undefined
       },
       deps: resolvables,
     })

--- a/packages/controls/src/controls/cascade/index.ts
+++ b/packages/controls/src/controls/cascade/index.ts
@@ -1,0 +1,2 @@
+export * from './cascade'
+export * from './cascade-control'

--- a/packages/controls/src/controls/index.ts
+++ b/packages/controls/src/controls/index.ts
@@ -1,3 +1,4 @@
+export * from './cascade'
 export * from './checkbox'
 export * from './code'
 export * from './color'

--- a/packages/controls/src/controls/visitor/control-serialization-visitor.ts
+++ b/packages/controls/src/controls/visitor/control-serialization-visitor.ts
@@ -4,6 +4,7 @@ import {
   serializeObject,
 } from '../../serialization'
 
+import { type CascadeDefinition } from '../cascade'
 import { CheckboxDefinition } from '../checkbox'
 import { CodeDefinition } from '../code'
 import { ColorDefinition } from '../color'
@@ -51,6 +52,11 @@ export abstract class ControlSerializationVisitor extends ControlDefinitionVisit
     } as unknown as SerializedRecord
   }
 
+  visitCascade(_def: CascadeDefinition): SerializedRecord {
+    throw new Error(
+      'unstable_Cascade: serialization is not yet supported outside a live builder connection',
+    )
+  }
   visitCode(def: CodeDefinition): SerializedRecord {
     return this.serializeConfig(def, { version: def.version })
   }

--- a/packages/controls/src/controls/visitor/definition-visitor.ts
+++ b/packages/controls/src/controls/visitor/definition-visitor.ts
@@ -1,3 +1,4 @@
+import { type CascadeDefinition } from '../cascade'
 import { CheckboxDefinition } from '../checkbox'
 import { CodeDefinition } from '../code'
 import { ColorDefinition } from '../color'
@@ -25,6 +26,7 @@ import { TextInputDefinition } from '../text-input'
 import { unstable_TypographyDefinition } from '../typography'
 
 abstract class ControlDefinitionVisitor<R> {
+  abstract visitCascade(def: CascadeDefinition, ...args: unknown[]): R
   abstract visitCode(def: CodeDefinition, ...args: unknown[]): R
   abstract visitCheckbox(def: CheckboxDefinition, ...args: unknown[]): R
   abstract visitColor(def: ColorDefinition, ...args: unknown[]): R

--- a/packages/controls/src/controls/visitor/merge-translations-visitor.ts
+++ b/packages/controls/src/controls/visitor/merge-translations-visitor.ts
@@ -4,6 +4,7 @@ import { Data } from '../../common'
 import { MergeTranslatableDataContext } from '../../context'
 
 import { DataType } from '../associated-types'
+import { type CascadeDefinition } from '../cascade'
 import { CheckboxDefinition } from '../checkbox'
 import { CodeDefinition } from '../code'
 import { ColorDefinition } from '../color'
@@ -47,6 +48,16 @@ abstract class MergeTranslationsVisitor extends ControlDefinitionVisitor<Data> {
   private defaultMerge(data: Data, translatedData: Data): Data {
     if (data == null || translatedData == null) return data
     return translatedData
+  }
+
+  visitCascade(
+    _def: CascadeDefinition,
+    data: unknown,
+    _translatedData: unknown,
+  ): Data {
+    // Translation merge for the dynamic (factory-based) cascade is out of scope
+    // for this spike; pass the existing data through unchanged.
+    return (data ?? null) as Data
   }
 
   visitCode(

--- a/packages/runtime/src/controls/index.ts
+++ b/packages/runtime/src/controls/index.ts
@@ -2,6 +2,9 @@ export * from './control'
 
 export {
   ControlDefinition,
+  unstable_Cascade,
+  CascadeDefinition,
+  CascadeControl,
   Checkbox,
   CheckboxDefinition,
   Code,

--- a/packages/runtime/src/controls/serialization/base/index.ts
+++ b/packages/runtime/src/controls/serialization/base/index.ts
@@ -8,6 +8,7 @@ import {
 } from '@makeswift/controls'
 
 import {
+  CascadeDefinition,
   CheckboxDefinition,
   CodeDefinition,
   ColorDefinition,
@@ -65,6 +66,7 @@ export function deserializeControl(
 export function deserializeUnifiedControlDef(record: DeserializedRecord): ControlDefinition {
   type DeserializeMethod = (data: DeserializedRecord) => ControlDefinition
   const deserializeMethod: Record<string, DeserializeMethod> = {
+    [CascadeDefinition.type]: CascadeDefinition.deserialize,
     [CheckboxDefinition.type]: CheckboxDefinition.deserialize,
     [CodeDefinition.type]: CodeDefinition.deserialize,
     [ColorDefinition.type]: ColorDefinition.deserialize,

--- a/packages/runtime/src/controls/serialization/message-port/cascade-chain-serialization.test.ts
+++ b/packages/runtime/src/controls/serialization/message-port/cascade-chain-serialization.test.ts
@@ -51,4 +51,51 @@ describe('serializeCascadeChain', () => {
     expect(records[0].config.getOptions).toBeInstanceOf(MessagePort)
     port.close()
   })
+
+  test('a newer materialization closes the previous call’s host-side ports', async () => {
+    const cascade = unstable_Cascade({
+      steps: [
+        () =>
+          Combobox({
+            getOptions: async (query: string) => [{ id: query, label: query, value: query }],
+          }),
+      ],
+    })
+
+    const port = serializeCascadeChain(cascade)
+    const materializeChain = deserializeFunction(port)
+    const allPorts: MessagePort[] = []
+
+    try {
+      const [first] = (await materializeChain([])) as unknown as [{ config: { getOptions: unknown } }]
+      const firstGetOptionsPort = first.config.getOptions as MessagePort
+      allPorts.push(firstGetOptionsPort)
+      const firstGetOptions = deserializeFunction(
+        firstGetOptionsPort as Parameters<typeof deserializeFunction>[0],
+      )
+
+      // the first reply's channel is alive before supersession
+      await expect(firstGetOptions('a')).resolves.toEqual([{ id: 'a', label: 'a', value: 'a' }])
+
+      const [second] = (await materializeChain([])) as unknown as [{ config: { getOptions: unknown } }] // supersede: a newer call arrives
+      const secondGetOptionsPort = second.config.getOptions as MessagePort
+      allPorts.push(secondGetOptionsPort)
+      const secondGetOptions = deserializeFunction(
+        secondGetOptionsPort as Parameters<typeof deserializeFunction>[0],
+      )
+
+      // the current call's channel still works after supersession
+      await expect(secondGetOptions('b')).resolves.toEqual([{ id: 'b', label: 'b', value: 'b' }])
+
+      const closed = new Promise(resolve => {
+        firstGetOptionsPort.addEventListener('close', () => resolve('closed'))
+      })
+      const timeout = new Promise(resolve => setTimeout(() => resolve('timeout'), 500))
+
+      await expect(Promise.race([closed, timeout])).resolves.toBe('closed')
+    } finally {
+      allPorts.forEach(p => p.close())
+      port.close()
+    }
+  })
 })

--- a/packages/runtime/src/controls/serialization/message-port/cascade-chain-serialization.test.ts
+++ b/packages/runtime/src/controls/serialization/message-port/cascade-chain-serialization.test.ts
@@ -1,0 +1,54 @@
+import { unstable_Cascade, Checkbox, Combobox } from '@makeswift/controls'
+
+import { deserializeFunction } from './function-serialization'
+import { serializeCascadeChain } from './cascade-chain-serialization'
+
+describe('serializeCascadeChain', () => {
+  test('returns serialized records for the reachable chain', async () => {
+    const cascade = unstable_Cascade({
+      steps: [
+        () => Checkbox({ defaultValue: true }),
+        (_showDiscounts: boolean) => Combobox({ getOptions: async () => [] }),
+      ],
+    })
+
+    const port = serializeCascadeChain(cascade)
+    const materialize = deserializeFunction(port)
+    const records = await materialize([])
+
+    expect(records).toEqual([
+      expect.objectContaining({ type: 'makeswift::controls::checkbox' }),
+      expect.objectContaining({ type: 'makeswift::controls::combobox' }),
+    ])
+    port.close()
+  })
+
+  test('an unselected step yields only the reachable prefix', async () => {
+    const cascade = unstable_Cascade({
+      steps: [
+        () => Combobox({ getOptions: async () => [] }),
+        (_p: { id: string }) => Combobox({ getOptions: async () => [] }),
+      ],
+    })
+
+    const port = serializeCascadeChain(cascade)
+    const materialize = deserializeFunction(port)
+    const records = await materialize([])
+
+    expect(records).toHaveLength(1)
+    port.close()
+  })
+
+  test('a step control with a nested function config (getOptions) round-trips without a DataCloneError', async () => {
+    const cascade = unstable_Cascade({
+      steps: [() => Combobox({ getOptions: async (query: string) => [{ id: query, label: query, value: query }] })],
+    })
+
+    const port = serializeCascadeChain(cascade)
+    const materialize = deserializeFunction(port)
+    const records = (await materialize([])) as unknown as [{ config: { getOptions: unknown } }]
+
+    expect(records[0].config.getOptions).toBeInstanceOf(MessagePort)
+    port.close()
+  })
+})

--- a/packages/runtime/src/controls/serialization/message-port/cascade-chain-serialization.ts
+++ b/packages/runtime/src/controls/serialization/message-port/cascade-chain-serialization.ts
@@ -8,9 +8,20 @@ type CascadeData = DataType<CascadeDefinition>
 export function serializeCascadeChain(
   definition: CascadeDefinition,
 ): SerializedFunction<(data: CascadeData) => Promise<SerializedRecord[]>> {
+  let previousCallPorts: MessagePort[] = []
+
   return serializeFunction(async (data: CascadeData) => {
-    const controls = definition.materializeForSerialization(data)
-    const visitor = new ClientMessagePortSerializationVisitor()
-    return controls.map(control => control.accept(visitor))
+    const currentCallPorts: MessagePort[] = []
+    try {
+      const controls = definition.materializeForSerialization(data)
+      const visitor = new ClientMessagePortSerializationVisitor(currentCallPorts)
+      const records = controls.map(control => control.accept(visitor))
+      previousCallPorts.forEach(port => port.close())
+      previousCallPorts = currentCallPorts
+      return records
+    } catch (error) {
+      currentCallPorts.forEach(port => port.close())
+      throw error
+    }
   })
 }

--- a/packages/runtime/src/controls/serialization/message-port/cascade-chain-serialization.ts
+++ b/packages/runtime/src/controls/serialization/message-port/cascade-chain-serialization.ts
@@ -1,12 +1,14 @@
-import { type CascadeDefinition, type Data, type SerializedRecord } from '@makeswift/controls'
+import { type CascadeDefinition, type DataType, type SerializedRecord } from '@makeswift/controls'
 
 import { ClientMessagePortSerializationVisitor } from './visitor'
 import { serializeFunction, type SerializedFunction } from './function-serialization'
 
+type CascadeData = DataType<CascadeDefinition>
+
 export function serializeCascadeChain(
   definition: CascadeDefinition,
-): SerializedFunction<(data: Data[]) => Promise<SerializedRecord[]>> {
-  return serializeFunction(async (data: Data[]) => {
+): SerializedFunction<(data: CascadeData) => Promise<SerializedRecord[]>> {
+  return serializeFunction(async (data: CascadeData) => {
     const controls = definition.materializeForSerialization(data)
     const visitor = new ClientMessagePortSerializationVisitor()
     return controls.map(control => control.accept(visitor))

--- a/packages/runtime/src/controls/serialization/message-port/cascade-chain-serialization.ts
+++ b/packages/runtime/src/controls/serialization/message-port/cascade-chain-serialization.ts
@@ -1,0 +1,14 @@
+import { type CascadeDefinition, type Data, type SerializedRecord } from '@makeswift/controls'
+
+import { ClientMessagePortSerializationVisitor } from './visitor'
+import { serializeFunction, type SerializedFunction } from './function-serialization'
+
+export function serializeCascadeChain(
+  definition: CascadeDefinition,
+): SerializedFunction<(data: Data[]) => Promise<SerializedRecord[]>> {
+  return serializeFunction(async (data: Data[]) => {
+    const controls = definition.materializeForSerialization(data)
+    const visitor = new ClientMessagePortSerializationVisitor()
+    return controls.map(control => control.accept(visitor))
+  })
+}

--- a/packages/runtime/src/controls/serialization/message-port/function-serialization.test.ts
+++ b/packages/runtime/src/controls/serialization/message-port/function-serialization.test.ts
@@ -71,4 +71,52 @@ describe('function serialization', () => {
 
     serialized.close()
   })
+
+  test(
+    'a thrown error rejects the caller instead of hanging',
+    async () => {
+      const serialized = serializeFunction(() => {
+        throw new Error('boom')
+      })
+      const deserialized = deserializeFunction(serialized)
+
+      await expect(deserialized()).rejects.toThrow('boom')
+      serialized.close()
+    },
+    1000,
+  )
+
+  test(
+    'a rejected async result rejects the caller instead of hanging',
+    async () => {
+      const serialized = serializeFunction(async () => {
+        throw new Error('async boom')
+      })
+      const deserialized = deserializeFunction(serialized)
+
+      await expect(deserialized()).rejects.toThrow('async boom')
+      serialized.close()
+    },
+    1000,
+  )
+
+  test(
+    'forwards a MessagePort nested in the result as a transferable',
+    async () => {
+      const inner = serializeFunction((a: number) => a + 1)
+      const outer = serializeFunction(() => ({ port: inner }))
+      const deserializedOuter = deserializeFunction(outer)
+
+      const result = (await deserializedOuter()) as { port: MessagePort }
+      expect(result.port).toBeInstanceOf(MessagePort)
+
+      const deserializedInner = deserializeFunction(result.port as any)
+      expect(await deserializedInner(41)).toBe(42)
+
+      outer.close()
+      inner.close()
+      result.port.close()
+    },
+    1000,
+  )
 })

--- a/packages/runtime/src/controls/serialization/message-port/function-serialization.ts
+++ b/packages/runtime/src/controls/serialization/message-port/function-serialization.ts
@@ -52,7 +52,10 @@ function collectTransferables(value: unknown, seen: Set<unknown> = new Set()): T
   return []
 }
 
-export function serializeFunction<T extends AnyFunction>(func: T): SerializedFunction<T> {
+export function serializeFunction<T extends AnyFunction>(
+  func: T,
+  hostPortRegistry?: MessagePort[],
+): SerializedFunction<T> {
   type CallMessageEvent = MessageEvent<[CallID, Parameters<T>]>
 
   const messageChannel = new MessageChannel()
@@ -71,6 +74,8 @@ export function serializeFunction<T extends AnyFunction>(func: T): SerializedFun
         },
       )
   }
+
+  hostPortRegistry?.push(messageChannel.port1)
 
   return messageChannel.port2 as SerializedFunction<T>
 }

--- a/packages/runtime/src/controls/serialization/message-port/function-serialization.ts
+++ b/packages/runtime/src/controls/serialization/message-port/function-serialization.ts
@@ -10,9 +10,10 @@ export { type DeserializedFunction } from '@makeswift/controls'
 declare const SerializedFunctionTag: unique symbol
 
 type ResolveCallPromise<T extends AnyFunction> = (value: SerializedFunctionReturnType<T>) => void
+type RejectCallPromise = (error: unknown) => void
 
 type OnMessageHandler<T extends AnyFunction> = MessagePort['onmessage'] & {
-  newCall?(resolve: ResolveCallPromise<T>): number
+  newCall?(resolve: ResolveCallPromise<T>, reject: RejectCallPromise): number
 }
 
 export type SerializedFunction<T extends AnyFunction> = MessagePort & {
@@ -25,6 +26,31 @@ export function isSerializedFunction(value: any): value is SerializedFunction<An
 }
 
 type CallID = number
+type ErrorDescriptor = { message: string; name?: string }
+type ReplyMessage<T extends AnyFunction> =
+  | [CallID, 'resolve', SerializedFunctionReturnType<T>]
+  | [CallID, 'reject', ErrorDescriptor]
+
+function toErrorDescriptor(error: unknown): ErrorDescriptor {
+  if (error instanceof Error) return { message: error.message, name: error.name }
+  return { message: String(error) }
+}
+
+// Walks a plain object/array tree collecting any MessagePort found within it,
+// since a reply carrying one (e.g. a nested serialized function/control) must
+// list it as a transferable or postMessage throws DataCloneError.
+function collectTransferables(value: unknown, seen: Set<unknown> = new Set()): Transferable[] {
+  if (value == null || typeof value !== 'object') return []
+  if (value instanceof MessagePort) return [value]
+  if (seen.has(value)) return []
+  seen.add(value)
+
+  if (Array.isArray(value)) return value.flatMap(item => collectTransferables(item, seen))
+  if (value.constructor === Object) {
+    return Object.values(value).flatMap(item => collectTransferables(item, seen))
+  }
+  return []
+}
 
 export function serializeFunction<T extends AnyFunction>(func: T): SerializedFunction<T> {
   type CallMessageEvent = MessageEvent<[CallID, Parameters<T>]>
@@ -34,25 +60,44 @@ export function serializeFunction<T extends AnyFunction>(func: T): SerializedFun
   messageChannel.port1.onmessage = ({ data: [callId, args] }: CallMessageEvent) => {
     Promise.resolve()
       .then(() => func.apply(null, args))
-      .then(result => messageChannel.port1.postMessage([callId, result]))
+      .then(
+        result => {
+          const reply: ReplyMessage<T> = [callId, 'resolve', result]
+          messageChannel.port1.postMessage(reply, collectTransferables(result))
+        },
+        (error: unknown) => {
+          const reply: ReplyMessage<T> = [callId, 'reject', toErrorDescriptor(error)]
+          messageChannel.port1.postMessage(reply)
+        },
+      )
   }
 
   return messageChannel.port2 as SerializedFunction<T>
 }
 
 function onmessageHandler<T extends AnyFunction>(): OnMessageHandler<T> {
-  type ResultMessageEvent = MessageEvent<[CallID, SerializedFunctionReturnType<T>]>
+  type ResultMessageEvent = MessageEvent<ReplyMessage<T>>
   let nextCallId = 0
-  const calls = new Map<CallID, ResolveCallPromise<T>>()
+  const calls = new Map<CallID, { resolve: ResolveCallPromise<T>; reject: RejectCallPromise }>()
 
-  const result: OnMessageHandler<T> = ({ data: [callId, result] }: ResultMessageEvent) => {
-    calls.get(callId)?.(result)
+  const result: OnMessageHandler<T> = ({ data }: ResultMessageEvent) => {
+    const [callId, status, payload] = data
+    const call = calls.get(callId)
     calls.delete(callId)
+    if (call == null) return
+
+    if (status === 'reject') {
+      const error = new Error(payload.message)
+      if (payload.name != null) error.name = payload.name
+      call.reject(error)
+    } else {
+      call.resolve(payload)
+    }
   }
 
-  result.newCall = (resolve: ResolveCallPromise<T>) => {
+  result.newCall = (resolve: ResolveCallPromise<T>, reject: RejectCallPromise) => {
     const callId = nextCallId++
-    calls.set(callId, resolve)
+    calls.set(callId, { resolve, reject })
     return callId
   }
 
@@ -67,7 +112,7 @@ export function deserializeFunction<T extends AnyFunction>(
   }
 
   return function deserializedFunction(...args) {
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       const { newCall } = serializedFunction.onmessage
       if (newCall == null) {
         throw new Error(
@@ -75,7 +120,7 @@ export function deserializeFunction<T extends AnyFunction>(
         )
       }
 
-      const callId = newCall(resolve)
+      const callId = newCall(resolve, reject)
       serializedFunction.postMessage([callId, args])
     })
   }

--- a/packages/runtime/src/controls/serialization/message-port/function-serialization.ts
+++ b/packages/runtime/src/controls/serialization/message-port/function-serialization.ts
@@ -41,7 +41,7 @@ function toErrorDescriptor(error: unknown): ErrorDescriptor {
 // list it as a transferable or postMessage throws DataCloneError.
 function collectTransferables(value: unknown, seen: Set<unknown> = new Set()): Transferable[] {
   if (value == null || typeof value !== 'object') return []
-  if (value instanceof MessagePort) return [value]
+  if (isSerializedFunction(value)) return [value]
   if (seen.has(value)) return []
   seen.add(value)
 

--- a/packages/runtime/src/controls/serialization/message-port/visitor.test.ts
+++ b/packages/runtime/src/controls/serialization/message-port/visitor.test.ts
@@ -1,0 +1,17 @@
+import { unstable_Cascade, Checkbox } from '@makeswift/controls'
+
+import { ClientMessagePortSerializationVisitor } from './visitor'
+
+describe('ClientMessagePortSerializationVisitor.visitCascade', () => {
+  test('no longer throws, and returns a transferable port for steps', () => {
+    const cascade = unstable_Cascade({ steps: [() => Checkbox()] })
+    const visitor = new ClientMessagePortSerializationVisitor()
+
+    const record = cascade.accept(visitor)
+    const config = record.config as { steps: unknown }
+
+    expect(record.type).toBe('makeswift::controls::cascade')
+    expect(config.steps).toBeInstanceOf(MessagePort)
+    expect(visitor.getTransferables()).toContain(config.steps)
+  })
+})

--- a/packages/runtime/src/controls/serialization/message-port/visitor.ts
+++ b/packages/runtime/src/controls/serialization/message-port/visitor.ts
@@ -7,11 +7,11 @@ import { serializeCascadeChain } from './cascade-chain-serialization'
 export class ClientMessagePortSerializationVisitor extends BaseControlSerializationVisitor {
   private transferables: Transferable[] = []
 
-  constructor() {
+  constructor(hostPortRegistry?: MessagePort[]) {
     const serializeFunctionPlugin: SerializationPlugin<AnyFunction> = {
       match: isFunction,
       serialize: (val: AnyFunction) => {
-        const r = serializeFunction(val)
+        const r = serializeFunction(val, hostPortRegistry)
         this.transferables.push(r)
         return r
       },

--- a/packages/runtime/src/controls/serialization/message-port/visitor.ts
+++ b/packages/runtime/src/controls/serialization/message-port/visitor.ts
@@ -1,7 +1,8 @@
-import { AnyFunction, SerializationPlugin, isFunction } from '@makeswift/controls'
+import { AnyFunction, SerializationPlugin, isFunction, type CascadeDefinition, type SerializedRecord } from '@makeswift/controls'
 
 import { BaseControlSerializationVisitor } from '../base/visitor'
 import { serializeFunction } from './function-serialization'
+import { serializeCascadeChain } from './cascade-chain-serialization'
 
 export class ClientMessagePortSerializationVisitor extends BaseControlSerializationVisitor {
   private transferables: Transferable[] = []
@@ -17,6 +18,20 @@ export class ClientMessagePortSerializationVisitor extends BaseControlSerializat
     }
 
     super([serializeFunctionPlugin])
+  }
+
+  visitCascade(def: CascadeDefinition): SerializedRecord {
+    const stepsPort = serializeCascadeChain(def)
+    this.transferables.push(stepsPort)
+
+    return {
+      type: def.controlType,
+      config: {
+        label: def.config.label,
+        description: def.config.description,
+        steps: stepsPort,
+      },
+    } as unknown as SerializedRecord
   }
 
   getTransferables(): Transferable[] {


### PR DESCRIPTION
One of three parallel explorations of the same product goal (product → image picker) — siblings are #1351 (ARR-769) and #1357 (ARR-969). This one keeps the cascade as the container but makes `unstable_Cascade` **composable**: steps hold real controls (`Checkbox`, `Combobox`, ...) instead of fixed display types, piping each step's resolved value into the next step's factory.

Also cleaned up the message-port serialization it relies on: swapped a hand-rolled `MessageChannel` RPC for the shared `serializeFunction` helper, and made that helper propagate errors as rejections (previously a failure would just hang forever) and auto-forward nested `MessagePort`s instead of throwing `DataCloneError`.

**Known limitations — flagged for discussion, not fixed here:**
- Steps needing a real resolver (Image, Color) will throw; only a no-op stand-in resolver is available where the chain gets materialized.
- Only step 0's child control is wired up — step ≥1 interactions silently no-op until the builder-side panel exists.
- Translated content in a step control isn't merged yet.
- `deserialize` only accepts the live-connection shape, not persisted data (fine today — it's never called any other way in practice).

Draft, opened to align on direction before going further