### PR TITLE
feat(controls): Add `resolveValueFromData` method to `ControlDefinition`

### DIFF
--- a/.changeset/twelve-pillows-allow.md
+++ b/.changeset/twelve-pillows-allow.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/controls': patch
+---
+
+Implement resolveValueFromData method on ControlDefinition

--- a/packages/controls/src/controls/checkbox/checkbox.ts
+++ b/packages/controls/src/controls/checkbox/checkbox.ts
@@ -155,7 +155,9 @@ class Definition<C extends Config> extends ControlDefinition<
     return data
   }
 
-  resolveContextValue(data: DataType<C>): ResolvedValueType<C> | undefined {
+  resolveValueFromData(
+    data: DataType<C> | undefined,
+  ): ResolvedValueType<C> | undefined {
     return this.fromData(data) ?? this.config.defaultValue
   }
 
@@ -164,7 +166,7 @@ class Definition<C extends Config> extends ControlDefinition<
   ): Resolvable<ResolvedValueType<C> | undefined> {
     return {
       name: Definition.type,
-      readStable: () => this.fromData(data) ?? this.config.defaultValue,
+      readStable: () => this.resolveValueFromData(data),
       subscribe: () => () => {},
       triggerResolve: async () => {},
     }

--- a/packages/controls/src/controls/checkbox/checkbox.ts
+++ b/packages/controls/src/controls/checkbox/checkbox.ts
@@ -155,6 +155,10 @@ class Definition<C extends Config> extends ControlDefinition<
     return data
   }
 
+  resolveContextValue(data: DataType<C>): ResolvedValueType<C> | undefined {
+    return this.fromData(data) ?? this.config.defaultValue
+  }
+
   resolveValue(
     data: DataType<C> | undefined,
   ): Resolvable<ResolvedValueType<C> | undefined> {

--- a/packages/controls/src/controls/code/code.ts
+++ b/packages/controls/src/controls/code/code.ts
@@ -170,7 +170,9 @@ class Definition<C extends Config> extends ControlDefinition<
     return data
   }
 
-  resolveContextValue(data: DataType<C>): ResolvedValueType<C> | undefined {
+  resolveValueFromData(
+    data: DataType<C> | undefined,
+  ): ResolvedValueType<C> | undefined {
     const value = this.fromData(data) ?? this.config.defaultValue
     return value === undefined ? undefined : ({ value } as ResolvedValueType<C>)
   }
@@ -178,9 +180,7 @@ class Definition<C extends Config> extends ControlDefinition<
   resolveValue(
     data: DataType<C> | undefined,
   ): Resolvable<ResolvedValueType<C> | undefined> {
-    const value = this.fromData(data) ?? this.config.defaultValue
-    const resolved =
-      value === undefined ? undefined : ({ value } as ResolvedValueType<C>)
+    const resolved = this.resolveValueFromData(data)
     return {
       name: Definition.type,
       readStable: () => resolved,

--- a/packages/controls/src/controls/code/code.ts
+++ b/packages/controls/src/controls/code/code.ts
@@ -170,6 +170,11 @@ class Definition<C extends Config> extends ControlDefinition<
     return data
   }
 
+  resolveContextValue(data: DataType<C>): ResolvedValueType<C> | undefined {
+    const value = this.fromData(data) ?? this.config.defaultValue
+    return value === undefined ? undefined : ({ value } as ResolvedValueType<C>)
+  }
+
   resolveValue(
     data: DataType<C> | undefined,
   ): Resolvable<ResolvedValueType<C> | undefined> {

--- a/packages/controls/src/controls/color/color.ts
+++ b/packages/controls/src/controls/color/color.ts
@@ -230,6 +230,10 @@ class Definition<C extends Config> extends ControlDefinition<
     }
   }
 
+  resolveContextValue(): ResolvedValueType<C> | undefined {
+    return undefined
+  }
+
   resolveValue(
     data: DataType<C> | undefined,
     resolver: ResourceResolver,

--- a/packages/controls/src/controls/color/color.ts
+++ b/packages/controls/src/controls/color/color.ts
@@ -230,7 +230,7 @@ class Definition<C extends Config> extends ControlDefinition<
     }
   }
 
