### PR TITLE
refactor: client throws on error, retry on rate limit

### DIFF
--- a/.changeset/cold-knives-accept.md
+++ b/.changeset/cold-knives-accept.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+REST API client now throws on non-404 failures. Also implement request retries when hitting rate limits, with exponential backoff and jitter applied.

--- a/packages/runtime/jest.config.ts
+++ b/packages/runtime/jest.config.ts
@@ -10,6 +10,8 @@ const baseConfig: Config = {
   setupFiles: ['./jest.polyfills.js'],
   setupFilesAfterEnv: ['<rootDir>/src/jest-setup.ts'],
   resolver: `${__dirname}/jest.resolver.js`,
+  // `ky` is ESM-only
+  transformIgnorePatterns: ['/node_modules/(?!(.*/)?ky/)'],
   transform: {
     '^.+\\.(t|j)s?$': '@swc/jest',
     '^.+\\.(t|j)sx?$': [

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -18,7 +18,7 @@
     "unstable-framework-support"
   ],
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.19.0"
   },
   "sideEffects": false,
   "exports": {
@@ -242,6 +242,7 @@
     "is-hotkey": "^0.1.4",
     "js-base64": "^3.7.7",
     "jwt-decode": "^4.0.0",
+    "ky": "^1.14.3",
     "ot-json0": "^1.1.0",
     "parse5": "^7.3.0",
     "path-to-regexp": "^6.2.1",

--- a/packages/runtime/src/api/__tests__/rest-api-client.get-resources.test.ts
+++ b/packages/runtime/src/api/__tests__/rest-api-client.get-resources.test.ts
@@ -1,4 +1,4 @@
-import { MakeswiftRestAPIClient } from '../rest-api-client'
+import { MakeswiftRestAPIClient, RestApiClientError } from '../rest-api-client'
 import { http, HttpResponse } from 'msw'
 
 import { server } from '../../mocks/server'
@@ -13,6 +13,18 @@ function createTestClient() {
     apiKey: TEST_API_KEY,
     apiOrigin: TestOrigins.apiOrigin,
   })
+}
+
+async function captureClientError(promise: Promise<unknown>): Promise<RestApiClientError> {
+  try {
+    await promise
+  } catch (error) {
+    if (error instanceof RestApiClientError) return error
+
+    throw new Error(`Expected a RestApiClientError, but got: ${error}`)
+  }
+
+  throw new Error('Expected the request to fail, but it succeeded')
 }
 
 let consoleErrorSpy: jest.SpyInstance
@@ -47,7 +59,7 @@ describe('getSwatch', () => {
     expect(consoleErrorSpy).not.toHaveBeenCalled()
   })
 
