### PR TITLE
fix(runtime): don't register elements when we're not in the builder

### DIFF
--- a/.changeset/dirty-parts-ask.md
+++ b/.changeset/dirty-parts-ask.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+fix: don't register elements when we're not in the builder

--- a/packages/runtime/src/runtimes/react/components/Element.tsx
+++ b/packages/runtime/src/runtimes/react/components/Element.tsx
@@ -1,17 +1,33 @@
 'use client'
 
-import { forwardRef, memo, Ref, useCallback, useImperativeHandle, useRef, ReactNode } from 'react'
+import {
+  type ReactNode,
+  type Ref,
+  type PropsWithChildren,
+  forwardRef,
+  memo,
+  useCallback,
+  useImperativeHandle,
+  useRef,
+  lazy,
+} from 'react'
+
 import {
   isElementReference,
   type Element as ElementDataOrRef,
 } from '../../../state/read-only-state'
-import { ElementRegistration } from './ElementRegistration'
-import { ElementReference } from './ElementReference'
-import { ElementData } from './ElementData'
-import { ElementImperativeHandle } from '../element-imperative-handle'
-import { FindDomNode } from '../find-dom-node'
+
 import { FallbackComponent } from '../../../components/shared/FallbackComponent'
 import { ErrorBoundary } from '../../../components/shared/ErrorBoundary'
+
+import { useIsReadOnly } from '../hooks/use-is-read-only'
+import { ElementImperativeHandle } from '../element-imperative-handle'
+import { FindDomNode } from '../find-dom-node'
+
+import { ElementReference } from './ElementReference'
+import { ElementData } from './ElementData'
+
+const BuilderElementRegistration = lazy(() => import('./ElementRegistration'))
 
 type Props = {
   element: ElementDataOrRef
@@ -39,6 +55,8 @@ export const Element = memo(
 
     useImperativeHandle(ref, () => imperativeHandleRef.current, [])
 
+    const ElementRegistration = useIsReadOnly() ? NoOp : BuilderElementRegistration
+
     return (
       <ElementRegistration componentHandle={imperativeHandleRef.current} elementKey={element.key}>
         <FindDomNode ref={findDomNodeCallbackRef}>
@@ -58,6 +76,10 @@ export const Element = memo(
     )
   }),
 )
+
+function NoOp({ children }: PropsWithChildren) {
+  return children
+}
 
 function ErrorFallback() {
   return <FallbackComponent text={`Error rendering component`} />

--- a/packages/runtime/src/runtimes/react/components/ElementRegistration.tsx
+++ b/packages/runtime/src/runtimes/react/components/ElementRegistration.tsx
@@ -38,3 +38,5 @@ export const ElementRegistration = memo(function ElementRegistration({
 
   return <>{children}</>
 })
+
+export default ElementRegistration


### PR DESCRIPTION
Register elements in the read-write state only if we're in the read-write state. Sister PR to https://github.com/makeswift/makeswift/pull/1376. 

Tested performance impact on the `makeswift-nextjs-app-router` deployment.

Before:
<img width="1405" height="441" alt="before" src="https://github.com/user-attachments/assets/54a62a9e-c1a8-4661-9b1b-3c974d7b9378" />

After:
<img width="1402" height="438" alt="after" src="https://github.com/user-attachments/assets/b46d0ca2-577e-4b2a-8bba-9d896dd1717d" />