-  resolveContextValue(): ResolvedValueType<C> | undefined {
+  resolveValueFromData(): undefined {
     return undefined
   }
 

--- a/packages/controls/src/controls/combobox/combobox.ts
+++ b/packages/controls/src/controls/combobox/combobox.ts
@@ -118,6 +118,10 @@ class Definition<C extends Config> extends ControlDefinition<
     return data
   }
 
+  resolveContextValue(data: DataType<C>): ResolvedValueType<C> | undefined {
+    return this.fromData(data)?.value
+  }
+
   resolveValue(
     data: DataType<C> | undefined,
   ): Resolvable<ResolvedValueType<C> | undefined> {

--- a/packages/controls/src/controls/combobox/combobox.ts
+++ b/packages/controls/src/controls/combobox/combobox.ts
@@ -118,7 +118,9 @@ class Definition<C extends Config> extends ControlDefinition<
     return data
   }
 
-  resolveContextValue(data: DataType<C>): ResolvedValueType<C> | undefined {
+  resolveValueFromData(
+    data: DataType<C> | undefined,
+  ): ResolvedValueType<C> | undefined {
     return this.fromData(data)?.value
   }
 
@@ -127,7 +129,7 @@ class Definition<C extends Config> extends ControlDefinition<
   ): Resolvable<ResolvedValueType<C> | undefined> {
     return {
       name: Definition.type,
-      readStable: () => this.fromData(data)?.value,
+      readStable: () => this.resolveValueFromData(data),
       subscribe: () => () => {},
       triggerResolve: async () => {},
     }

--- a/packages/controls/src/controls/definition.ts
+++ b/packages/controls/src/controls/definition.ts
@@ -77,6 +77,10 @@ export abstract class ControlDefinition<
     return null
   }
 
+  abstract resolveContextValue(
+    data: DataType | undefined,
+  ): ResolvedValueType | undefined
+
   abstract resolveValue(
     data: DataType | undefined,
     resolver: ResourceResolver,

--- a/packages/controls/src/controls/definition.ts
+++ b/packages/controls/src/controls/definition.ts
@@ -77,7 +77,7 @@ export abstract class ControlDefinition<
     return null
   }
 
-  abstract resolveContextValue(
+  abstract resolveValueFromData(
     data: DataType | undefined,
   ): ResolvedValueType | undefined
 

--- a/packages/controls/src/controls/font/font.ts
+++ b/packages/controls/src/controls/font/font.ts
@@ -244,6 +244,10 @@ class Definition<C extends Config> extends ControlDefinition<
     }
   }
 
+  resolveContextValue(data: DataType<C>): ResolvedValueType<C> | undefined {
+    return this.fromData(data) ?? this.config.defaultValue
+  }
+
   resolveValue(
     data: DataType<C> | undefined,
   ): Resolvable<ResolvedValueType<C> | undefined> {

--- a/packages/controls/src/controls/font/font.ts
+++ b/packages/controls/src/controls/font/font.ts
@@ -244,7 +244,9 @@ class Definition<C extends Config> extends ControlDefinition<
     }
   }
 
-  resolveContextValue(data: DataType<C>): ResolvedValueType<C> | undefined {
+  resolveValueFromData(
+    data: DataType<C> | undefined,
+  ): ResolvedValueType<C> | undefined {
     return this.fromData(data) ?? this.config.defaultValue
   }
 
@@ -253,7 +255,7 @@ class Definition<C extends Config> extends ControlDefinition<
   ): Resolvable<ResolvedValueType<C> | undefined> {
     return {
       name: Definition.type,
-      readStable: () => this.fromData(data) ?? this.config.defaultValue,
+      readStable: () => this.resolveValueFromData(data),
       subscribe: () => () => {},
       triggerResolve: async () => {},
     }

--- a/packages/controls/src/controls/gallery/gallery.ts
+++ b/packages/controls/src/controls/gallery/gallery.ts
@@ -130,7 +130,9 @@ class Definition<C extends Config> extends ControlDefinition<
     return data
   }
 
