### PR TITLE
fix: unset body overflow styles to allow scrolling in builder

### DIFF
--- a/.changeset/giant-humans-read.md
+++ b/.changeset/giant-humans-read.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Unset body overflow styles when loaded in builder to allow scrolling

--- a/packages/runtime/src/state/middleware/read-write/builder-api/initialize-connection.ts
+++ b/packages/runtime/src/state/middleware/read-write/builder-api/initialize-connection.ts
@@ -100,13 +100,30 @@ function startMeasuringElements(): ThunkAction<() => void, State, unknown, Actio
 
 function lockDocumentScroll(): ThunkAction<() => void, State, unknown, Action> {
   return dispatch => {
+    // Adjust root HTML styles so the page is scrollable in the builder.
+    // Specifically, we make two adjustments:
+    //
+    // 1. Set the root element's overflow to hidden. Otherwise, you'll see two
+    //    scrollbars in the builder when viewing the page: one being the native
+    //    scrollbar of the page, and the other being the builder's scrollbar.
+    //
+    // 2. Set the root body element's overflow to initial. There's cases where
+    //    if the body has an overflow property set on it, then the body
+    //    overflow-y property will become auto. This, combined with the
+    //    body/html having a 100% height means that the overflowing content of
+    //    the body won't count towards the scroll height of the root element,
+    //    thus preventing scrolling from the builder.
     const lastDocumentOverflow = window.document.documentElement.style.overflow
     window.document.documentElement.style.overflow = 'hidden'
+
+    const lastBodyOverflow = window.document.body.style.overflow
+    window.document.body.style.overflow = 'initial'
 
     window.document.documentElement.addEventListener('wheel', handleWheelEvent)
 
     return () => {
       window.document.documentElement.style.overflow = lastDocumentOverflow
+      window.document.body.style.overflow = lastBodyOverflow
       window.document.documentElement.removeEventListener('wheel', handleWheelEvent)
     }
 


### PR DESCRIPTION
Addresses a case where setting certain overflow properties on the body results in the body's contents not overflowing to the root element. The runtime then measures the root element height as the same as the window height, resulting in the builder not showing a scroll bar (even if the scroll bar was shown, the root element would also not be scrollable).