### PR TITLE
refactor: make element prop controllers available on first render

### DIFF
--- a/.changeset/sweet-vans-invent.md
+++ b/.changeset/sweet-vans-invent.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+refactor: make element prop controllers available on first render

--- a/packages/runtime/src/controls/__tests__/slot.test.tsx
+++ b/packages/runtime/src/controls/__tests__/slot.test.tsx
@@ -1,0 +1,102 @@
+/** @jest-environment jsdom */
+
+import { type ReactNode, useRef, act } from 'react'
+
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import { ControlInstance } from '@makeswift/controls'
+
+import { Slot } from '../../controls'
+
+import { createReactRuntime, ReactProvider } from '../../runtimes/react/testing'
+import { Page } from '../../runtimes/react/components/page'
+
+import { createRootComponent, createMakeswiftPageSnapshot } from '../../testing/element-data'
+import { TestWorkingSiteVersion } from '../../testing/fixtures/site-version'
+
+const TEST_ID = 'slot-test-id'
+
+jest.mock('../../state/builder-api/proxy', () => ({
+  BuilderAPIProxy: jest.fn(() => ({
+    setup: () => () => {},
+    execute: () => {},
+  })),
+}))
+
+function SlotValue(props: { control: ControlInstance }) {
+  const renderCount = useRef(0)
+  ++renderCount.current
+
+  return (
+    <div
+      data-testid={TEST_ID}
+      data-render-count={renderCount.current}
+      data-instance-key={JSON.stringify(props.control?.instanceKey)}
+    >
+      Slot placeholder
+    </div>
+  )
+}
+
+jest.mock('../../runtimes/react/controls/slot', () => ({
+  renderSlot: (props: { control: ControlInstance }) => <SlotValue {...props} />,
+}))
+
+function SlotTest({ children }: { children: ReactNode }) {
+  return <div>{children}</div>
+}
+
+describe('Slot', () => {
+  const createFixtures = () => {
+    const componentType = 'slot-test'
+
+    const runtime = createReactRuntime()
+    runtime.registerComponent(SlotTest, {
+      type: componentType,
+      label: 'Slot Test',
+      props: {
+        children: Slot(),
+      },
+    })
+
+    const testElementTree = (component: ReactNode, { draft }: { draft: boolean }) => (
+      <ReactProvider runtime={runtime} siteVersion={draft ? TestWorkingSiteVersion : null}>
+        {component}
+      </ReactProvider>
+    )
+
+    const elementKey = '11111111-1111-1111-1111-111111111111'
+    const elementData = {
+      key: elementKey,
+      props: {},
+      type: componentType,
+    }
+
+    const snapshot = createMakeswiftPageSnapshot(createRootComponent([elementData]))
+    return { snapshot, elementKey, testElementTree }
+  }
+
+  test('renders with a null control instance on live pages', async () => {
+    const { snapshot, testElementTree } = createFixtures()
+    await act(async () => render(testElementTree(<Page snapshot={snapshot} />, { draft: false })))
+
+    const renderedInstanceKey = screen.getByTestId(TEST_ID).dataset['instanceKey']
+    expect(JSON.parse(renderedInstanceKey ?? 'null')).toBe(null)
+  })
+
+  test('renders with a corresponding control instance when editing', async () => {
+    const { snapshot, elementKey, testElementTree } = createFixtures()
+    await act(async () => render(testElementTree(<Page snapshot={snapshot} />, { draft: true })))
+
+    const element = screen.getByTestId(TEST_ID)
+    const renderedInstanceKey = element.dataset['instanceKey']
+    expect(JSON.parse(renderedInstanceKey ?? 'null')).toEqual({
+      elementKey,
+      propPath: 'children',
+    })
+
+    const renderCount = element.dataset['renderCount']
+    expect(renderCount).toBe('1')
+  })
+})

--- a/packages/runtime/src/runtimes/react/components/Element.tsx
+++ b/packages/runtime/src/runtimes/react/components/Element.tsx
@@ -21,6 +21,8 @@ import { FallbackComponent } from '../../../components/shared/FallbackComponent'
 import { ErrorBoundary } from '../../../components/shared/ErrorBoundary'
 
 import { useIsReadOnly } from '../hooks/use-is-read-only'
+import { useIsRegisterElementDisabled } from '../hooks/use-disable-register-element'
+
 import { ElementImperativeHandle } from '../element-imperative-handle'
 import { FindDomNode } from '../find-dom-node'
 