-  resolveContextValue(data: DataType<C>): ResolvedValueType<C> | undefined {
+  resolveValueFromData(
+    data: DataType<C> | undefined,
+  ): ResolvedValueType<C> | undefined {
     return this.fromData(data)?.value
   }
 
@@ -139,7 +141,7 @@ class Definition<C extends Config> extends ControlDefinition<
   ): Resolvable<ResolvedValueType<C> | undefined> {
     return {
       name: Definition.type,
-      readStable: () => this.fromData(data)?.value,
+      readStable: () => this.resolveValueFromData(data),
       subscribe: () => () => {},
       triggerResolve: async () => {},
     }

--- a/packages/controls/src/controls/gallery/gallery.ts
+++ b/packages/controls/src/controls/gallery/gallery.ts
@@ -130,6 +130,10 @@ class Definition<C extends Config> extends ControlDefinition<
     return data
   }
 
+  resolveContextValue(data: DataType<C>): ResolvedValueType<C> | undefined {
+    return this.fromData(data)?.value
+  }
+
   resolveValue(
     data: DataType<C> | undefined,
   ): Resolvable<ResolvedValueType<C> | undefined> {

--- a/packages/controls/src/controls/group/group.ts
+++ b/packages/controls/src/controls/group/group.ts
@@ -244,11 +244,11 @@ class Definition<C extends Config> extends ControlDefinition<
     )
   }
 
-  resolveContextValue(data: DataType<C>): ResolvedValueType<C> | undefined {
+  resolveValueFromData(data: DataType<C>): ResolvedValueType<C> | undefined {
     const propsData = data != null ? Definition.propsData(data) : undefined
 
     return mapValues(this.propDefs, (def, key) =>
-      def.resolveContextValue(propsData?.[key]),
+      def.resolveValueFromData(propsData?.[key]),
     ) as ResolvedValueType<C>
   }
 

--- a/packages/controls/src/controls/group/group.ts
+++ b/packages/controls/src/controls/group/group.ts
@@ -244,6 +244,14 @@ class Definition<C extends Config> extends ControlDefinition<
     )
   }
 
+  resolveContextValue(data: DataType<C>): ResolvedValueType<C> | undefined {
+    const propsData = data != null ? Definition.propsData(data) : undefined
+
+    return mapValues(this.propDefs, (def, key) =>
+      def.resolveContextValue(propsData?.[key]),
+    ) as ResolvedValueType<C>
+  }
+
   resolveValue(
     data: DataType<C> | undefined,
     resolver: ResourceResolver,

--- a/packages/controls/src/controls/icon-radio-group/icon-radio-group.ts
+++ b/packages/controls/src/controls/icon-radio-group/icon-radio-group.ts
@@ -161,6 +161,14 @@ class Definition<C extends Config> extends ControlDefinition<
     return data
   }
 
+  resolveContextValue(
+    data: DataType<C> | undefined,
+  ): ResolvedValueType<C> | undefined {
+    return (
+      this.fromData(data) ?? (this.config.defaultValue as ResolvedValueType<C>)
+    )
+  }
+
   resolveValue(
     data: DataType<C> | undefined,
   ): Resolvable<ResolvedValueType<C> | undefined> {

--- a/packages/controls/src/controls/icon-radio-group/icon-radio-group.ts
+++ b/packages/controls/src/controls/icon-radio-group/icon-radio-group.ts
@@ -161,7 +161,7 @@ class Definition<C extends Config> extends ControlDefinition<
     return data
   }
 
