### PR TITLE
refactor: formalize `ControlInstance<any>` as `AnyControlInstance`

### DIFF
--- a/.changeset/free-camels-lead.md
+++ b/.changeset/free-camels-lead.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/controls': patch
+---
+
+Formalize `ControlInstance<any>` as `AnyControlInstance` to avoid having to suppress warnings about `any` throughout the codebase

--- a/packages/controls/src/controls/definition.ts
+++ b/packages/controls/src/controls/definition.ts
@@ -13,7 +13,11 @@ import { ControlInstance, type ControlInstanceArgs } from './instance'
 import { ControlDefinitionVisitor } from './visitor'
 
 export type SchemaType<T> = z.ZodType<T>
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type SchemaTypeAny = SchemaType<any> | z.ZodBranded<SchemaType<any>, any>
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AnyControlInstance = ControlInstance<any>
 
 export type Resolvable<T> = ValueSubscription<T> & {
   triggerResolve(currentValue?: T): Promise<unknown>
@@ -25,7 +29,7 @@ export abstract class ControlDefinition<
   DataType extends Data = Data,
   ValueType extends Data = Data,
   ResolvedValueType = Data | unknown,
-  InstanceType extends ControlInstance<any> = ControlInstance<any>,
+  InstanceType extends AnyControlInstance = AnyControlInstance,
 > {
   // workaround for TypeScript type inference issues: https://bit.ly/4g2RvOQ
   __associatedTypes(_: {

--- a/packages/controls/src/controls/rich-text/v1/rich-text.ts
+++ b/packages/controls/src/controls/rich-text/v1/rich-text.ts
@@ -5,8 +5,11 @@ import { safeParse, type ParseResult } from '../../../lib/zod'
 
 import { type CopyContext } from '../../../context'
 import { type IntrospectionTarget } from '../../../introspection'
-import { ControlDefinition, type SchemaType } from '../../definition'
-import { ControlInstance } from '../../instance'
+import {
+  ControlDefinition,
+  type AnyControlInstance,
+  type SchemaType,
+} from '../../definition'
 import { ControlDefinitionVisitor } from '../../visitor'
 
 import {
@@ -25,7 +28,7 @@ type ValueType = z.infer<typeof Definition.schema.value>
 
 abstract class Definition<
   RuntimeNode,
-  InstanceType extends ControlInstance<any>,
+  InstanceType extends AnyControlInstance,
 > extends ControlDefinition<
   typeof Definition.type,
   unknown,

--- a/packages/controls/src/controls/rich-text/v2/rich-text.ts
+++ b/packages/controls/src/controls/rich-text/v2/rich-text.ts
@@ -5,8 +5,11 @@ import { safeParse, type ParseResult } from '../../../lib/zod'
 
 import { type CopyContext } from '../../../context'
 import { type IntrospectionTarget } from '../../../introspection'
-import { ControlDefinition, type SchemaType } from '../../definition'
-import { ControlInstance } from '../../instance'
+import {
+  ControlDefinition,
+  type AnyControlInstance,
+  type SchemaType,
+} from '../../definition'
 import { ControlDefinitionVisitor } from '../../visitor'
 
 import { DTOSchema, isRichTextDTO, richTextDTOtoDAO } from '../dto'
@@ -25,7 +28,7 @@ type ValueType = z.infer<typeof Definition.schema.value>
 abstract class Definition<
   RuntimeNode,
   Config extends UserConfig = UserConfig,
-  InstanceType extends ControlInstance<any> = ControlInstance<any>,
+  InstanceType extends AnyControlInstance = AnyControlInstance,
 > extends ControlDefinition<
   typeof Definition.type,
   Config,

--- a/packages/controls/src/controls/rich-text/v2/testing.ts
+++ b/packages/controls/src/controls/rich-text/v2/testing.ts
@@ -1,9 +1,8 @@
 import { z } from 'zod'
 
 import { type DataType } from '../../associated-types'
-import { type Resolvable } from '../../definition'
+import { type AnyControlInstance, type Resolvable } from '../../definition'
 import {
-  ControlInstance,
   DefaultControlInstance,
   type ControlInstanceArgs,
 } from '../../instance'
@@ -29,7 +28,7 @@ class Definition extends RichTextDefinition<RenderedNode> {
     }
   }
 
-  createInstance(args: ControlInstanceArgs): ControlInstance<any> {
+  createInstance(args: ControlInstanceArgs): AnyControlInstance {
     return new DefaultControlInstance(args)
   }
 

--- a/packages/runtime/src/prop-controllers/instances.ts
+++ b/packages/runtime/src/prop-controllers/instances.ts
@@ -6,6 +6,7 @@ import {
   type ControlInstanceArgs,
   type ControlMessage,
   type InstanceType,
+  type AnyControlInstance,
   ControlInstance,
   DefaultControlInstance,
 } from '@makeswift/controls'
@@ -71,7 +72,7 @@ export type DescriptorsPropControllers<T extends Record<string, Descriptor>> = {
     : DescriptorPropController<T[K]>
 }
 
-export type AnyPropController = ControlInstance<any> | TableFormFieldsPropController
+export type AnyPropController = AnyControlInstance | TableFormFieldsPropController
 
 export function createPropController({
   descriptor,


### PR DESCRIPTION
Formalize `ControlInstance<any>` as `AnyControlInstance` to avoid having to suppress warnings about `any` throughout the codebase.