-  test('returns null on other errors, logs details to the console', async () => {
+  test('throws on other errors, attaching the details to the error', async () => {
     // Arrange
     const client = createTestClient()
 
@@ -58,12 +70,14 @@ describe('getSwatch', () => {
     )
 
     // Act
-    const result = await client.getSwatch(swatchId, TestWorkingSiteVersion)
+    const error = await captureClientError(client.getSwatch(swatchId, TestWorkingSiteVersion))
 
     // Assert
-    expect(result).toBeNull()
-    expect(consoleErrorSpy).toHaveBeenCalledWith("Failed to get swatch 'mySwatch'", {
-      response: 'Internal server error',
+    expect(error.name).toBe('RestApiClientError')
+    expect(error.message).toBe("Failed to get swatch 'mySwatch': 500 Internal Server Error")
+    expect(error.status).toBe(500)
+    expect(error.cause).toEqual({
+      body: 'Internal server error',
       siteVersion: TestWorkingSiteVersion,
     })
   })
@@ -91,7 +105,7 @@ describe('getTypography', () => {
     expect(consoleErrorSpy).not.toHaveBeenCalled()
   })
 
-  test('returns null on other errors, logs details to the console', async () => {
+  test('throws on other errors, attaching the details to the error', async () => {
     // Arrange
     const client = createTestClient()
 
@@ -102,14 +116,13 @@ describe('getTypography', () => {
     )
 
     // Act
-    const result = await client.getTypography(typographyId, TestWorkingSiteVersion)
+    const error = await captureClientError(
+      client.getTypography(typographyId, TestWorkingSiteVersion),
+    )
 
     // Assert
-    expect(result).toBeNull()
-    expect(consoleErrorSpy).toHaveBeenCalledWith("Failed to get typography 'myTypography'", {
-      response: 'Unauthorized',
-      siteVersion: TestWorkingSiteVersion,
-    })
+    expect(error.message).toBe("Failed to get typography 'myTypography': 401 Unauthorized")
+    expect(error.cause).toEqual({ body: 'Unauthorized', siteVersion: TestWorkingSiteVersion })
   })
 })
 
@@ -135,7 +148,7 @@ describe('getGlobalElement', () => {
     expect(consoleErrorSpy).not.toHaveBeenCalled()
   })
 
-  test('returns null on other errors, logs details to the console', async () => {
+  test('throws on other errors, attaching the details to the error', async () => {
     // Arrange
     const client = createTestClient()
 
@@ -146,14 +159,11 @@ describe('getGlobalElement', () => {
     )
 
     // Act
-    const result = await client.getGlobalElement(globalElementId, null)
+    const error = await captureClientError(client.getGlobalElement(globalElementId, null))
 
     // Assert
-    expect(result).toBeNull()
-    expect(consoleErrorSpy).toHaveBeenCalledWith("Failed to get global element 'myGlobalElement'", {
-      response: 'Bad request',
-      siteVersion: null,
-    })
+    expect(error.message).toBe("Failed to get global element 'myGlobalElement': 400 Bad Request")
+    expect(error.cause).toEqual({ body: 'Bad request', siteVersion: null })
   })
 })
 
@@ -184,7 +194,7 @@ describe('getLocalizedGlobalElement', () => {
     expect(consoleErrorSpy).not.toHaveBeenCalled()
   })
 
-  test('returns null on other errors, logs details to the console', async () => {
+  test('throws on other errors, attaching the details to the error', async () => {
     // Arrange
     const client = createTestClient()
 
@@ -195,18 +205,19 @@ describe('getLocalizedGlobalElement', () => {
     )
 
     // Act
-    const result = await client.getLocalizedGlobalElement(globalElementId, locale, null)
+    const error = await captureClientError(
+      client.getLocalizedGlobalElement(globalElementId, locale, null),
+    )
 
     // Assert
-    expect(result).toBeNull()
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      "Failed to get localized global element 'myGlobalElement'",
-      {
-        response: 'Request timeout',
-        locale: 'es-MX',
-        siteVersion: null,
-      },
+    expect(error.message).toBe(
+      "Failed to get localized global element 'myGlobalElement': 408 Request Timeout",
     )
+    expect(error.cause).toEqual({
+      body: 'Request timeout',
+      locale: 'es-MX',
+      siteVersion: null,
+    })
   })
 })
 
@@ -215,7 +226,7 @@ describe('getPagePathnameSlice', () => {
   const locale = 'fr'
   const resourceUrl = `${baseUrl}/page-pathname-slices/bulk`
 
-  test('returns null on all errors, logs details to the console', async () => {
+  test('throws on errors, attaching the details to the error', async () => {
     // Arrange
     const client = createTestClient()
 
@@ -226,17 +237,12 @@ describe('getPagePathnameSlice', () => {
     )
 
     // Act
-    const result = await client.getPagePathnameSlice(pageId, null, { locale })
+    const error = await captureClientError(client.getPagePathnameSlice(pageId, null, { locale }))
 
     // Assert
-    expect(result).toBeNull()
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      'Failed to get page pathname slice(s) for pageId',
-      {
-        response: 'Request timeout',
-        locale: 'fr',
-        siteVersion: null,
-      },
+    expect(error.message).toBe(
+      'Failed to get page pathname slice(s) for pageId: 408 Request Timeout',
     )
+    expect(error.cause).toEqual({ body: 'Request timeout', locale: 'fr', siteVersion: null })
   })
 })

--- a/packages/runtime/src/api/__tests__/rest-api-client.retries.test.ts
+++ b/packages/runtime/src/api/__tests__/rest-api-client.retries.test.ts
@@ -1,0 +1,141 @@
+import { http, HttpResponse } from 'msw'
+
+import { MakeswiftRestAPIClient, RestApiClientError } from '../rest-api-client'
+
+import { server } from '../../mocks/server'
+import { TestOrigins, TestWorkingSiteVersion, makeSwatch } from '../../testing/fixtures'
+
+const TEST_API_KEY = 'xxx'
+const swatchId = 'mySwatch'
+const resourceUrl = `${TestOrigins.apiOrigin}/v3/swatches/${swatchId}`
+
+function createTestClient() {
+  return new MakeswiftRestAPIClient({
+    fetch: globalThis.fetch,
+    apiKey: TEST_API_KEY,
+    apiOrigin: TestOrigins.apiOrigin,
+  })
+}
+
+// Responds with `status` for the first `failureCount` requests, then with the
+// given swatch, counting every request it receives along the way.
+function respondAfterFailures(
+  status: number,
+  failureCount: number,
+): { requestCount: () => number } {
+  let requestCount = 0
+
+  server.use(
+    http.get(resourceUrl, () => {
+      requestCount++
+
+      return requestCount <= failureCount
+        ? HttpResponse.json('Rate limited', { status })
+        : HttpResponse.json(makeSwatch(swatchId))
+    }),
+  )
+
+  return { requestCount: () => requestCount }
+}
+
+let consoleErrorSpy: jest.SpyInstance
+
+beforeEach(() => {
+  consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  consoleErrorSpy.mockRestore()
+})
+
+describe('rate limiting', () => {
+  test('retries rate limited requests and returns the eventual success', async () => {
+    // Arrange
+    const client = createTestClient()
+    const { requestCount } = respondAfterFailures(429, 2)
+
+    // Act
+    const result = await client.getSwatch(swatchId, TestWorkingSiteVersion)
+
+    // Assert
+    expect(result).toStrictEqual(makeSwatch(swatchId))
+    expect(requestCount()).toBe(3)
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+  })
+
+  test('gives up after exhausting its retries', async () => {
+    // Arrange
+    const client = createTestClient()
+    const { requestCount } = respondAfterFailures(429, 1_000)
+
+    // Act
+    const error = await client
+      .getSwatch(swatchId, TestWorkingSiteVersion)
+      .then(() => null)
+      .catch((e: RestApiClientError) => e)
+
+    // Assert
+    expect(error?.message).toBe("Failed to get swatch 'mySwatch': 429 Too Many Requests")
+    expect(error?.cause).toEqual({ body: 'Rate limited', siteVersion: TestWorkingSiteVersion })
+
+    // The initial request, plus three retries.
+    expect(requestCount()).toBe(4)
+  }, 15_000)
+
+  test('honors the `Retry-After` header', async () => {
+    // Arrange
+    const client = createTestClient()
+    let requestCount = 0
+
+    // Retry-After value that doesn't match the current backoff delay
+    const retryAfterSeconds = 3
+
+    server.use(
+      http.get(resourceUrl, () => {
+        requestCount++
+
+        return requestCount === 1
+          ? HttpResponse.json('Rate limited', {
+              status: 429,
+              headers: { 'Retry-After': String(retryAfterSeconds) },
+            })
+          : HttpResponse.json(makeSwatch(swatchId))
+      }),
+    )
+
+    // Act
+    const start = Date.now()
+    const result = await client.getSwatch(swatchId, TestWorkingSiteVersion)
+    const elapsedMs = Date.now() - start
+
+    // Assert
+    expect(result).toStrictEqual(makeSwatch(swatchId))
+    expect(requestCount).toBe(2)
+
+    const toleranceMs = 500
+    const retryAfterMs = retryAfterSeconds * 1000
+    // The client should have waited (approximately) the `Retry-After` delay
+    // before retrying.
+    expect(elapsedMs).toBeGreaterThanOrEqual(retryAfterMs - toleranceMs)
+    expect(elapsedMs).toBeLessThan(retryAfterMs + toleranceMs)
+  })
+})
+
+describe.each([
+  ['408 Request Timeout', 408],
+  ['500 Internal Server Error', 500],
+  ['503 Service Unavailable', 503],
+])('%s', (_name, status) => {
+  test('is not retried', async () => {
+    // Arrange
+    const client = createTestClient()
+    const { requestCount } = respondAfterFailures(status, 1)
+
+    // Act & Assert
+    await expect(client.getSwatch(swatchId, TestWorkingSiteVersion)).rejects.toThrow(
+      `Failed to get swatch 'mySwatch': ${status}`,
+    )
+
+    expect(requestCount()).toBe(1)
+  })
+})

--- a/packages/runtime/src/api/rest-api-client.ts
+++ b/packages/runtime/src/api/rest-api-client.ts
@@ -1,3 +1,5 @@
+import ky, { HTTPError, isHTTPError, type KyInstance } from 'ky'
+
 import {
   type GlobalElement,
   type LocalizedGlobalElement,
@@ -10,8 +12,13 @@ import {
 import { type SiteVersion } from './site-version'
 import * as Schema from './schema'
 
+const RetryBackoffConfig = {
+  MaxAttempts: 3,
+  MaxDelayMs: 5_000,
+}
+
 export class MakeswiftRestAPIClient {
-  private _fetch: HttpFetch
+  private _fetch: KyInstance
 
   readonly apiKey: string
   readonly apiOrigin: string
@@ -25,7 +32,30 @@ export class MakeswiftRestAPIClient {
     apiKey: string
     apiOrigin: string
   }) {
-    this._fetch = fetch
+    this._fetch = ky.create({
+      fetch,
+      timeout: false,
+      retry: {
+        statusCodes: [429],
+        limit: RetryBackoffConfig.MaxAttempts,
+        backoffLimit: RetryBackoffConfig.MaxDelayMs,
+        delay: attemptCount => 2 ** (attemptCount - 1) * 1000,
+        jitter: true,
+      },
+      hooks: {
+        beforeRetry: [
+          async ({ request, error, retryCount }) => {
+            console.warn(
+              `Request to ${request.url} failed with ${error}. Retrying (${retryCount}/${RetryBackoffConfig.MaxAttempts})`,
+            )
+            // Drain the response body before retrying so we don't leak unconsumed
+            // response bodies (see the comment on `failedResponseBody` below).
+            if (isHTTPError(error)) await failedResponseBody(error.response)
+          },
+        ],
+      },
+    })
+
     this.apiKey = apiKey
     this.apiOrigin = apiOrigin
   }
@@ -35,14 +65,12 @@ export class MakeswiftRestAPIClient {
 
     if (!response.ok) {
       const failedBody = await failedResponseBody(response)
-      if (response.status !== 404) {
-        console.error(`Failed to get swatch '${swatchId}'`, {
-          response: failedBody,
-          siteVersion,
-        })
-      }
+      if (response.status === 404) return null
 
-      return null
+      throw new RestApiClientError(`Failed to get swatch '${swatchId}'`, response, {
+        body: failedBody,
+        siteVersion,
+      })
     }
 
     const swatch = await response.json()
@@ -58,14 +86,12 @@ export class MakeswiftRestAPIClient {
 
     if (!response.ok) {
       const failedBody = await failedResponseBody(response)
-      if (response.status !== 404) {
-        console.error(`Failed to get typography '${typographyId}'`, {
-          response: failedBody,
-          siteVersion,
-        })
-      }
+      if (response.status === 404) return null
 
-      return null
+      throw new RestApiClientError(`Failed to get typography '${typographyId}'`, response, {
+        body: failedBody,
+        siteVersion,
+      })
     }
 
     const typography = await response.json()
@@ -81,14 +107,12 @@ export class MakeswiftRestAPIClient {
 
     if (!response.ok) {
       const failedBody = await failedResponseBody(response)
-      if (response.status !== 404) {
-        console.error(`Failed to get global element '${globalElementId}'`, {
-          response: failedBody,
-          siteVersion,
-        })
-      }
+      if (response.status === 404) return null
 
-      return null
+      throw new RestApiClientError(`Failed to get global element '${globalElementId}'`, response, {
+        body: failedBody,
+        siteVersion,
+      })
     }
 
     const globalElement = await response.json()
@@ -108,15 +132,13 @@ export class MakeswiftRestAPIClient {
 
     if (!response.ok) {
       const failedBody = await failedResponseBody(response)
-      if (response.status !== 404) {
-        console.error(`Failed to get localized global element '${globalElementId}'`, {
-          response: failedBody,
-          siteVersion,
-          locale,
-        })
-      }
+      if (response.status === 404) return null
 
-      return null
+      throw new RestApiClientError(
+        `Failed to get localized global element '${globalElementId}'`,
+        response,
+        { body: failedBody, siteVersion, locale },
+      )
     }
 
     const localizedGlobalElement = await response.json()
@@ -139,13 +161,14 @@ export class MakeswiftRestAPIClient {
     const response = await this.fetch(url.pathname + url.search, siteVersion)
 
     if (!response.ok) {
-      console.error(`Failed to get page pathname slice(s) for ${pageIds.join(', ')}`, {
-        response: await failedResponseBody(response),
-        siteVersion,
-        locale,
-      })
+      const failedBody = await failedResponseBody(response)
+      if (response.status === 404) return []
 
-      return []
+      throw new RestApiClientError(
+        `Failed to get page pathname slice(s) for ${pageIds.join(', ')}`,
+        response,
+        { body: failedBody, siteVersion, locale },
+      )
     }
 
     const json = await response.json()
@@ -201,13 +224,16 @@ export class MakeswiftRestAPIClient {
       })
     }
 
-    const response = await this._fetch(requestUrl.toString(), {
-      ...init,
-      headers: requestHeaders,
-      ...(siteVersion != null ? { cache: 'no-store' } : {}),
-    })
-
-    return response
+    try {
+      return await this._fetch(requestUrl.toString(), {
+        ...init,
+        headers: requestHeaders,
+        ...(siteVersion != null ? { cache: 'no-store' } : {}),
+      })
+    } catch (error) {
+      if (error instanceof HTTPError) return error.response
+      throw error
+    }
   }
 }
 
@@ -231,5 +257,20 @@ export async function failedResponseBody(response: Response): Promise<unknown> {
     }
   } catch (e) {
     return `Failed to extract response body: ${e}`
+  }
+}
+
+function responseError(response: Response): string {
+  return `${response.status} ${response.statusText}`
+}
+
+export class RestApiClientError extends Error {
+  readonly status: number
+
+  constructor(message: string, response: Response, cause: Record<string, unknown>) {
+    super(`${message}: ${responseError(response)}`, { cause })
+
+    this.name = 'RestApiClientError'
+    this.status = response.status
   }
 }

--- a/packages/runtime/src/api/types.ts
+++ b/packages/runtime/src/api/types.ts
@@ -74,4 +74,4 @@ export type APIResourceLocale<R extends APIResource | APIResourceType> = R exten
   ? string | null
   : never
 
-export type HttpFetch = (url: string | URL, init?: RequestInit) => Promise<Response>
+export type HttpFetch = (input: string | URL | Request, init?: RequestInit) => Promise<Response>

--- a/packages/runtime/src/client/index.ts
+++ b/packages/runtime/src/client/index.ts
@@ -18,7 +18,11 @@ import {
 import { CacheData } from '../api/api-resources-client'
 
 import { MakeswiftGraphQLApiClient } from '../api/graphql-api-client'
-import { MakeswiftRestAPIClient, failedResponseBody } from '../api/rest-api-client'
+import {
+  MakeswiftRestAPIClient,
+  failedResponseBody,
+  RestApiClientError,
+} from '../api/rest-api-client'
 import { type SiteVersion } from '../api/site-version'
 
 import { Descriptor as PropControllerDescriptor } from '../prop-controllers/descriptors'
@@ -142,13 +146,12 @@ export class MakeswiftClient extends MakeswiftRestAPIClient {
 
     const response = await this.fetch(`v5/pages?${queryParams.toString()}`, siteVersion)
     if (!response.ok) {
-      console.error('Failed to get pages', {
-        response: await failedResponseBody(response),
+      const body = await failedResponseBody(response)
+      throw new RestApiClientError('Failed to get pages', response, {
+        body: body,
         siteVersion,
         params,
       })
-
-      throw new Error(`Failed to get pages: ${responseError(response)}`)
     }
 
     const result = await response.json()
@@ -176,13 +179,11 @@ export class MakeswiftClient extends MakeswiftRestAPIClient {
       const failedBody = await failedResponseBody(response)
       if (response.status === 404) return null
 
-      console.error(`Failed to get page snapshot for '${pathname}'`, {
-        response: failedBody,
+      throw new RestApiClientError(`Failed to get page snapshot for '${pathname}'`, response, {
+        body: failedBody,
         siteVersion,
         locale,
       })
-
-      throw new Error(`Failed to get page snapshot for '${pathname}': ${responseError(response)}`)
     }
 
     const json = await response.json()
@@ -205,12 +206,14 @@ export class MakeswiftClient extends MakeswiftRestAPIClient {
     const response = await this.fetch(url.pathname + url.search, siteVersion)
 
     if (!response.ok) {
-      console.error(`Failed to get typographies for [${typographyIds.join(', ')}]`, {
-        response: await failedResponseBody(response),
-        siteVersion,
-      })
+      const failedBody = await failedResponseBody(response)
+      if (response.status === 404) return []
 
-      return []
+      throw new RestApiClientError(
+        `Failed to get typographies for [${typographyIds.join(', ')}]`,
+        response,
+        { body: failedBody, siteVersion },
+      )
     }
 
     const body = await response.json()
@@ -233,12 +236,13 @@ export class MakeswiftClient extends MakeswiftRestAPIClient {
     const response = await this.fetch(url.pathname + url.search, siteVersion)
 
     if (!response.ok) {
-      console.error(`Failed to get swatches for ${ids.join(', ')}`, {
-        response: await failedResponseBody(response),
+      const failedBody = await failedResponseBody(response)
+      if (response.status === 404) return []
+
+      throw new RestApiClientError(`Failed to get swatches for ${ids.join(', ')}`, response, {
+        body: failedBody,
         siteVersion,
       })
-
-      return []
     }
 
     return await response.json()
@@ -266,13 +270,11 @@ export class MakeswiftClient extends MakeswiftRestAPIClient {
       // 404 can mean the requested version has no commit (e.g., site never published)
       if (response.status === 404) return ids.map(() => null)
 
-      console.error(`Failed to get element trees for [${ids.join(', ')}]`, {
-        response: failedBody,
-        siteVersion,
-        locale,
-      })
-
-      throw new Error(`Failed to get element trees: ${responseError(response)}`)
+      throw new RestApiClientError(
+        `Failed to get element trees for [${ids.join(', ')}]`,
+        response,
+        { body: failedBody, siteVersion, locale },
+      )
     }
 
     const responseBody = await response.json()
@@ -726,13 +728,11 @@ export class MakeswiftClient extends MakeswiftRestAPIClient {
       const failedBody = await failedResponseBody(response)
       if (response.status === 404) return null
 
-      console.error(`Failed to get page snapshot for '${pathname}'`, {
-        response: failedBody,
+      throw new RestApiClientError(`Failed to get page snapshot for '${pathname}'`, response, {
+        body: failedBody,
         siteVersion,
         locale,
       })
-
-      throw new Error(`Failed to get page snapshot for '${pathname}': ${responseError(response)}`)
     }
 
     const document: MakeswiftPageDocument = await response.json()
@@ -784,13 +784,11 @@ export class MakeswiftClient extends MakeswiftRestAPIClient {
           return null
         }
 
-        console.error(`Failed to get component snapshot for '${id}':`, {
-          response: failedBody,
+        throw new RestApiClientError(`Failed to get component snapshot for '${id}'`, response, {
+          body: failedBody,
           siteVersion,
           locale,
         })
-
-        throw new Error(`Failed to get component snapshot for '${id}': ${responseError(response)}`)
       }
 
       const responseBody = await response.json()
@@ -948,14 +946,9 @@ export class MakeswiftClient extends MakeswiftRestAPIClient {
   }
 
   async readPreviewToken(token: string): Promise<PreviewTokenPayload | null> {
-    const response = await fetch(new URL('v1/preview-tokens/reads', this.apiOrigin).toString(), {
+    const response = await this.fetch('v1/preview-tokens/reads', null, {
       method: 'POST',
-      headers: {
-        'x-api-key': this.apiKey,
-        'makeswift-site-api-key': this.apiKey,
-        'makeswift-runtime-version': PACKAGE_VERSION,
-        'content-type': 'application/json',
-      },
+      headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ token }),
       cache: 'no-store',
     })
@@ -966,13 +959,15 @@ export class MakeswiftClient extends MakeswiftRestAPIClient {
         console.error(`Preview token is invalid or expired`, {
           response: failedBody,
         })
-      } else if (response.status !== 404) {
-        console.error(`Failed to verify preview token`, {
-          response: failedBody,
-        })
+
+        return null
       }
 
-      return null
+      if (response.status === 404) return null
+
+      throw new RestApiClientError(`Failed to verify preview token`, response, {
+        body: failedBody,
+      })
     }
 
     const json = await response.json()
@@ -991,12 +986,13 @@ export class MakeswiftClient extends MakeswiftRestAPIClient {
     const response = await this.fetch('v1_unstable/fonts', siteVersion)
 
     if (!response.ok) {
-      console.error('Failed to fetch fonts', {
-        response: await failedResponseBody(response),
+      const failedBody = await failedResponseBody(response)
+      if (response.status === 404) return null
+
+      throw new RestApiClientError('Failed to fetch fonts', response, {
+        body: failedBody,
         siteVersion,
       })
-
-      return null
     }
 
     const json = await response.json()
@@ -1039,8 +1035,4 @@ function getPagesQueryParams({
   if (locale != null) params.set('locale', locale)
 
   return params
-}
-
-function responseError(response: Response): string {
-  return `${response.status} ${response.statusText}`
 }

--- a/packages/runtime/src/client/tests/client.get-fonts.test.ts
+++ b/packages/runtime/src/client/tests/client.get-fonts.test.ts
@@ -1,6 +1,7 @@
 import { GetFontsAPI, MakeswiftClient } from '../../client'
 import { http, HttpResponse } from 'msw'
 
+import { type RestApiClientError } from '../../api/rest-api-client'
 import { createReactRuntime } from '../../runtimes/react/testing/react-runtime'
 
 import { server } from '../../mocks/server'
@@ -72,9 +73,9 @@ describe('getFonts', () => {
   })
 
   test.each([
-    { status: 400, label: '400' },
-    { status: 500, label: '500' },
-  ])('returns null and logs error when response is $label', async ({ status }) => {
+    { status: 400, statusText: 'Bad Request' },
+    { status: 500, statusText: 'Internal Server Error' },
+  ])('throws when response is $status', async ({ status, statusText }) => {
     // Arrange
     const client = createTestClient()
     const errorResponseBody = 'Error response body'
@@ -86,14 +87,19 @@ describe('getFonts', () => {
     )
 
     // Act
-    const result = await client.unstable_getFonts(TestWorkingSiteVersion)
+    const error = await client
+      .unstable_getFonts(TestWorkingSiteVersion)
+      .then(() => null)
+      .catch((e: RestApiClientError) => e)
 
     // Assert
-    expect(result).toBeNull()
-    expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to fetch fonts', {
-      response: errorResponseBody,
+    expect(error?.message).toBe(`Failed to fetch fonts: ${status} ${statusText}`)
+    expect(error?.status).toBe(status)
+    expect(error?.cause).toEqual({
+      body: errorResponseBody,
       siteVersion: TestWorkingSiteVersion,
     })
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
   })
 
   test('returns null and logs error on failure to parse the response', async () => {

--- a/packages/runtime/src/client/tests/client.get-page-snapshot.test.ts
+++ b/packages/runtime/src/client/tests/client.get-page-snapshot.test.ts
@@ -1,6 +1,7 @@
 import { MakeswiftClient, type MakeswiftPageDocument } from '../../client'
 import { http, HttpResponse } from 'msw'
 
+import { type RestApiClientError } from '../../api/rest-api-client'
 import { createReactRuntime } from '../../runtimes/react/testing/react-runtime'
 
 import { server } from '../../mocks/server'
@@ -154,7 +155,7 @@ describe('getPageSnapshot', () => {
     expect(consoleErrorSpy).not.toHaveBeenCalled()
   })
 
-  test('throws on errors other than 404, logs details to the console', async () => {
+  test('throws on errors other than 404, attaching the details to the error', async () => {
     // Arrange
     const client = createTestClient()
 
@@ -165,27 +166,19 @@ describe('getPageSnapshot', () => {
     )
 
     // Act
-    const resultPromise = client.getPageSnapshot(pathname, {
-      siteVersion: null,
-      locale,
-    })
-
-    try {
-      await resultPromise
-    } catch (e) {}
+    const error = await client
+      .getPageSnapshot(pathname, { siteVersion: null, locale })
+      .then(() => null)
+      .catch((e: RestApiClientError) => e)
 
     // Assert
-    await expect(resultPromise).rejects.toThrow(
+    expect(error?.message).toBe(
       "Failed to get page snapshot for 'blog/hello-world': 500 Internal Server Error",
     )
-
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      "Failed to get page snapshot for 'blog/hello-world'",
-      {
-        response: 'Internal server error',
-        siteVersion: null,
-        locale: 'es-MX',
-      },
-    )
+    expect(error?.cause).toEqual({
+      body: 'Internal server error',
+      siteVersion: null,
+      locale: 'es-MX',
+    })
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -575,6 +575,9 @@ importers:
       jwt-decode:
         specifier: ^4.0.0
         version: 4.0.0
+      ky:
+        specifier: ^1.14.3
+        version: 1.14.3
       ot-json0:
         specifier: ^1.1.0
         version: 1.1.0
@@ -6222,6 +6225,10 @@ packages:
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
+
+  ky@1.14.3:
+    resolution: {integrity: sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==}
+    engines: {node: '>=18'}
 
   language-subtag-registry@0.3.22:
     resolution: {integrity: sha512-tN0MCzyWnoz/4nHS6uxdlFWoUZT7ABptwKPQ52Ea7URk6vll88bWBVhodtnlfEuCcKWNGoc+uGbw1cwa9IKh/w==}
@@ -16181,6 +16188,8 @@ snapshots:
       json-buffer: 3.0.1
 
   kleur@3.0.3: {}
+
+  ky@1.14.3: {}
 
   language-subtag-registry@0.3.22: {}
 


### PR DESCRIPTION
Update the REST API client to throw when a non-404 error is received. The exception to this is when there's a rate limiting error (429), in which case we retry the request with a backoff policy + jitter applied.

To do this, we switch to using ky for decorating our fetch capabilities.