### PR TITLE
fix: infinite loop when resubscribing to list instance updates

### DIFF
--- a/.changeset/forty-books-travel.md
+++ b/.changeset/forty-books-travel.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/controls': patch
+---
+
+fix: infinite loop when resubscribing to list instance updates in response to instance update

--- a/packages/controls/src/controls/list/list-control.ts
+++ b/packages/controls/src/controls/list/list-control.ts
@@ -92,7 +92,11 @@ export class ListControl<
 
     this.itemControlsById = children
     this.itemControlsList = [...children.values()]
-    this.listeners.forEach((listener) => listener())
+
+    // copy the listeners before notifying them to avoid an infinite loop when
+    // user resubscribes to updates in response to receiving one
+    const listeners = [...this.listeners.values()]
+    listeners.forEach((listener) => listener())
   }
 
   createItemControl = (index: number, itemId: string): ControlInstance => {

--- a/packages/controls/src/controls/list/list.test.ts
+++ b/packages/controls/src/controls/list/list.test.ts
@@ -229,6 +229,23 @@ describe('List', () => {
       ])
     })
 
+    test("updating list instance's subscription in response to the instance's state update doesn't cause an infinite loop", async () => {
+      const { listInstance, resolveValueContext } = fixtures()
+
+      let unsubscribe = () => {}
+
+      const subscribeCallback = jest.fn(async () => {
+        unsubscribe()
+        unsubscribe = listInstance.subscribe(subscribeCallback)
+      })
+
+      unsubscribe = listInstance.subscribe(subscribeCallback)
+
+      const resolved = list.resolveValue(listData, ...resolveValueContext)
+      await resolved.triggerResolve()
+      expect(subscribeCallback).toHaveBeenCalledTimes(1)
+    })
+
     test('partial reordering of list data recreates only affected child controls, triggers subscribe callback', async () => {
       const { listInstance, resolveValueContext, subscribeCallback } =
         fixtures()


### PR DESCRIPTION
Fix an infinite loop when resubscribing to list instance updates in response to instance update. Following up https://github.com/makeswift/makeswift/pull/1386