@@ -55,10 +57,16 @@ export const Element = memo(
 
     useImperativeHandle(ref, () => imperativeHandleRef.current, [])
 
-    const ElementRegistration = useIsReadOnly() ? NoOp : BuilderElementRegistration
+    const isRegisterElementDisabled = useIsRegisterElementDisabled()
+    const ElementRegistration =
+      useIsReadOnly() || isRegisterElementDisabled ? NoOp : BuilderElementRegistration
 
     return (
-      <ElementRegistration componentHandle={imperativeHandleRef.current} elementKey={element.key}>
+      <ElementRegistration
+        componentHandle={imperativeHandleRef.current}
+        elementKey={element.key}
+        componentType={element.type}
+      >
         <FindDomNode ref={findDomNodeCallbackRef}>
           <ErrorBoundary FallbackComponent={ErrorFallback}>
             {isElementReference(element) ? (

--- a/packages/runtime/src/runtimes/react/components/ElementRegistration.tsx
+++ b/packages/runtime/src/runtimes/react/components/ElementRegistration.tsx
@@ -1,42 +1,80 @@
 'use client'
 
-import { ReactNode, memo, useEffect } from 'react'
-import { ElementImperativeHandle } from '../element-imperative-handle'
+import { ReactNode, memo, useMemo, useEffect } from 'react'
+
+import {
+  createPropControllers,
+  registerComponentHandleEffect,
+  registerPropControllersEffect,
+} from '../../../state/actions/internal/read-write-actions'
+import { mountComponentEffect } from '../../../state/builder-api/actions'
+
 import { useDispatch } from '../hooks/use-dispatch'
 import { useDocumentKey } from '../hooks/use-document-context'
-import { useDisableRegisterElement } from '../hooks/use-disable-register-element'
-import { mountComponentEffect } from '../../../state/builder-api/actions'
-import { registerComponentHandleEffect } from '../../../state/actions/internal/read-write-actions'
 
-type RegisterChildrenAsElementProps = {
-  elementKey: string
-  componentHandle: ElementImperativeHandle
-  children?: ReactNode
-}
+import { ElementImperativeHandle } from '../element-imperative-handle'
+
+import { ControlInstancesProvider } from './control-instances-context'
 
 export const ElementRegistration = memo(function ElementRegistration({
   elementKey,
+  componentType,
   componentHandle,
   children,
-}: RegisterChildrenAsElementProps): ReactNode {
+}: {
+  elementKey: string
+  componentHandle: ElementImperativeHandle
+  componentType: string
+  children?: ReactNode
+}): ReactNode {
   const dispatch = useDispatch()
   const documentKey = useDocumentKey()
 
-  const isRegisterElementDisabled = useDisableRegisterElement()
+  // Create control instances on first render and make them available down the React tree
+  // through `ControlInstancesProvider`
+  const controlInstancesContext = useMemo(
+    () => ({
+      elementKey,
+      instances: documentKey
+        ? dispatch(createPropControllers({ documentKey, elementKey, componentType }))
+        : null,
+    }),
+    [dispatch, documentKey, elementKey, componentType],
+  )
+
+  const controlInstances = controlInstancesContext?.instances
+
+  // Set control instances into the corresponding component handle
+  useEffect(() => {
+    if (controlInstances == null) return
+
+    componentHandle.setPropControllers(controlInstances)
+    return () => componentHandle.setPropControllers(null)
+  }, [controlInstances, componentHandle])
+
+  // Register the control instances and component handle in the state
+  useEffect(() => {
+    if (documentKey == null || controlInstances == null) return
+
+    return dispatch(registerPropControllersEffect(documentKey, elementKey, controlInstances))
+  }, [dispatch, documentKey, elementKey, controlInstances])
 
   useEffect(() => {
-    if (documentKey == null || isRegisterElementDisabled) return
+    if (documentKey == null) return
 
     return dispatch(registerComponentHandleEffect(documentKey, elementKey, componentHandle))
-  }, [dispatch, documentKey, elementKey, isRegisterElementDisabled])
+  }, [dispatch, documentKey, elementKey, componentHandle])
 
+  // Register the element with to the builder
   useEffect(() => {
-    if (documentKey == null || isRegisterElementDisabled) return
+    if (documentKey == null) return
 
     return dispatch(mountComponentEffect(documentKey, elementKey))
-  }, [dispatch, documentKey, elementKey, isRegisterElementDisabled])
+  }, [dispatch, documentKey, elementKey])
 
-  return <>{children}</>
+  return (
+    <ControlInstancesProvider value={controlInstancesContext}>{children}</ControlInstancesProvider>
+  )
 })
 
 export default ElementRegistration

