### PR TITLE
fix: add 'use client' to framework-context

### DIFF
--- a/packages/runtime/src/runtimes/react/components/framework-context.tsx
+++ b/packages/runtime/src/runtimes/react/components/framework-context.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import {
   type ReactNode,
   type PropsWithChildren,


### PR DESCRIPTION
Set client boundary so it's not pulled by RSC environment. It's incompatible since it calls `createContext`
```ts
const FrameworkContext = createContext<Partial<FrameworkContext>>({})
```