-  resolveContextValue(
+  resolveValueFromData(
     data: DataType<C> | undefined,
   ): ResolvedValueType<C> | undefined {
     return (
@@ -174,9 +174,7 @@ class Definition<C extends Config> extends ControlDefinition<
   ): Resolvable<ResolvedValueType<C> | undefined> {
     return {
       name: Definition.type,
-      readStable: () =>
-        this.fromData(data) ??
-        (this.config.defaultValue as ResolvedValueType<C>),
+      readStable: () => this.resolveValueFromData(data),
       subscribe: () => () => {},
       triggerResolve: async () => {},
     }

--- a/packages/controls/src/controls/image/image.ts
+++ b/packages/controls/src/controls/image/image.ts
@@ -285,6 +285,10 @@ class Definition<C extends Config = DefaultConfig> extends ControlDefinition<
       .otherwise((val) => val)
   }
 
+  resolveContextValue(): ResolvedValueType<C> | undefined {
+    return undefined
+  }
+
   resolveValue(
     data: DataType<C> | undefined,
     resolver: ResourceResolver,

--- a/packages/controls/src/controls/image/image.ts
+++ b/packages/controls/src/controls/image/image.ts
@@ -285,7 +285,7 @@ class Definition<C extends Config = DefaultConfig> extends ControlDefinition<
       .otherwise((val) => val)
   }
 
-  resolveContextValue(): ResolvedValueType<C> | undefined {
+  resolveValueFromData(): undefined {
     return undefined
   }
 

--- a/packages/controls/src/controls/link/link.ts
+++ b/packages/controls/src/controls/link/link.ts
@@ -173,7 +173,7 @@ class Definition<
     return data
   }
 
-  resolveContextValue(): ResolvedValueType<MouseEventType, C> | undefined {
+  resolveValueFromData(): undefined {
     return undefined
   }
 

--- a/packages/controls/src/controls/link/link.ts
+++ b/packages/controls/src/controls/link/link.ts
@@ -173,6 +173,10 @@ class Definition<
     return data
   }
 
+  resolveContextValue(): ResolvedValueType<MouseEventType, C> | undefined {
+    return undefined
+  }
+
   resolveValue(
     data: DataType<C> | undefined,
     resolver: ResourceResolver,

--- a/packages/controls/src/controls/list/list.ts
+++ b/packages/controls/src/controls/list/list.ts
@@ -176,9 +176,9 @@ class Definition<C extends Config> extends ControlDefinition<
     )
   }
 
-  resolveContextValue(data: DataType<C>): ResolvedValueType<C> | undefined {
+  resolveValueFromData(data: DataType<C>): ResolvedValueType<C> | undefined {
     const itemValues = data?.map(({ value }) =>
-      this.itemDef.resolveContextValue(value),
+      this.itemDef.resolveValueFromData(value),
     )
 
     return itemValues ?? []

--- a/packages/controls/src/controls/list/list.ts
+++ b/packages/controls/src/controls/list/list.ts
@@ -176,6 +176,14 @@ class Definition<C extends Config> extends ControlDefinition<
     )
   }
 
+  resolveContextValue(data: DataType<C>): ResolvedValueType<C> | undefined {
+    const itemValues = data?.map(({ value }) =>
+      this.itemDef.resolveContextValue(value),
+    )
+
+    return itemValues ?? []
+  }
+
   resolveValue(
     data: DataType<C> | undefined,
     resolver: ResourceResolver,

--- a/packages/controls/src/controls/number/number.ts
+++ b/packages/controls/src/controls/number/number.ts
@@ -166,6 +166,10 @@ class Definition<C extends Config> extends ControlDefinition<
     return data
   }
 
+  resolveContextValue(data: DataType<C>): ResolvedValueType<C> | undefined {
+    return this.fromData(data) ?? this.config.defaultValue
+  }
+
   resolveValue(
     data: DataType<C> | undefined,
   ): Resolvable<ResolvedValueType<C> | undefined> {

--- a/packages/controls/src/controls/number/number.ts
+++ b/packages/controls/src/controls/number/number.ts
@@ -166,7 +166,9 @@ class Definition<C extends Config> extends ControlDefinition<
     return data
   }
 
-  resolveContextValue(data: DataType<C>): ResolvedValueType<C> | undefined {
+  resolveValueFromData(
+    data: DataType<C> | undefined,
+  ): ResolvedValueType<C> | undefined {
     return this.fromData(data) ?? this.config.defaultValue
   }
 
@@ -175,7 +177,7 @@ class Definition<C extends Config> extends ControlDefinition<
   ): Resolvable<ResolvedValueType<C> | undefined> {
     return {
       name: Definition.type,
-      readStable: () => this.fromData(data) ?? this.config.defaultValue,
+      readStable: () => this.resolveValueFromData(data),
       subscribe: () => () => {},
       triggerResolve: async () => {},
     }

--- a/packages/controls/src/controls/rich-text/v1/rich-text.ts
+++ b/packages/controls/src/controls/rich-text/v1/rich-text.ts
@@ -116,6 +116,10 @@ abstract class Definition<
   static dataToSelection(data: DataType): Selection {
     return richTextDTOtoSelection(data)
   }
+
+  resolveValueFromData(): undefined {
+    return undefined
+  }
 }
 
 export type RichTextValue = DataType

--- a/packages/controls/src/controls/rich-text/v2/rich-text.ts
+++ b/packages/controls/src/controls/rich-text/v2/rich-text.ts
@@ -163,6 +163,10 @@ abstract class Definition<
       : data
   }
 
