### PR TITLE
fix(runtime): unregister prop controllers handle on component unmount

### DIFF
--- a/.changeset/strong-mice-smash.md
+++ b/.changeset/strong-mice-smash.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+fix: unregister prop controllers handle when the component unmounts

--- a/packages/runtime/src/state/actions/internal/read-write-actions.ts
+++ b/packages/runtime/src/state/actions/internal/read-write-actions.ts
@@ -110,7 +110,7 @@ export function registerComponentHandle(
   }
 }
 
-function unregisterComponentHandle(
+export function unregisterComponentHandle(
   documentKey: string,
   elementKey: string,
 ): UnregisterComponentHandleAction {

--- a/packages/runtime/src/state/middleware/read-write/__tests__/prop-controller-handles.test.ts
+++ b/packages/runtime/src/state/middleware/read-write/__tests__/prop-controller-handles.test.ts
@@ -2,10 +2,13 @@ import { configureStore as configureReduxStore } from '@reduxjs/toolkit'
 
 import { ElementImperativeHandle } from '../../../../runtimes/react/element-imperative-handle'
 
-import { registerComponentHandle } from '../../../actions/internal/read-write-actions'
+import {
+  registerComponentHandle,
+  unregisterComponentHandle,
+} from '../../../actions/internal/read-write-actions'
 import { middlewareOptions } from '../../../toolkit'
 import { registerDocument } from '../../../shared-api'
-import { createRootReducer } from '../../../read-write-state'
+import { createRootReducer, getPropControllersHandle } from '../../../read-write-state'
 import * as State from '../../../read-only-state'
 
 import { readOnlyElementTreeMiddleware } from '../../read-only-element-tree'
@@ -13,10 +16,7 @@ import { readOnlyElementTreeMiddleware } from '../../read-only-element-tree'
 import { propControllerHandlesMiddleware } from '../prop-controller-handles'
 
 describe('propControllerHandlesMiddleware', () => {
-  it('registers prop controllers for element data', () => {
-    // Arrange
-    const documentKey = 'documentKey'
-    const element: State.Element = { key: 'elementKey', type: 'type', props: {} }
+  const createFixtures = () => {
     const store = configureReduxStore({
       reducer: createRootReducer(),
       middleware: getDefaultMiddleware =>
@@ -26,41 +26,61 @@ describe('propControllerHandlesMiddleware', () => {
         ),
     })
 
-    const setPropControllers = jest.fn()
+    const documentKey = 'documentKey'
     const handle = new ElementImperativeHandle()
 
-    handle.callback(() => ({ setPropControllers }))
+    return { store, documentKey, handle }
+  }
+
+  it('registers and unregisters prop controllers for element data', () => {
+    // Arrange
+    const { store, documentKey, handle } = createFixtures()
+    const element: State.Element = { key: 'elementKey', type: 'type', props: {} }
 
     store.dispatch(registerDocument(State.createBaseDocument(documentKey, element, null)))
 
-    // Act
-    store.dispatch(registerComponentHandle(documentKey, element.key, handle))
+    const setPropControllers = jest.fn()
+    handle.callback(() => ({ setPropControllers }))
 
-    // Assert
+    // Register and assert
+    expect(
+      getPropControllersHandle(store.getState(), { documentKey, elementKey: element.key }),
+    ).toBe(null)
+
+    store.dispatch(registerComponentHandle(documentKey, element.key, handle))
+    expect(
+      getPropControllersHandle(store.getState(), { documentKey, elementKey: element.key }),
+    ).toBe(handle)
+
     expect(setPropControllers).toHaveBeenCalled()
+
+    // Unregister and assert
+    store.dispatch(unregisterComponentHandle(documentKey, element.key))
+    expect(
+      getPropControllersHandle(store.getState(), { documentKey, elementKey: element.key }),
+    ).toBe(null)
   })
 
   it("doesn't register prop controllers for element references", () => {
     // Arrange
-    const documentKey = 'documentKey'
+    const { store, documentKey, handle } = createFixtures()
     const element: State.Element = { type: 'reference', key: 'elementKey', value: 'value' }
-    const store = configureReduxStore({
-      reducer: createRootReducer(),
-      middleware: getDefaultMiddleware =>
-        getDefaultMiddleware(middlewareOptions).concat(propControllerHandlesMiddleware()),
-    })
 
     const setPropControllers = jest.fn()
-    const handle = new ElementImperativeHandle()
-
     handle.callback(() => ({ setPropControllers }))
 
     store.dispatch(registerDocument(State.createBaseDocument(documentKey, element, null)))
 
-    // Act
-    store.dispatch(registerComponentHandle(documentKey, element.key, handle))
+    // Act and assert
+    expect(
+      getPropControllersHandle(store.getState(), { documentKey, elementKey: element.key }),
+    ).toBe(null)
 
-    // Assert
+    store.dispatch(registerComponentHandle(documentKey, element.key, handle))
+    expect(
+      getPropControllersHandle(store.getState(), { documentKey, elementKey: element.key }),
+    ).toBe(null)
+
     expect(setPropControllers).not.toHaveBeenCalled()
   })
 })

--- a/packages/runtime/src/state/middleware/read-write/prop-controller-handles.ts
+++ b/packages/runtime/src/state/middleware/read-write/prop-controller-handles.ts
@@ -27,6 +27,7 @@ import {
   registerPropControllers,
   registerPropControllersHandle,
   unregisterPropControllers,
+  unregisterPropControllersHandle,
 } from '../../actions/internal/read-write-actions'
 
 function createAndRegisterPropControllers(
@@ -97,6 +98,7 @@ export function propControllerHandlesMiddleware(): Middleware<Dispatch, State, D
           handle?.setPropControllers(null)
 
           dispatch(unregisterPropControllers(documentKey, elementKey))
+          dispatch(unregisterPropControllersHandle(documentKey, elementKey))
 
           break
         }


### PR DESCRIPTION
Fixes a memory leak we had since we introduced the notion of prop controller handles.