--- a/packages/runtime/src/runtimes/react/components/__tests__/element-registration.test.tsx
+++ b/packages/runtime/src/runtimes/react/components/__tests__/element-registration.test.tsx
@@ -95,8 +95,9 @@ describe('Element registration', () => {
 
     const snapshot = createMakeswiftPageSnapshot(createRootComponent([element], ROOT_COMPONENT_KEY))
     const fullElementKey = { documentKey: snapshot.document.id, elementKey }
+    const instanceKey = { elementKey, propPath: 'className' }
 
-    return { runtime, snapshot, fullElementKey, testElementTree, globalElement }
+    return { runtime, snapshot, testElementTree, globalElement, fullElementKey, instanceKey }
   }
 
   test.each([false, true])(
@@ -119,7 +120,7 @@ describe('Element registration', () => {
   )
 
   test('registers element data prop controllers and handles when editing', async () => {
-    const { runtime, snapshot, fullElementKey, testElementTree } = createFixtures()
+    const { runtime, snapshot, fullElementKey, testElementTree, instanceKey } = createFixtures()
     const siteVersion = TestWorkingSiteVersion
     await act(async () => render(testElementTree(<Page snapshot={snapshot} />, siteVersion)))
 
@@ -128,10 +129,14 @@ describe('Element registration', () => {
 
     const propControllers = getPropControllers(state, fullElementKey)
     expect(propControllers).not.toBe(null)
+    expect(propControllers?.['className']?.instanceKey).toStrictEqual(instanceKey)
 
     const handle = getPropControllersHandle(state, fullElementKey)
     expect(handle).toBeInstanceOf(ElementImperativeHandle)
     expect((handle as ElementImperativeHandle).getDomNode()?.innerHTML).toEqual('This is a test')
+    expect(JSON.parse(JSON.stringify(handle))).toEqual({
+      lastPropControllers: { className: { instanceKey } },
+    })
   })
 
   test('does not register reference or global element prop controllers and handles when editing', async () => {

--- a/packages/runtime/src/runtimes/react/components/control-instances-context.tsx
+++ b/packages/runtime/src/runtimes/react/components/control-instances-context.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { createContext, useContext } from 'react'
+
+import { ControlInstance } from '@makeswift/controls'
+
+type Context = {
+  elementKey: string
+  instances: Record<string, ControlInstance> | null
+}
+
+const ControlInstancesContext = createContext<Context | null>(null)
+
+export const ControlInstancesProvider = ControlInstancesContext.Provider
+
+export function useControlInstances(elementKey: string): Context['instances'] | null {
+  const cx = useContext(ControlInstancesContext)
+  return cx && cx.elementKey === elementKey ? cx.instances : null
+}

--- a/packages/runtime/src/runtimes/react/hooks/use-control-instances.ts
+++ b/packages/runtime/src/runtimes/react/hooks/use-control-instances.ts
@@ -1,16 +1,1 @@
-import { ControlInstance } from '@makeswift/controls'
-
-import { getPropControllers } from '../../../state/read-write-state'
-import { isReadWriteState } from '../../../state/unified-state'
-import { useDocumentKey } from './use-document-context'
-import { useSelector } from './use-selector'
-
-export function useControlInstances(elementKey: string): Record<string, ControlInstance> | null {
-  const documentKey = useDocumentKey()
-
-  return useSelector(state => {
-    if (documentKey == null || !isReadWriteState(state)) return null
-
-    return getPropControllers(state, { documentKey, elementKey })
-  })
-}
+export { useControlInstances } from '../components/control-instances-context'

--- a/packages/runtime/src/runtimes/react/hooks/use-disable-register-element.ts
+++ b/packages/runtime/src/runtimes/react/hooks/use-disable-register-element.ts
@@ -2,6 +2,6 @@ import { createContext, useContext } from 'react'
 
 export const DisableRegisterElement = createContext(false)
 
-export function useDisableRegisterElement() {
+export function useIsRegisterElementDisabled() {
   return useContext(DisableRegisterElement)
 }

--- a/packages/runtime/src/state/actions/internal/read-write-actions.ts
+++ b/packages/runtime/src/state/actions/internal/read-write-actions.ts
@@ -9,8 +9,15 @@ import { type DescriptorsByComponentType } from '../../modules/prop-controller-d
 import { type Measurable } from '../../modules/read-write/box-models'
 import { type PropControllersHandle } from '../../modules/read-write/prop-controllers'
 
+import { createPropController } from '../../../prop-controllers/instances'
+
+import { type Action } from '../../actions'
+import * as Builder from '../../builder-api/actions'
+
 import { type DocumentPayload } from '../../shared-api'
 import { type SerializedState as APIClientCache } from '../../api-client/state'
+import { getComponentPropControllerDescriptors } from '../../read-only-state'
+import { type State } from '../../unified-state'
 
 import { ReadWriteActionTypes } from './read-write-action-types'
 
@@ -185,6 +192,20 @@ export function unregisterPropControllers(
   }
 }
 
+export function registerPropControllersEffect(
+  documentKey: string,
+  elementKey: string,
+  propControllers: Record<string, ControlInstance>,
+): ThunkAction<() => void, unknown, unknown, ReadWriteAction> {
+  return dispatch => {
+    dispatch(registerPropControllers(documentKey, elementKey, propControllers))
+
+    return () => {
+      dispatch(unregisterPropControllers(documentKey, elementKey))
+    }
+  }
+}
+
 export function registerMeasurable(
   documentKey: string,
   elementKey: string,
@@ -223,4 +244,37 @@ export function updateAPIClientCache(payload: APIClientCache): UpdateAPIClientCa
 
 export function clearAPIClientCache(): ClearAPIClientCache {
   return { type: ReadWriteActionTypes.CLEAR_API_CLIENT_CACHE }
+}
+
+export function createPropControllers({
+  documentKey,
+  elementKey,
+  componentType,
+}: {
+  documentKey: string
+  elementKey: string
+  componentType: string
+}): ThunkAction<Record<string, ControlInstance> | null, State, unknown, Action> {
+  return (dispatch, getState) => {
+    const descriptors = getComponentPropControllerDescriptors(getState(), componentType)
+    if (descriptors == null) return null
+
+    const propControllers = Object.entries(descriptors).reduce(
+      (acc, [propName, descriptor]) => {
+        const propController = createPropController({
+          descriptor,
+          instanceKey: { elementKey, propPath: propName },
+          sendMessage: message =>
+            dispatch(
+              Builder.messageBuilderPropController(documentKey, elementKey, propName, message),
+            ),
+        }) as ControlInstance
+
+        return { ...acc, [propName]: propController }
+      },
+      {} as Record<string, ControlInstance>,
+    )
+
+    return propControllers
+  }
 }

--- a/packages/runtime/src/state/middleware/read-write/__tests__/prop-controller-handles.test.ts
+++ b/packages/runtime/src/state/middleware/read-write/__tests__/prop-controller-handles.test.ts
@@ -39,9 +39,6 @@ describe('propControllerHandlesMiddleware', () => {
 
     store.dispatch(registerDocument(State.createBaseDocument(documentKey, element, null)))
 
-    const setPropControllers = jest.fn()
-    handle.callback(() => ({ setPropControllers }))
-
     // Register and assert
     expect(
       getPropControllersHandle(store.getState(), { documentKey, elementKey: element.key }),
@@ -51,8 +48,6 @@ describe('propControllerHandlesMiddleware', () => {
     expect(
       getPropControllersHandle(store.getState(), { documentKey, elementKey: element.key }),
     ).toBe(handle)
-
-    expect(setPropControllers).toHaveBeenCalled()
 
     // Unregister and assert
     store.dispatch(unregisterComponentHandle(documentKey, element.key))
@@ -66,9 +61,6 @@ describe('propControllerHandlesMiddleware', () => {
     const { store, documentKey, handle } = createFixtures()
     const element: State.Element = { type: 'reference', key: 'elementKey', value: 'value' }
 
-    const setPropControllers = jest.fn()
-    handle.callback(() => ({ setPropControllers }))
-
     store.dispatch(registerDocument(State.createBaseDocument(documentKey, element, null)))
 
     // Act and assert
@@ -80,7 +72,5 @@ describe('propControllerHandlesMiddleware', () => {
     expect(
       getPropControllersHandle(store.getState(), { documentKey, elementKey: element.key }),
     ).toBe(null)
-
-    expect(setPropControllers).not.toHaveBeenCalled()
   })
 })

--- a/packages/runtime/src/state/middleware/read-write/prop-controller-handles.ts
+++ b/packages/runtime/src/state/middleware/read-write/prop-controller-handles.ts
@@ -1,69 +1,22 @@
-import { type Middleware, type ThunkAction } from '@reduxjs/toolkit'
-
-import { ControlInstance } from '@makeswift/controls'
+import { type Middleware } from '@reduxjs/toolkit'
 
 import * as PropControllers from '../../modules/read-write/prop-controllers'
 
 import { type Action } from '../../actions'
 
-import * as Builder from '../../builder-api/actions'
-
 import { ReadWriteActionTypes } from '../../actions/internal/read-write-action-types'
 
 import { actionMiddleware } from '../../toolkit'
-
-import { createPropController } from '../../../prop-controllers/instances'
 import { HostActionTypes } from '../../host-api'
 
 import * as ReadOnlyState from '../../read-only-state'
-import {
-  type State,
-  type Dispatch,
-  getPropControllersHandle,
-  getPropController,
-} from '../../read-write-state'
+
+import { type State, type Dispatch, getPropController } from '../../read-write-state'
 
 import {
-  registerPropControllers,
   registerPropControllersHandle,
-  unregisterPropControllers,
   unregisterPropControllersHandle,
 } from '../../actions/internal/read-write-actions'
-
-function createAndRegisterPropControllers(
-  documentKey: string,
-  elementKey: string,
-): ThunkAction<Record<string, ControlInstance> | null, State, unknown, Action> {
-  return (dispatch, getState) => {
-    const descriptors = ReadOnlyState.getElementPropControllerDescriptors(
-      getState(),
-      documentKey,
-      elementKey,
-    )
-
-    if (descriptors == null) return null
-
-    const propControllers = Object.entries(descriptors).reduce(
-      (acc, [propName, descriptor]) => {
-        const propController = createPropController({
-          descriptor,
-          instanceKey: { elementKey, propPath: propName },
-          sendMessage: message =>
-            dispatch(
-              Builder.messageBuilderPropController(documentKey, elementKey, propName, message),
-            ),
-        }) as ControlInstance
-
-        return { ...acc, [propName]: propController }
-      },
-      {} as Record<string, ControlInstance>,
-    )
-
-    dispatch(registerPropControllers(documentKey, elementKey, propControllers))
-
-    return propControllers
-  }
-}
 
 export function propControllerHandlesMiddleware(): Middleware<Dispatch, State, Dispatch> {
   return actionMiddleware(({ dispatch, getState }) => next => {
@@ -72,9 +25,6 @@ export function propControllerHandlesMiddleware(): Middleware<Dispatch, State, D
         case ReadWriteActionTypes.REGISTER_COMPONENT_HANDLE: {
           const { documentKey, elementKey, componentHandle } = action.payload
           const element = ReadOnlyState.getElement(getState(), documentKey, elementKey)
-          const propControllers = dispatch(
-            createAndRegisterPropControllers(documentKey, elementKey),
-          )
 
           if (
             element != null &&
@@ -82,7 +32,6 @@ export function propControllerHandlesMiddleware(): Middleware<Dispatch, State, D
             PropControllers.isPropControllersHandle(componentHandle)
           ) {
             dispatch(registerPropControllersHandle(documentKey, elementKey, componentHandle))
-            componentHandle.setPropControllers(propControllers)
           }
 
           break
@@ -90,16 +39,7 @@ export function propControllerHandlesMiddleware(): Middleware<Dispatch, State, D
 
         case ReadWriteActionTypes.UNREGISTER_COMPONENT_HANDLE: {
           const { documentKey, elementKey } = action.payload
-          const handle = getPropControllersHandle(getState(), {
-            documentKey,
-            elementKey,
-          })
-
-          handle?.setPropControllers(null)
-
-          dispatch(unregisterPropControllers(documentKey, elementKey))
           dispatch(unregisterPropControllersHandle(documentKey, elementKey))
-
           break
         }
 


### PR DESCRIPTION
Element prop controller instances were previously both created and registered in the Redux state in an effect, and therefore were unavailable during an element's initial render. 

Practically, this wasn't felt because other related state such as prop controller descriptors was (and is) also not available during the initial render, and we didn't have code like the following that would exercise this particular path:

```ts
const prevInstances = useRef(instances)
```

That said, this did lead to an additional unnecessary rerender before React settled on the final props.

Fixed by separating prop controller creation from prop controller registration. Controllers are now created on first render, registered and unregistered in an effect, and accessed through context rather than Redux state when resolving props during render.

Before:
<img width="903" height="321" alt="before" src="https://github.com/user-attachments/assets/c176d809-84cf-4903-9a09-b44d58437e35" />


After:
<img width="1034" height="254" alt="after" src="https://github.com/user-attachments/assets/3610cdec-7bf4-47d7-9661-65d10351dbeb" />

Best reviewed commit-by-commit.