+  resolveContextValue(): undefined {
+    return undefined
+  }
+
   abstract toText(data: DataType | undefined): string
   abstract get pluginControls(): RichTextPluginControl[]
   abstract pluginControlAt(index: number): RichTextPluginControl | undefined

--- a/packages/controls/src/controls/rich-text/v2/rich-text.ts
+++ b/packages/controls/src/controls/rich-text/v2/rich-text.ts
@@ -163,7 +163,7 @@ abstract class Definition<
       : data
   }
 
-  resolveContextValue(): undefined {
+  resolveValueFromData(): undefined {
     return undefined
   }
 

--- a/packages/controls/src/controls/select/select.ts
+++ b/packages/controls/src/controls/select/select.ts
@@ -144,7 +144,7 @@ class Definition<C extends Config> extends ControlDefinition<
     return data
   }
 
-  resolveContextValue(
+  resolveValueFromData(
     data: DataType<C> | undefined,
   ): ResolvedValueType<C> | undefined {
     return (
@@ -157,9 +157,7 @@ class Definition<C extends Config> extends ControlDefinition<
   ): Resolvable<ResolvedValueType<C> | undefined> {
     return {
       name: Definition.type,
-      readStable: () =>
-        this.fromData(data) ??
-        (this.config.defaultValue as ResolvedValueType<C>),
+      readStable: () => this.resolveValueFromData(data),
       subscribe: () => () => {},
       triggerResolve: async () => {},
     }

--- a/packages/controls/src/controls/select/select.ts
+++ b/packages/controls/src/controls/select/select.ts
@@ -144,6 +144,14 @@ class Definition<C extends Config> extends ControlDefinition<
     return data
   }
 
+  resolveContextValue(
+    data: DataType<C> | undefined,
+  ): ResolvedValueType<C> | undefined {
+    return (
+      this.fromData(data) ?? (this.config.defaultValue as ResolvedValueType<C>)
+    )
+  }
+
   resolveValue(
     data: DataType<C> | undefined,
   ): Resolvable<ResolvedValueType<C> | undefined> {

--- a/packages/controls/src/controls/shape/v1/shape.ts
+++ b/packages/controls/src/controls/shape/v1/shape.ts
@@ -157,6 +157,14 @@ class Definition<C extends Config> extends ControlDefinition<
     })
   }
 
+  resolveContextValue(
+    data: DataType<C> | undefined,
+  ): ResolvedValueType<C> | undefined {
+    return mapValues(this.keyDefs, (def, key) =>
+      def.resolveContextValue(data?.[key]),
+    ) as ResolvedValueType<C>
+  }
+
   resolveValue(
     data: DataType<C> | undefined,
     resolver: ResourceResolver,

--- a/packages/controls/src/controls/shape/v1/shape.ts
+++ b/packages/controls/src/controls/shape/v1/shape.ts
@@ -157,11 +157,11 @@ class Definition<C extends Config> extends ControlDefinition<
     })
   }
 
-  resolveContextValue(
+  resolveValueFromData(
     data: DataType<C> | undefined,
   ): ResolvedValueType<C> | undefined {
     return mapValues(this.keyDefs, (def, key) =>
-      def.resolveContextValue(data?.[key]),
+      def.resolveValueFromData(data?.[key]),
     ) as ResolvedValueType<C>
   }
 

--- a/packages/controls/src/controls/slider/slider.ts
+++ b/packages/controls/src/controls/slider/slider.ts
@@ -168,7 +168,7 @@ class Definition<C extends Config> extends ControlDefinition<
     return data
   }
 
