### PR TITLE
refactor: `ApiResourcesClient.cacheData` accessor

### DIFF
--- a/packages/runtime/src/api/api-resources-client.ts
+++ b/packages/runtime/src/api/api-resources-client.ts
@@ -40,6 +40,10 @@ export abstract class ApiResourcesClient {
     this.subscribe = this.store.subscribe
   }
 
+  get cacheData(): CacheData {
+    return ApiClientState.getSerializedState(this.store.getState())
+  }
+
   async fetchSwatch(swatchId: string): Promise<Swatch | null> {
     const fetch = (id: string, version: SiteVersion | null) => this.fetchSwatchImpl(id, version)
 

--- a/packages/runtime/src/state/api-client/state.ts
+++ b/packages/runtime/src/state/api-client/state.ts
@@ -24,6 +24,13 @@ export type SerializedState = {
   localizedResourcesMap: LocalizedResourcesMap.SerializedState
 }
 
+export function getSerializedState(state: State): SerializedState {
+  return {
+    apiResources: APIResources.getSerializedState(state.apiResources),
+    localizedResourcesMap: LocalizedResourcesMap.getSerializedState(state.localizedResourcesMap),
+  }
+}
+
 export function getLocalizedResourceId(
   state: State,
   locale: string,


### PR DESCRIPTION
Prep for RSC snapshot rendering.