### PR TITLE
fix: esm builder error for ky

### DIFF
--- a/.changeset/olive-donkeys-shave.md
+++ b/.changeset/olive-donkeys-shave.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Fix `ERR_REQUIRE_ESM` error when loading the runtime from a CJS host, due to `ky` being an ESM-only package. `ky` is now bundled into the CJS build, so `dist/cjs` no longer `require`s it.

--- a/packages/runtime/src/api/ky.ts
+++ b/packages/runtime/src/api/ky.ts
@@ -1,0 +1,12 @@
+// `ky` is an ESM-only package: it has no `require` condition in its exports map
+// and ships no CommonJS build. Because we build with `bundle: false`, importing
+// it directly would leave a bare `require('ky')` in our CommonJS output, which
+// throws `ERR_REQUIRE_ESM` on any host whose loader doesn't implement
+// `require(esm)` — older Node, or a platform that patches `Module._load` (some
+// serverless runtimes do).
+//
+// Routing every `ky` import through this module lets us bundle `ky` into the
+// CommonJS build, so the shipped `dist/cjs` output never requires it. See the
+// `ky` entry in `tsup.config.ts`.
+export { default, HTTPError, isHTTPError } from 'ky'
+export type { KyInstance } from 'ky'

--- a/packages/runtime/src/api/rest-api-client.ts
+++ b/packages/runtime/src/api/rest-api-client.ts
@@ -1,4 +1,4 @@
-import ky, { HTTPError, isHTTPError, type KyInstance } from 'ky'
+import ky, { HTTPError, isHTTPError, type KyInstance } from './ky'
 
 import {
   type GlobalElement,

--- a/packages/runtime/tsup.config.ts
+++ b/packages/runtime/tsup.config.ts
@@ -30,9 +30,23 @@ export default defineConfig(() => {
 
   const cjsOptions: Options = {
     ...commonOptions,
+    entry: [...commonOptions.entry, '!src/api/ky.ts'],
     format: 'cjs',
     outDir: 'dist/cjs',
   }
 
-  return [esmOptions, cjsOptions]
+  // `ky` is ESM-only, so a `require('ky')` left in our CommonJS output throws
+  // `ERR_REQUIRE_ESM` on hosts whose loader doesn't implement `require(esm)`.
+  // Every `ky` import goes through `src/api/ky.ts`, which we bundle for CJS,
+  // since the ESM output can import `ky` as-is.
+  const cjsKyOptions: Options = {
+    ...commonOptions,
+    entry: { 'api/ky': 'src/api/ky.ts' },
+    bundle: true,
+    noExternal: ['ky'],
+    format: 'cjs',
+    outDir: 'dist/cjs',
+  }
+
+  return [esmOptions, cjsOptions, cjsKyOptions]
 })


### PR DESCRIPTION
`ky` is ESM only. The current bundling method resulted in CJS environments attempting to execute `require`, which breaks when the loader doesn't support `require`