-  resolveContextValue(
+  resolveValueFromData(
     data: DataType<C> | undefined,
   ): ResolvedValueType<C> | undefined {
     return this.fromData(data) ?? this.config.defaultValue
@@ -179,7 +179,7 @@ class Definition<C extends Config> extends ControlDefinition<
   ): Resolvable<ResolvedValueType<C> | undefined> {
     return {
       name: Definition.type,
-      readStable: () => this.fromData(data) ?? this.config.defaultValue,
+      readStable: () => this.resolveValueFromData(data),
       subscribe: () => () => {},
       triggerResolve: async () => {},
     }

--- a/packages/controls/src/controls/slider/slider.ts
+++ b/packages/controls/src/controls/slider/slider.ts
@@ -168,6 +168,12 @@ class Definition<C extends Config> extends ControlDefinition<
     return data
   }
 
+  resolveContextValue(
+    data: DataType<C> | undefined,
+  ): ResolvedValueType<C> | undefined {
+    return this.fromData(data) ?? this.config.defaultValue
+  }
+
   resolveValue(
     data: DataType<C> | undefined,
   ): Resolvable<ResolvedValueType<C> | undefined> {

--- a/packages/controls/src/controls/slot/slot.ts
+++ b/packages/controls/src/controls/slot/slot.ts
@@ -160,6 +160,10 @@ abstract class Definition<
 
     return []
   }
+
+  resolveContextValue(): undefined {
+    return undefined
+  }
 }
 
 export { Definition as SlotDefinition }

--- a/packages/controls/src/controls/slot/slot.ts
+++ b/packages/controls/src/controls/slot/slot.ts
@@ -161,7 +161,7 @@ abstract class Definition<
     return []
   }
 
-  resolveContextValue(): undefined {
+  resolveValueFromData(): undefined {
     return undefined
   }
 }

--- a/packages/controls/src/controls/style/v1/style.ts
+++ b/packages/controls/src/controls/style/v1/style.ts
@@ -166,6 +166,10 @@ class Definition<C extends Config> extends ControlDefinition<
     }
   }
 
+  resolveContextValue(): ResolvedValueType<C> | undefined {
+    return undefined
+  }
+
   resolveValue(
     data: DataType<C> | undefined,
     resolver: ResourceResolver,

--- a/packages/controls/src/controls/style/v1/style.ts
+++ b/packages/controls/src/controls/style/v1/style.ts
@@ -166,7 +166,7 @@ class Definition<C extends Config> extends ControlDefinition<
     }
   }
 
-  resolveContextValue(): ResolvedValueType<C> | undefined {
+  resolveValueFromData(): undefined {
     return undefined
   }
 

--- a/packages/controls/src/controls/style/v2/style-v2.ts
+++ b/packages/controls/src/controls/style/v2/style-v2.ts
@@ -136,7 +136,7 @@ class Definition<
     )
   }
 
-  resolveContextValue(): string | undefined {
+  resolveValueFromData(): undefined {
     return undefined
   }
 

--- a/packages/controls/src/controls/style/v2/style-v2.ts
+++ b/packages/controls/src/controls/style/v2/style-v2.ts
@@ -136,6 +136,10 @@ class Definition<
     )
   }
 
+  resolveContextValue(): string | undefined {
+    return undefined
+  }
+
   resolveValue(
     data: DataType<Prop> | undefined,
     resolver: ResourceResolver,

--- a/packages/controls/src/controls/text-area/text-area.ts
+++ b/packages/controls/src/controls/text-area/text-area.ts
@@ -169,7 +169,7 @@ class Definition<C extends Config> extends ControlDefinition<
     return data
   }
 
