### PR TITLE
feat(controls): ability to subscribe to changes to instance state

### DIFF
--- a/.changeset/fine-books-sit.md
+++ b/.changeset/fine-books-sit.md
@@ -1,0 +1,6 @@
+---
+'@makeswift/controls': patch
+'@makeswift/runtime': patch
+---
+
+feat: add the ability to subscribe to changes in the control instance state

--- a/packages/controls/src/controls/group/group-control.ts
+++ b/packages/controls/src/controls/group/group-control.ts
@@ -41,6 +41,11 @@ export class GroupControl<
     }
   }
 
+  subscribe = (_listener: () => void): (() => void) => {
+    // No mutable state, nothing to subscribe to
+    return () => {}
+  }
+
   isCompositeProp = () => true
 
   children = () => [...this.childControls.values()]

--- a/packages/controls/src/controls/group/group.ts
+++ b/packages/controls/src/controls/group/group.ts
@@ -31,6 +31,7 @@ import { ControlDefinitionVisitor } from '../visitor'
 
 import { GroupControl } from './group-control'
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ItemDefinition = ControlDefinition<string, unknown, any, any, any>
 type KeyDefinitions = Record<string, ItemDefinition>
 

--- a/packages/controls/src/controls/instance.ts
+++ b/packages/controls/src/controls/instance.ts
@@ -43,6 +43,11 @@ export abstract class ControlInstance<
   abstract recv(message: M): void
 
   /**
+   * Subscribe to changes to the instance state; returns an unsubscribe function.
+   */
+  abstract subscribe(listener: () => void): () => void
+
+  /**
    * Returns true if the control represents a composite prop value (a prop that contains other props).
    *
    * In contrast with `children()`, this return value doesn't change over the control lifetime.
@@ -73,6 +78,11 @@ export abstract class ControlInstance<
 export class DefaultControlInstance extends ControlInstance {
   recv(_message: ControlMessage) {
     // Do nothing
+  }
+
+  subscribe(_listener: () => void): () => void {
+    // No mutable state, nothing to subscribe to
+    return () => {}
   }
 
   isCompositeProp(): boolean {

--- a/packages/controls/src/controls/list/list-control.ts
+++ b/packages/controls/src/controls/list/list-control.ts
@@ -21,6 +21,7 @@ export class ListControl<
 
   private itemControlsById: Map<string, ControlInstance> = new Map()
   private itemControlsList: Array<ControlInstance> = []
+  private listeners = new Set<() => void>()
 
   constructor(
     private readonly definition: Def,
@@ -36,6 +37,11 @@ export class ListControl<
         this.childByItemId(itemId)?.recv(itemMessage)
       }
     }
+  }
+
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
   }
 
   isCompositeProp = () => true
@@ -82,8 +88,11 @@ export class ListControl<
   }
 
   setChildControls = (children: Map<string, ControlInstance>) => {
+    if (children === this.itemControlsById) return
+
     this.itemControlsById = children
     this.itemControlsList = [...children.values()]
+    this.listeners.forEach((listener) => listener())
   }
 
   createItemControl = (index: number, itemId: string): ControlInstance => {

--- a/packages/controls/src/controls/list/list.test.ts
+++ b/packages/controls/src/controls/list/list.test.ts
@@ -148,16 +148,26 @@ describe('List', () => {
         listInstance,
       ] as const
 
-      return { listInstance, resolveValueContext }
+      const subscribeCallback = jest.fn()
+      listInstance.subscribe(subscribeCallback)
+
+      return {
+        listInstance,
+        resolveValueContext,
+        subscribeCallback,
+      }
     }
 
-    test('resolveValue creates a list of child controls with correct instance keys', async () => {
-      const { listInstance, resolveValueContext } = fixtures()
-
-      expect(listInstance.childControls().size).toBe(0)
+    test('resolveValue creates a list of child controls with correct instance keys, triggers subscribe callback', async () => {
+      const { listInstance, resolveValueContext, subscribeCallback } =
+        fixtures()
 
       const resolved = list.resolveValue(listData, ...resolveValueContext)
+      expect(listInstance.childControls().size).toBe(0)
+      expect(subscribeCallback).not.toHaveBeenCalled()
+
       await resolved.triggerResolve()
+      expect(subscribeCallback).toHaveBeenCalled()
 
       const childControls = [...listInstance.childControls().values()]
 
@@ -175,30 +185,36 @@ describe('List', () => {
       ])
     })
 
-    test('resolveValue on unchanged list maintains child control identity', async () => {
-      const { listInstance, resolveValueContext } = fixtures()
+    test("resolveValue on unchanged list maintains child control identity, doesn't trigger subscribe callback", async () => {
+      const { listInstance, resolveValueContext, subscribeCallback } =
+        fixtures()
 
       const resolved = list.resolveValue(listData, ...resolveValueContext)
       await resolved.triggerResolve()
+      expect(subscribeCallback).toHaveBeenCalledTimes(1)
       const childControls = listInstance.children()
 
       const resolved2 = list.resolveValue(listData, ...resolveValueContext)
       await resolved2.triggerResolve()
+      expect(subscribeCallback).toHaveBeenCalledTimes(1)
       const childControls2 = listInstance.children()
 
       childControls2.forEach((item, i) => expect(item).toBe(childControls[i]))
     })
 
-    test('reordering list data recreates child controls with correct prop paths', async () => {
-      const { listInstance, resolveValueContext } = fixtures()
+    test('reordering list data recreates child controls with correct prop paths, triggers subscribe callback', async () => {
+      const { listInstance, resolveValueContext, subscribeCallback } =
+        fixtures()
 
       const resolved = list.resolveValue(listData, ...resolveValueContext)
       await resolved.triggerResolve()
+      expect(subscribeCallback).toHaveBeenCalledTimes(1)
       const childControls = listInstance.children()
 
       const listData2 = [...listData].sort((a, b) => b.id.localeCompare(a.id))
       const resolved2 = list.resolveValue(listData2, ...resolveValueContext)
       await resolved2.triggerResolve()
+      expect(subscribeCallback).toHaveBeenCalledTimes(2)
       const childControls2 = listInstance.children()
 
       childControls2.forEach((item, i) =>
@@ -213,16 +229,19 @@ describe('List', () => {
       ])
     })
 
-    test('partial reordering of list data recreates only affected child controls', async () => {
-      const { listInstance, resolveValueContext } = fixtures()
+    test('partial reordering of list data recreates only affected child controls, triggers subscribe callback', async () => {
+      const { listInstance, resolveValueContext, subscribeCallback } =
+        fixtures()
 
       const resolved = list.resolveValue(listData, ...resolveValueContext)
       await resolved.triggerResolve()
+      expect(subscribeCallback).toHaveBeenCalledTimes(1)
       const childControls = listInstance.children()
 
       const listData2 = [listData[0], listData[2], listData[1], listData[3]]
       const resolved2 = list.resolveValue(listData2, ...resolveValueContext)
       await resolved2.triggerResolve()
+      expect(subscribeCallback).toHaveBeenCalledTimes(2)
       const childControls2 = listInstance.children()
 
       expect(childControls2[0]).toBe(childControls[0])

--- a/packages/controls/src/controls/shape/v1/shape-control.ts
+++ b/packages/controls/src/controls/shape/v1/shape-control.ts
@@ -41,6 +41,11 @@ export class ShapeControl<
     }
   }
 
+  subscribe = (_listener: () => void): (() => void) => {
+    // No mutable state, nothing to subscribe to
+    return () => {}
+  }
+
   isCompositeProp = () => true
 
   children = () => [...this.childControls.values()]

--- a/packages/controls/src/controls/slot/slot-control.ts
+++ b/packages/controls/src/controls/slot/slot-control.ts
@@ -23,6 +23,11 @@ export class SlotControl extends ControlInstance<Message> {
 
   recv = (_message: Message) => {}
 
+  subscribe(_listener: () => void): () => void {
+    // No mutable state, nothing to subscribe to
+    return () => {}
+  }
+
   isCompositeProp(): boolean {
     return false
   }

--- a/packages/controls/src/controls/style/v1/style-control.ts
+++ b/packages/controls/src/controls/style/v1/style-control.ts
@@ -12,6 +12,11 @@ export class StyleControl extends ControlInstance<Message> {
 
   recv = (_message: Message) => {}
 
+  subscribe(_listener: () => void): () => void {
+    // No mutable state, nothing to subscribe to
+    return () => {}
+  }
+
   isCompositeProp(): boolean {
     return false
   }

--- a/packages/controls/src/controls/style/v2/style-v2-control.ts
+++ b/packages/controls/src/controls/style/v2/style-v2-control.ts
@@ -38,6 +38,20 @@ export class StyleV2Control extends ControlInstance<Message> {
     })
   }
 
+  recv = (message: Message) => {
+    switch (message.type) {
+      case StyleV2Control.INNER_CONTROL_MESSAGE: {
+        if (this.inner == null) return
+        this.inner.recv(message.payload.message)
+      }
+    }
+  }
+
+  subscribe(_listener: () => void): () => void {
+    // No mutable state, nothing to subscribe to
+    return () => {}
+  }
+
   isCompositeProp(): boolean {
     return false
   }
@@ -48,15 +62,6 @@ export class StyleV2Control extends ControlInstance<Message> {
 
   child(_key: string): ControlInstance | undefined {
     return undefined
-  }
-
-  recv = (message: Message) => {
-    switch (message.type) {
-      case StyleV2Control.INNER_CONTROL_MESSAGE: {
-        if (this.inner == null) return
-        this.inner.recv(message.payload.message)
-      }
-    }
   }
 
   resolvesToRenderableNode(): boolean {

--- a/packages/runtime/src/controls/rich-text-v2/control.ts
+++ b/packages/runtime/src/controls/rich-text-v2/control.ts
@@ -123,6 +123,11 @@ export class RichTextV2Control extends ControlInstance<Message> {
     }
   }
 
+  subscribe(_listener: () => void): () => void {
+    // No mutable state, nothing to subscribe to
+    return () => {}
+  }
+
   isCompositeProp(): boolean {
     return false
   }

--- a/packages/runtime/src/controls/rich-text/control.ts
+++ b/packages/runtime/src/controls/rich-text/control.ts
@@ -87,6 +87,11 @@ export class RichTextControl extends ControlInstance<Message> {
     }
   }
 
+  subscribe(_listener: () => void): () => void {
+    // No mutable state, nothing to subscribe to
+    return () => {}
+  }
+
   isCompositeProp(): boolean {
     return false
   }

--- a/packages/runtime/src/prop-controllers/instances.ts
+++ b/packages/runtime/src/prop-controllers/instances.ts
@@ -35,6 +35,11 @@ export type TableFormFieldsMessage =
 export class TableFormFieldsPropController extends ControlInstance<TableFormFieldsMessage> {
   recv = () => {}
 
+  subscribe(_listener: () => void): () => void {
+    // No mutable state, nothing to subscribe to
+    return () => {}
+  }
+
   isCompositeProp(): boolean {
     return false
   }


### PR DESCRIPTION
Enables us to use control instances with `useSyncExternalStore`. Prep for [RSC-enabled `Slot` prop rendering](https://github.com/makeswift/makeswift/pull/1381).