-  resolveContextValue(
+  resolveValueFromData(
     data: DataType<C> | undefined,
   ): ResolvedValueType<C> | undefined {
     return this.fromData(data) ?? this.config.defaultValue
@@ -180,7 +180,7 @@ class Definition<C extends Config> extends ControlDefinition<
   ): Resolvable<ResolvedValueType<C> | undefined> {
     return {
       name: Definition.type,
-      readStable: () => this.fromData(data) ?? this.config.defaultValue,
+      readStable: () => this.resolveValueFromData(data),
       subscribe: () => () => {},
       triggerResolve: async () => {},
     }

--- a/packages/controls/src/controls/text-area/text-area.ts
+++ b/packages/controls/src/controls/text-area/text-area.ts
@@ -169,6 +169,12 @@ class Definition<C extends Config> extends ControlDefinition<
     return data
   }
 
+  resolveContextValue(
+    data: DataType<C> | undefined,
+  ): ResolvedValueType<C> | undefined {
+    return this.fromData(data) ?? this.config.defaultValue
+  }
+
   resolveValue(
     data: DataType<C> | undefined,
   ): Resolvable<ResolvedValueType<C> | undefined> {

--- a/packages/controls/src/controls/text-input/text-input.ts
+++ b/packages/controls/src/controls/text-input/text-input.ts
@@ -169,7 +169,7 @@ class Definition<C extends Config> extends ControlDefinition<
     return data
   }
 
-  resolveContextValue(
+  resolveValueFromData(
     data: DataType<C> | undefined,
   ): ResolvedValueType<C> | undefined {
     return this.fromData(data) ?? this.config.defaultValue
@@ -180,7 +180,7 @@ class Definition<C extends Config> extends ControlDefinition<
   ): Resolvable<ResolvedValueType<C> | undefined> {
     return {
       name: Definition.type,
-      readStable: () => this.fromData(data) ?? this.config.defaultValue,
+      readStable: () => this.resolveValueFromData(data),
       subscribe: () => () => {},
       triggerResolve: async () => {},
     }

--- a/packages/controls/src/controls/text-input/text-input.ts
+++ b/packages/controls/src/controls/text-input/text-input.ts
@@ -169,6 +169,12 @@ class Definition<C extends Config> extends ControlDefinition<
     return data
   }
 
+  resolveContextValue(
+    data: DataType<C> | undefined,
+  ): ResolvedValueType<C> | undefined {
+    return this.fromData(data) ?? this.config.defaultValue
+  }
+
   resolveValue(
     data: DataType<C> | undefined,
   ): Resolvable<ResolvedValueType<C> | undefined> {

--- a/packages/controls/src/controls/typography/typography.ts
+++ b/packages/controls/src/controls/typography/typography.ts
@@ -163,6 +163,10 @@ class Definition extends ControlDefinition<
     }
   }
 
+  resolveContextValue(): ResolvedValueType | undefined {
+    return undefined
+  }
+
   resolveValue(
     data: DataType | undefined,
     resolver: ResourceResolver,

--- a/packages/controls/src/controls/typography/typography.ts
+++ b/packages/controls/src/controls/typography/typography.ts
@@ -163,7 +163,7 @@ class Definition extends ControlDefinition<
     }
   }
 
-  resolveContextValue(): ResolvedValueType | undefined {
+  resolveValueFromData(): undefined {
     return undefined
   }
 

--- a/packages/runtime/src/controls/rich-text/rich-text.ts
+++ b/packages/runtime/src/controls/rich-text/rich-text.ts
@@ -25,7 +25,7 @@ class Definition extends BaseDefinition {
     return new (class RichTextV1 extends Definition {})()
   }
 
-  resolveContextValue(): undefined {
+  resolveValueFromData(): undefined {
     return undefined
   }
 

--- a/packages/runtime/src/controls/rich-text/rich-text.ts
+++ b/packages/runtime/src/controls/rich-text/rich-text.ts
@@ -25,10 +25,6 @@ class Definition extends BaseDefinition {
     return new (class RichTextV1 extends Definition {})()
   }
 
-  resolveValueFromData(): undefined {
-    return undefined
-  }
-
   resolveValue(
     data: DataType<BaseDefinition> | undefined,
     _resolver: ResourceResolver,

--- a/packages/runtime/src/controls/rich-text/rich-text.ts
+++ b/packages/runtime/src/controls/rich-text/rich-text.ts
@@ -25,6 +25,10 @@ class Definition extends BaseDefinition {
     return new (class RichTextV1 extends Definition {})()
   }
 
+  resolveContextValue(): undefined {
+    return undefined
+  }
+
   resolveValue(
     data: DataType<BaseDefinition> | undefined,
     _resolver: ResourceResolver,


### PR DESCRIPTION
In order to implement passing control values as context to other control callbacks such as `getOptions`, it must be possible to get the resolved value of controls from within the builder.

However, the existing `resolveValue` function cannot be used for two reasons:
1. It depends on a `ResourceResolver` and `Stylesheet`, using both of these for value resolution and expecting to mutate the stylesheet.
2. `resolveValue` can return values that cannot be serialized, such as React nodes. In this case, it would not be possible for the builder to pass these values to a callback within the runtime.

This PR implements a new method `resolveValueFromData` that returns the control's resolved value only if it can only be derived from the control's `DataType`

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>