### PR TITLE
feat(runtime): RSC support infra

### DIFF
--- a/.changeset/dark-items-drive.md
+++ b/.changeset/dark-items-drive.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+feat: core runtime infrastructure for React Server Components support

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -97,6 +97,11 @@
       "require": "./dist/cjs/react/index.js",
       "import": "./dist/esm/react/index.js"
     },
+    "./react/server": {
+      "types": "./dist/types/react/server/index.d.ts",
+      "require": "./dist/cjs/react/server/index.js",
+      "import": "./dist/esm/react/server/index.js"
+    },
     "./react/builtins": {
       "types": "./dist/types/react/builtins/index.d.ts",
       "require": "./dist/cjs/react/builtins/index.js",

--- a/packages/runtime/react/server/package.json
+++ b/packages/runtime/react/server/package.json
@@ -1,0 +1,5 @@
+{
+  "main": "../../dist/cjs/react/server/index.js",
+  "module": "../../dist/esm/react/server/index.js",
+  "types": "../../dist/types/react/server/index.d.ts"
+}

--- a/packages/runtime/src/react/server/index.ts
+++ b/packages/runtime/src/react/server/index.ts
@@ -1,0 +1,12 @@
+export {
+  type ServerRenderContext,
+  RenderElementPayload,
+  RenderContext as MakeswiftRenderContext,
+  setRenderContext,
+  getRenderContext,
+  ServerCSSCollector,
+  ServerElement,
+  RSCElementRenderer,
+  MakeswiftComponent,
+  Slot,
+} from '../../runtimes/react/server'

--- a/packages/runtime/src/runtimes/react/components/ElementData.tsx
+++ b/packages/runtime/src/runtimes/react/components/ElementData.tsx
@@ -1,41 +1,98 @@
-import { Ref, forwardRef, memo, ReactNode } from 'react'
+import { type ReactNode, type Ref, forwardRef, memo } from 'react'
 
-import { ElementData as ReactPageElementData } from '../../../state/read-only-state'
-import { useBuiltinSuspense } from '../hooks/use-builtin-suspense'
-import { useComponent } from '../hooks/use-component'
-import { canAcceptRef } from '../utils/can-accept-ref'
+import { type ElementData as MakeswiftElementData } from '../../../state/read-only-state'
 import { FallbackComponent } from '../../../components/shared/FallbackComponent'
+
+import { EditableServerElement } from '../server/components/editable-server-element'
+import { useServerElementsCache } from '../server/components/server-elements-cache'
+
+import { useBuiltinSuspense } from '../hooks/use-builtin-suspense'
+import { useComponent, useComponentMeta } from '../hooks/use-component'
+import { useIsReadOnly } from '../hooks/use-is-read-only'
+
+import { canAcceptRef } from '../utils/can-accept-ref'
+
 import { ResolveProps } from './resolve-props'
 import { ActivityOrFallback } from './activity-with-fallback'
 
 type ElementDataProps = {
-  elementData: ReactPageElementData
+  elementData: MakeswiftElementData
 }
 
 export const ElementData = memo(
   forwardRef(function ElementData({ elementData }: ElementDataProps, ref: Ref<unknown>): ReactNode {
-    const Component = useComponent(elementData.type)
-    const builtinSuspense = useBuiltinSuspense(elementData.type)
+    const componentMeta = useComponentMeta(elementData.type)
 
-    if (Component == null) {
-      console.warn(`Unknown component '${elementData.type}'`, { elementData })
-      return <FallbackComponent ref={ref as Ref<HTMLDivElement>} text="Component not found" />
+    if (componentMeta == null) {
+      const msg = `Component metadata not found for '${elementData.type}'`
+      console.warn(msg)
+      return (
+        <FallbackComponent
+          ref={ref as Ref<HTMLDivElement>}
+          text="Component not found"
+          details={msg}
+        />
+      )
     }
 
-    const forwardRef = canAcceptRef(Component)
-
-    return (
-      <ActivityOrFallback suspenseFallback={builtinSuspense}>
-        <ResolveProps element={elementData}>
-          {props =>
-            forwardRef ? (
-              <Component {...props} key={elementData.key} ref={ref} />
-            ) : (
-              <Component {...props} key={elementData.key} />
-            )
-          }
-        </ResolveProps>
-      </ActivityOrFallback>
+    return componentMeta.server ? (
+      <ElementDataServer elementData={elementData} ref={ref} />
+    ) : (
+      <ElementDataClient elementData={elementData} ref={ref} />
     )
   }),
 )
+
+const ElementDataServer = forwardRef(function ElementDataServer(
+  { elementData }: ElementDataProps,
+  ref: Ref<unknown>,
+): ReactNode {
+  // lookup and render RSC node for the element; see the `ServerElementsCache` comment
+  const rscNode = useServerElementsCache().getElement(elementData.key)
+  const isReadOnly = useIsReadOnly()
+
+  if (isReadOnly) {
+    if (rscNode == null) {
+      console.error(
+        `React node not found for server component ${elementData.type}, element key ${elementData.key}`,
+      )
+
+      return (
+        <FallbackComponent ref={ref as Ref<HTMLDivElement>} text="Server component not found" />
+      )
+    }
+
+    return rscNode
+  }
+
+  return <EditableServerElement initialElementData={elementData}>{rscNode}</EditableServerElement>
+})
+
+const ElementDataClient = forwardRef(function ElementDataClient(
+  { elementData }: ElementDataProps,
+  ref: Ref<unknown>,
+): ReactNode {
+  const Component = useComponent(elementData.type)
+  const builtinSuspense = useBuiltinSuspense(elementData.type)
+
+  if (Component == null) {
+    console.warn(`Unknown component '${elementData.type}'`, { elementData })
+    return <FallbackComponent ref={ref as Ref<HTMLDivElement>} text="Component not found" />
+  }
+
+  const forwardRef = canAcceptRef(Component)
+
+  return (
+    <ActivityOrFallback suspenseFallback={builtinSuspense}>
+      <ResolveProps element={elementData}>
+        {props =>
+          forwardRef ? (
+            <Component {...props} key={elementData.key} ref={ref} />
+          ) : (
+            <Component {...props} key={elementData.key} />
+          )
+        }
+      </ResolveProps>
+    </ActivityOrFallback>
+  )
+})

--- a/packages/runtime/src/runtimes/react/components/framework-context.tsx
+++ b/packages/runtime/src/runtimes/react/components/framework-context.tsx
@@ -16,7 +16,9 @@ import {
 
 import { type LinkData } from '@makeswift/prop-controllers'
 
-import { type Snippet } from '../../../client'
+import { type Snippet } from '../../../client/page-snapshot'
+
+import { type RenderElementPayload } from '../server/render-element-payload'
 
 import { BaseHeadSnippet } from './page/HeadSnippet'
 
@@ -45,6 +47,10 @@ export type FrameworkContext = {
   HeadSnippet: HeadSnippet
   Image: ImageComponent
   Link: LinkComponent
+  /**
+   * Callback to render a single RSC element on the server and return the result.
+   */
+  renderRSCElement?: (args: RenderElementPayload) => Promise<ReactNode>
 }
 
 // React 19 automatically hoists metadata tags to the <head>

--- a/packages/runtime/src/runtimes/react/hooks/__tests__/use-server-element-refresh.test.tsx
+++ b/packages/runtime/src/runtimes/react/hooks/__tests__/use-server-element-refresh.test.tsx
@@ -1,0 +1,131 @@
+/** @jest-environment jsdom */
+
+import { type PropsWithChildren, type ReactNode, act } from 'react'
+import { renderHook } from '@testing-library/react'
+
+import { TestWorkingSiteVersion } from '../../../../testing/fixtures/site-version'
+import { type ElementData } from '../../../../state/read-only-state'
+
+import { FrameworkContextProvider } from '../../components/framework-context'
+import { createReactRuntime, ReactProvider } from '../../testing'
+import {
+  ServerElementsCache,
+  useServerElementsCache,
+} from '../../server/components/server-elements-cache'
+
+import { DocumentKeyContext, DocumentLocaleContext } from '../use-document-context'
+import { useServerElementRefresh } from '../use-server-element-refresh'
+
+import { createDeferred } from '../../../../utils/deferred'
+
+jest.mock('../../../../state/builder-api/proxy', () => ({
+  BuilderAPIProxy: jest.fn(() => ({
+    setup: () => () => {},
+    execute: jest.fn(),
+  })),
+}))
+
+const elementKey = 'test-element-key'
+const documentKey = 'test-document-key'
+const elementData: ElementData = { key: elementKey, type: 'TestComponent', props: {} }
+
+const createFixture = () => {
+  const runtime = createReactRuntime()
+  const renderRSCElement = jest.fn<Promise<ReactNode>, [unknown]>()
+  const initialNode = <div>Initial server render</div>
+
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <ReactProvider runtime={runtime} siteVersion={TestWorkingSiteVersion}>
+      <DocumentKeyContext.Provider value={documentKey}>
+        <DocumentLocaleContext.Provider value={null}>
+          <FrameworkContextProvider value={{ renderRSCElement }}>
+            <ServerElementsCache value={new Map([[elementKey, initialNode]])}>
+              {children}
+            </ServerElementsCache>
+          </FrameworkContextProvider>
+        </DocumentLocaleContext.Provider>
+      </DocumentKeyContext.Provider>
+    </ReactProvider>
+  )
+
+  const renderResult = renderHook(
+    () => {
+      const serverRefresh = useServerElementRefresh({ elementKey })
+      const { getElement } = useServerElementsCache()
+
+      return { serverRefresh, renderedElement: getElement(elementKey) }
+    },
+    { wrapper },
+  )
+
+  return { ...renderResult, renderRSCElement }
+}
+
+describe('useServerElementRefresh', () => {
+  test('applies each response when requests resolve in order', async () => {
+    const { result, renderRSCElement } = createFixture()
+    const firstResponse = createDeferred<ReactNode>()
+    const secondResponse = createDeferred<ReactNode>()
+
+    renderRSCElement.mockImplementationOnce(() => firstResponse.promise)
+    renderRSCElement.mockImplementationOnce(() => secondResponse.promise)
+
+    const firstRefresh = result.current.serverRefresh(elementData)
+    const secondRefresh = result.current.serverRefresh(elementData)
+
+    const firstNode = <div>First server render</div>
+    await act(async () => {
+      firstResponse.resolve(firstNode)
+      expect(await firstRefresh).toBe(true)
+    })
+
+    expect(result.current.renderedElement).toBe(firstNode)
+
+    const secondNode = <div>Second server render</div>
+    await act(async () => {
+      secondResponse.resolve(secondNode)
+      expect(await secondRefresh).toBe(true)
+    })
+
+    expect(result.current.renderedElement).toBe(secondNode)
+  })
+
+  test('ignores an older response that resolves after a newer response', async () => {
+    const { result, renderRSCElement } = createFixture()
+    const firstResponse = createDeferred<ReactNode>()
+    const secondResponse = createDeferred<ReactNode>()
+
+    renderRSCElement.mockImplementationOnce(() => firstResponse.promise)
+    renderRSCElement.mockImplementationOnce(() => secondResponse.promise)
+
+    const firstRefresh = result.current.serverRefresh(elementData)
+    const secondRefresh = result.current.serverRefresh(elementData)
+
+    const secondNode = <div>Second server render</div>
+    await act(async () => {
+      secondResponse.resolve(secondNode)
+      expect(await secondRefresh).toBe(true)
+    })
+
+    const firstNode = <div>First server render</div>
+    await act(async () => {
+      firstResponse.resolve(firstNode)
+      expect(await firstRefresh).toBe(false)
+    })
+
+    expect(result.current.renderedElement).toBe(secondNode)
+  })
+
+  test('ignores a response that resolves after unmount', async () => {
+    const { result, renderRSCElement, unmount } = createFixture()
+    const pending = createDeferred<ReactNode>()
+
+    renderRSCElement.mockImplementationOnce(() => pending.promise)
+    const refresh = result.current.serverRefresh(elementData)
+
+    unmount()
+    pending.resolve(<div>Late server render</div>)
+
+    await expect(refresh).resolves.toBe(false)
+  })
+})

--- a/packages/runtime/src/runtimes/react/hooks/use-editable-element-stylesheet-factory.tsx
+++ b/packages/runtime/src/runtimes/react/hooks/use-editable-element-stylesheet-factory.tsx
@@ -1,0 +1,40 @@
+import { useMemo } from 'react'
+
+import { StylesheetEngine } from '../server/css/css-runtime'
+import { useClientCSS } from '../server/css/client-css'
+
+import { type StylesheetFactory } from '../stylesheet-factory'
+
+import { useBreakpoints } from './use-breakpoints'
+
+export const useEditableElementStylesheetFactory = ({
+  elementKey: baseElementKey,
+}: {
+  elementKey: string
+}): StylesheetFactory => {
+  const { updateStyle } = useClientCSS()
+  const breakpoints = useBreakpoints()
+
+  const stylesheetEngine = useMemo(
+    () =>
+      new StylesheetEngine(
+        breakpoints,
+        baseElementKey,
+        undefined,
+        (_className, css, elementKey, propName) => {
+          if (elementKey && propName) updateStyle(elementKey, propName, css)
+        },
+      ),
+    [breakpoints, baseElementKey, updateStyle],
+  )
+
+  return useMemo(
+    () => ({
+      get: (propName: string) => stylesheetEngine.child(propName),
+      useDefinedStyles: () => {
+        // No-op, the styles are updated as they are defined
+      },
+    }),
+    [stylesheetEngine],
+  )
+}

--- a/packages/runtime/src/runtimes/react/hooks/use-resolved-props.ts
+++ b/packages/runtime/src/runtimes/react/hooks/use-resolved-props.ts
@@ -20,6 +20,9 @@ type CacheItem = {
   resolvedValue: Resolvable<unknown>
 }
 
+/**
+ * Client-side prop resolution. See `resolveProps` for server-side counterpart.
+ */
 export function useResolvedProps({
   elementKey,
   propDefs,

--- a/packages/runtime/src/runtimes/react/hooks/use-server-element-refresh.tsx
+++ b/packages/runtime/src/runtimes/react/hooks/use-server-element-refresh.tsx
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useRef } from 'react'
+
+import { type ElementData } from '../../../state/read-only-state'
+
+import { useFrameworkContext } from '../components/hooks/use-framework-context'
+import { useServerElementsCache } from '../server/components/server-elements-cache'
+
+import { useDocumentKey, useDocumentLocale } from './use-document-context'
+import { useApiResourcesClient } from './use-api-resources-client'
+
+/**
+ * Returns a element-scoped callback that renders the provided element data on
+ * the server and stores the result in the server element cache under the
+ * provided element key.
+ *
+ * The callback returns true only if the element render succeeds and is committed
+ * to the cache. Returns false when rendering is unavailable, fails, or produces a
+ * stale/out-of-order result.
+ */
+export const useServerElementRefresh = ({
+  elementKey,
+}: {
+  elementKey: string
+}): ((elementData: ElementData) => Promise<boolean>) => {
+  const requestIdRef = useRef(0)
+  const lastAppliedRequestId = useRef(0)
+
+  const { renderRSCElement } = useFrameworkContext()
+  const { updateElement } = useServerElementsCache()
+
+  const documentKey = useDocumentKey()
+  const documentLocale = useDocumentLocale()
+  const apiResourcesClient = useApiResourcesClient()
+
+  useEffect(() => {
+    // Invalidate all in-flight requests on unmount so they cannot update the cache
+    return () => {
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      lastAppliedRequestId.current = ++requestIdRef.current
+    }
+  }, [])
+
+  return useCallback(
+    async (elementData: ElementData): Promise<boolean> => {
+      if (!documentKey) return false
+      if (elementData.key !== elementKey) {
+        console.error(
+          `Cannot refresh server element: mismatching element key '${elementData.key}' != '${elementKey}'`,
+        )
+        return false
+      }
+
+      if (!renderRSCElement) {
+        console.error(
+          `Cannot refresh server element '${elementKey}' of type '${elementData.type}': \`renderRSCElement\` callback is null`,
+        )
+        return false
+      }
+
+      try {
+        // Assign each server refresh a sequential ID so we can track response
+        // arrival and ignore out-of-order results
+        const requestId = ++requestIdRef.current
+        const reactNode = await renderRSCElement({
+          elementData,
+          cacheData: apiResourcesClient.cacheData,
+          documentContext: {
+            key: documentKey,
+            locale: documentLocale ?? undefined,
+          },
+        })
+
+        if (requestId > lastAppliedRequestId.current) {
+          updateElement(elementKey, reactNode)
+          lastAppliedRequestId.current = requestId
+          return true
+        }
+      } catch (error) {
+        console.error(
+          `Failed to refresh server element '${elementKey}' of type '${elementData.type}'`,
+          error,
+        )
+      }
+
+      return false
+    },
+    [renderRSCElement, documentKey, documentLocale, elementKey, apiResourcesClient, updateElement],
+  )
+}

--- a/packages/runtime/src/runtimes/react/react-runtime-core.ts
+++ b/packages/runtime/src/runtimes/react/react-runtime-core.ts
@@ -14,8 +14,13 @@ import type { ComponentType } from '../../state/read-only-state'
 
 import { RuntimeCore } from './runtime-core'
 
-function validateComponentType(type: string, component?: ComponentType): void {
-  const componentName = component?.name ?? 'Component'
+function validateComponentType({
+  type,
+  componentName,
+}: {
+  type: string
+  componentName: string
+}): void {
   if (typeof type !== 'string' || type === '') {
     throw new Error(
       `${componentName}: A non-empty string \`type\` is required for component registration, got ${type}`,
@@ -38,6 +43,7 @@ export class ReactRuntimeCore extends RuntimeCore {
       description,
       builtinSuspense,
       unstable_migration,
+      server = false,
       props,
     }: {
       type: string
@@ -57,15 +63,25 @@ export class ReactRuntimeCore extends RuntimeCore {
        * update existing instances.
        */
       unstable_migration?: { replacementType: string }
+      server?: boolean
       props?: P
     },
   ): () => void {
-    validateComponentType(type, component as unknown as ComponentType)
+    validateComponentType(
+      // make sure we don't access `component?.name` and trigger loading of the server
+      // component unless we're running in the RSC environment
+      server && !this.isRSCEnv()
+        ? { type, componentName: label || 'Unknown server component' }
+        : {
+            type,
+            componentName: component?.name || label || 'Unknown component',
+          },
+    )
 
     const unregisterComponent = this.protoStore.dispatch(
       registerComponentEffect(
         type,
-        { label, icon, hidden, description, builtinSuspense, unstable_migration },
+        { label, icon, hidden, description, builtinSuspense, unstable_migration, server },
         props ?? {},
       ),
     )
@@ -76,6 +92,16 @@ export class ReactRuntimeCore extends RuntimeCore {
       )
     }
 
+    if (server && !this.isRSCEnv()) {
+      // we can't load server components code outside of the RSC environment, but we also
+      // don't need to: if everything is set up correctly, React has already rendered and
+      // streamed the corresponding React elements to the client for us -- see
+      // `ServerElementsCache` and `ElementDataServer`
+      return () => {
+        unregisterComponent()
+      }
+    }
+
     const unregisterReactComponent = this.protoStore.dispatch(
       registerReactComponentEffect(type, component as unknown as ComponentType),
     )
@@ -84,5 +110,9 @@ export class ReactRuntimeCore extends RuntimeCore {
       unregisterComponent()
       unregisterReactComponent()
     }
+  }
+
+  protected isRSCEnv() {
+    return false
   }
 }

--- a/packages/runtime/src/runtimes/react/resource-resolver.ts
+++ b/packages/runtime/src/runtimes/react/resource-resolver.ts
@@ -4,6 +4,8 @@ import { getElementId } from '../../state/read-only-state'
 import { ApiResourcesClient } from '../../api/api-resources-client'
 import { Store } from '../../state/store'
 
+export { type ResourceResolver } from '@makeswift/controls'
+
 export const createResourceResolver = ({
   store,
   apiClient,

--- a/packages/runtime/src/runtimes/react/server/collect-server-elements.tsx
+++ b/packages/runtime/src/runtimes/react/server/collect-server-elements.tsx
@@ -1,0 +1,79 @@
+import { type ReactNode } from 'react'
+
+import { isElementReference } from '@makeswift/controls'
+
+import { type CacheData } from '../../../api/api-resources-client'
+
+import { type Document } from '../../../state/modules/read-only-documents'
+import { getComponentsMeta } from '../../../state/modules/components-meta'
+import { traverseElementTree } from '../../../state/modules/element-trees'
+import { registerDocument } from '../../../state/shared-api'
+import { getPropControllerDescriptors } from '../../../state/read-only-state'
+
+import { ServerElement } from './components/element'
+
+import { type ServerRenderContext, getStore } from './render-context'
+import { updateApiResourceCache } from './update-api-resource-cache'
+
+export type ElementsMap = Map<string, ReactNode>
+
+/**
+ * Collects React nodes for document's server elements into a map keyed by
+ * element key.
+ *
+ * Note that this function only *creates* React elements and associates them
+ * with the corresponding Makeswift elements; it does not render anything.
+ *
+ * The actual render happens when React's server renderer walks the React tree
+ * and hits the 'use client' boundary at `<ServerElementsCache />`, at which
+ * point it needs to serialize the `value` prop into the flight stream and thus
+ * execute `ServerElement` rendering code for each entry in the map.
+ */
+export function collectServerElements(
+  context: ServerRenderContext,
+  document: Document,
+  cacheData: CacheData,
+): ElementsMap {
+  const store = getStore(context)
+  updateApiResourceCache(store, cacheData)
+
+  store.dispatch(registerDocument(document))
+
+  const state = store.getState()
+  const descriptors = getPropControllerDescriptors(state)
+
+  const result: ElementsMap = new Map()
+
+  for (const element of traverseElementTree(document.rootElement, descriptors)) {
+    if (isElementReference(element)) {
+      // TODO: Element reference support
+      continue
+    }
+
+    const meta = getComponentsMeta(state.componentsMeta).get(element.type)
+
+    if (meta == null) {
+      console.warn(`collectServerElements: Component meta not found for ${element.type}`)
+      continue
+    }
+
+    if (result.has(element.key)) {
+      console.warn(`collectServerElements: RSC node already exists for ${element.key}`)
+      continue
+    }
+
+    if (meta.server) {
+      result.set(
+        element.key,
+        <ServerElement
+          key={element.key}
+          context={context}
+          element={element}
+          documentKey={document.key}
+        />,
+      )
+    }
+  }
+
+  return result
+}

--- a/packages/runtime/src/runtimes/react/server/components/__tests__/editable-server-element.test.tsx
+++ b/packages/runtime/src/runtimes/react/server/components/__tests__/editable-server-element.test.tsx
@@ -1,0 +1,268 @@
+/** @jest-environment jsdom */
+
+import { type ReactNode, act } from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { type Operation, type ReadOnlySnapshot } from 'ot-json0'
+
+import { type ControlDefinition, type Data } from '@makeswift/controls'
+
+import { Slot, TextInput, List, Group } from '../../../../../controls'
+import { TestWorkingSiteVersion } from '../../../../../testing/fixtures/site-version'
+import { expectReadWriteState } from '../../../../../testing/read-write-state'
+import { changeDocument } from '../../../../../state/host-api'
+import { createBaseDocument, type ElementData } from '../../../../../state/read-only-state'
+import { getPropControllers, hasResolvedValueOverride } from '../../../../../state/read-write-state'
+import { registerDocument } from '../../../../../state/shared-api'
+import { setResolvedValueOverride } from '../../../../../state/actions/internal/read-write-actions'
+
+import { Document } from '../../../components/Document'
+import { FrameworkContextProvider } from '../../../components/framework-context'
+import { createReactRuntime, ReactProvider } from '../../../testing'
+import { ClientCSSProvider } from '../../css/client-css'
+
+import { ServerElementsCache } from '../server-elements-cache'
+
+jest.mock('../../../../../state/builder-api/proxy', () => ({
+  BuilderAPIProxy: jest.fn(() => ({
+    setup: () => () => {},
+    execute: jest.fn(),
+  })),
+}))
+
+const elementKey = 'test-element-key'
+const documentKey = 'test-document-key'
+const componentType = 'TestComponent'
+const instanceKey = (propPath: string) => ({ elementKey, propPath })
+
+const createFixtures = async ({
+  propDefs,
+  propsData,
+  serverNode = <div>Initial server render</div>,
+}: {
+  propDefs: Record<string, ControlDefinition>
+  propsData: Record<string, Data>
+  serverNode?: ReactNode
+}) => {
+  const runtime = createReactRuntime({ env: 'rsc' })
+  runtime.registerComponent(() => null, {
+    type: componentType,
+    label: 'Test server component',
+    server: true,
+    props: propDefs,
+  })
+
+  const store = runtime.getOrCreateStore({
+    siteVersion: TestWorkingSiteVersion,
+    locale: undefined,
+  })
+
+  const initialElementData: ElementData = {
+    key: elementKey,
+    type: componentType,
+    props: propsData,
+  }
+
+  const document = createBaseDocument(documentKey, initialElementData, null)
+  store.dispatch(registerDocument(document))
+
+  const renderRSCElement = jest.fn<Promise<ReactNode>, [unknown]>()
+
+  render(
+    <ReactProvider runtime={runtime} siteVersion={TestWorkingSiteVersion}>
+      <FrameworkContextProvider value={{ renderRSCElement }}>
+        <ServerElementsCache value={new Map([[elementKey, serverNode]])}>
+          <ClientCSSProvider>
+            <Document document={document} />
+          </ClientCSSProvider>
+        </ServerElementsCache>
+      </FrameworkContextProvider>
+    </ReactProvider>,
+  )
+
+  await waitFor(() => {
+    const state = store.getState()
+    expectReadWriteState(state)
+    expect(getPropControllers(state, { documentKey, elementKey })).not.toBeNull()
+  })
+
+  return { renderRSCElement, store }
+}
+
+const updateProp = (propName: string, oldValue: Data, newValue: Data): Operation => [
+  { p: ['props', propName], od: oldValue as ReadOnlySnapshot, oi: newValue as ReadOnlySnapshot },
+]
+
+describe('EditableServerElement', () => {
+  test('existing ReactNode prop is updated through a client override', async () => {
+    const initialProp = { columns: [], elements: [] }
+    const { renderRSCElement, store } = await createFixtures({
+      propDefs: { content: Slot() },
+      propsData: {
+        content: initialProp,
+      },
+    })
+
+    const updatedProp = {
+      ...initialProp,
+      elements: [{ key: '1', type: 'component', props: {} }],
+    }
+
+    act(() => {
+      store.dispatch(changeDocument(documentKey, updateProp('content', initialProp, updatedProp)))
+    })
+
+    await waitFor(() => {
+      const state = store.getState()
+      expectReadWriteState(state)
+      expect(hasResolvedValueOverride(state, documentKey, instanceKey('content'))).toBe(true)
+    })
+
+    expect(renderRSCElement).not.toHaveBeenCalled()
+  })
+
+  test('existing nested ReactNode prop is updated through a client override', async () => {
+    const group = Group({ props: { slot: Slot(), title: TextInput() } })
+    const initialProp = { slot: { columns: [], elements: [] }, title: 'Before' }
+    const initialData = group.toData(initialProp)
+
+    const { renderRSCElement, store } = await createFixtures({
+      propDefs: { content: group },
+      propsData: { content: initialData },
+    })
+
+    const updatedProp = {
+      ...initialProp,
+      slot: {
+        columns: [],
+        elements: [{ key: '1', type: 'component', props: {} }],
+      },
+    }
+
+    const updatedData = group.toData(updatedProp)
+
+    act(() => {
+      store.dispatch(changeDocument(documentKey, updateProp('content', initialData, updatedData)))
+    })
+
+    await waitFor(() => {
+      const state = store.getState()
+      expectReadWriteState(state)
+      expect(hasResolvedValueOverride(state, documentKey, instanceKey('content'))).toBe(false)
+      expect(hasResolvedValueOverride(state, documentKey, instanceKey('content.slot'))).toBe(true)
+    })
+
+    expect(renderRSCElement).not.toHaveBeenCalled()
+  })
+
+  test('a new ReactNode prop triggers a server refresh', async () => {
+    const list = List({ type: Slot() })
+    const initialProp = [{ columns: [], elements: [] }]
+    const initialData = list.toData(initialProp)
+
+    const { renderRSCElement, store } = await createFixtures({
+      propDefs: { content: list },
+      propsData: {
+        content: initialData,
+      },
+    })
+
+    renderRSCElement.mockResolvedValue(<div>Refreshed server render</div>)
+
+    const updatedProp = [...initialProp, { columns: [], elements: [] }]
+    const updatedData = list.toData(updatedProp)
+
+    act(() => {
+      store.dispatch(changeDocument(documentKey, updateProp('content', initialData, updatedData)))
+    })
+
+    await screen.findByText('Refreshed server render')
+
+    expect(renderRSCElement).toHaveBeenCalledWith(
+      expect.objectContaining({
+        elementData: { key: elementKey, type: componentType, props: { content: updatedData } },
+        documentContext: { key: documentKey, locale: undefined },
+      }),
+    )
+
+    await waitFor(() => {
+      const state = store.getState()
+      expectReadWriteState(state)
+      expect(hasResolvedValueOverride(state, documentKey, instanceKey('title'))).toBe(false)
+    })
+  })
+
+  test('refreshes the server element when a non-ReactNode prop changes', async () => {
+    const { renderRSCElement, store } = await createFixtures({
+      propDefs: { title: TextInput() },
+      propsData: { title: 'Before' },
+    })
+
+    renderRSCElement.mockResolvedValue(<div>Refreshed server render</div>)
+
+    act(() => {
+      store.dispatch(
+        setResolvedValueOverride({
+          documentKey,
+          instanceKey: instanceKey('title'),
+          value: 'stale override',
+        }),
+      )
+
+      store.dispatch(changeDocument(documentKey, updateProp('title', 'Before', 'After')))
+    })
+
+    await screen.findByText('Refreshed server render')
+
+    expect(renderRSCElement).toHaveBeenCalledWith(
+      expect.objectContaining({
+        elementData: { key: elementKey, type: componentType, props: { title: 'After' } },
+        documentContext: { key: documentKey, locale: undefined },
+      }),
+    )
+
+    await waitFor(() => {
+      const state = store.getState()
+      expectReadWriteState(state)
+      expect(hasResolvedValueOverride(state, documentKey, instanceKey('title'))).toBe(false)
+    })
+  })
+
+  test('refreshes the server element when a nested non-ReactNode prop changes', async () => {
+    const group = Group({ props: { slot: Slot(), title: TextInput() } })
+    const initialProp = { slot: { columns: [], elements: [] }, title: 'Before' }
+    const initialData = group.toData(initialProp)
+
+    const { renderRSCElement, store } = await createFixtures({
+      propDefs: { content: group },
+      propsData: { content: initialData },
+    })
+
+    const updatedProp = {
+      ...initialProp,
+      title: 'After',
+    }
+
+    renderRSCElement.mockResolvedValue(<div>Refreshed server render</div>)
+
+    const updatedData = group.toData(updatedProp)
+
+    act(() => {
+      store.dispatch(changeDocument(documentKey, updateProp('content', initialData, updatedData)))
+    })
+
+    await screen.findByText('Refreshed server render')
+
+    expect(renderRSCElement).toHaveBeenCalledWith(
+      expect.objectContaining({
+        elementData: { key: elementKey, type: componentType, props: { content: updatedData } },
+        documentContext: { key: documentKey, locale: undefined },
+      }),
+    )
+
+    await waitFor(() => {
+      const state = store.getState()
+      expectReadWriteState(state)
+      expect(hasResolvedValueOverride(state, documentKey, instanceKey('title'))).toBe(false)
+    })
+  })
+})

--- a/packages/runtime/src/runtimes/react/server/components/editable-server-element.tsx
+++ b/packages/runtime/src/runtimes/react/server/components/editable-server-element.tsx
@@ -1,0 +1,237 @@
+'use client'
+
+import { type PropsWithChildren, useEffect, useRef, startTransition, useCallback } from 'react'
+
+import { ControlInstance } from '@makeswift/controls'
+
+import { type ElementData } from '../../../../state/read-only-state'
+import {
+  setResolvedValueOverride,
+  clearResolvedValueOverride,
+} from '../../../../state/actions/internal/read-write-actions'
+
+import { useServerElementRefresh } from '../../hooks/use-server-element-refresh'
+import { useElementData } from '../../hooks/use-element-data'
+import { useControlDefs } from '../../hooks/use-control-defs'
+import { useEditableElementStylesheetFactory } from '../../hooks/use-editable-element-stylesheet-factory'
+import { useResolvedProps } from '../../hooks/use-resolved-props'
+import { useControlInstances } from '../../components/control-instances-context'
+import { useDispatch } from '../../hooks/use-dispatch'
+import { useDocumentKey } from '../../hooks/use-document-context'
+
+import { getProp } from '../../../../utils/prop-by-path'
+import { setUnion, setDifference } from '../../../../utils/set'
+
+export const EditableServerElement = ({
+  initialElementData,
+  children,
+}: PropsWithChildren<{ initialElementData: ElementData }>) => {
+  const elementKey = initialElementData.key
+  const elementData = useElementData({ elementKey })
+  if (elementData == null) {
+    // Element has been deleted
+    return null
+  }
+
+  return (
+    <EditableServerElementWrapper {...{ initialElementData, elementData }}>
+      {children}
+    </EditableServerElementWrapper>
+  )
+}
+
+/**
+ * Reflects edits to `elementData.props` in the server-rendered `children`.
+ * Changes limited to existing `ReactNode` props are applied through client-side
+ * overrides. Style prop changes are handled by the stylesheet engine during
+ * prop resolution. All other prop changes trigger a server refresh.
+ */
+const EditableServerElementWrapper = ({
+  initialElementData,
+  elementData,
+  children,
+}: PropsWithChildren<{ initialElementData: ElementData; elementData: ElementData }>) => {
+  const elementKey = initialElementData.key
+  const dispatch = useDispatch()
+  const documentKey = useDocumentKey()
+
+  const [_legacyDefs, definitions] = useControlDefs({ elementType: initialElementData.type })
+  const stylesheetFactory = useEditableElementStylesheetFactory({ elementKey })
+
+  const controlInstances = useControlInstances(elementKey)
+  const resolvedProps = useResolvedProps({
+    elementKey,
+    propDefs: definitions,
+    propData: elementData.props,
+    controlInstances,
+    stylesheetFactory,
+  })
+
+  const prevPropsRef = useRef(resolvedProps)
+  const prevLeafPropsRef = useRef(
+    getLeafPropsAndInstances(resolvedProps, controlInstances).leafProps,
+  )
+
+  const serverRefresh = useServerElementRefresh({ elementKey })
+  const applyServerRefresh = useCallback(
+    (elementData: ElementData, leafInstances: ControlInstance[], documentKey: string) =>
+      startTransition(async () => {
+        const applied = await serverRefresh(elementData)
+        if (!applied) return
+
+        // need a nested `startTransition` here, see
+        // https://react.dev/reference/react/useTransition#react-doesnt-treat-my-state-update-after-await-as-a-transition
+        startTransition(() => {
+          // reset instance overrides, if any
+          leafInstances.forEach(c =>
+            dispatch(clearResolvedValueOverride({ documentKey, instanceKey: c.instanceKey })),
+          )
+        })
+      }),
+    [serverRefresh, dispatch],
+  )
+
+  const applyResolvedValueOverrides = useCallback(
+    (instances: ControlInstance[], props: Record<string, unknown>, documentKey: string) =>
+      instances.forEach(c =>
+        dispatch(
+          setResolvedValueOverride({
+            documentKey,
+            instanceKey: c.instanceKey,
+            value: getProp(props, c.propPath),
+          }),
+        ),
+      ),
+    [dispatch],
+  )
+
+  useEffect(() => {
+    if (documentKey == null) return
+
+    if (children == null) {
+      // If we don't have a server-rendered node (i.e. user just dropped the element to the page),
+      // trigger a server re-render
+      const { leafInstances, leafProps } = getLeafPropsAndInstances(resolvedProps, controlInstances)
+
+      applyServerRefresh(elementData, leafInstances, documentKey)
+
+      prevPropsRef.current = resolvedProps
+      prevLeafPropsRef.current = leafProps
+      return
+    }
+
+    if (resolvedProps !== prevPropsRef.current) {
+      // If there was a change in resolved value, check if any of the changed props necessitate
+      // a server refresh.
+      //
+      // Note that style props have stable class names and updating a style prop will not result
+      // in a change to the resolved value, which is what we want. The stylesheet engine takes
+      // care of updating the client CSS on style prop updates through the `useResolvedProps` call.
+      const { needsRefresh, leafInstances, leafProps, reactNodeInstances } = needsServerRefresh({
+        resolvedProps,
+        controlInstances,
+        prevProps: prevPropsRef.current,
+        prevLeafProps: prevLeafPropsRef.current,
+      })
+
+      if (needsRefresh) {
+        applyServerRefresh(elementData, leafInstances, documentKey)
+      } else {
+        applyResolvedValueOverrides(reactNodeInstances, resolvedProps, documentKey)
+      }
+
+      prevPropsRef.current = resolvedProps
+      prevLeafPropsRef.current = leafProps
+    }
+  }, [
+    children,
+    resolvedProps,
+    documentKey,
+    elementData,
+    controlInstances,
+    applyServerRefresh,
+    applyResolvedValueOverrides,
+  ])
+
+  return children
+}
+
+/**
+ * Determines whether resolved prop changes require a server refresh and returns
+ * the control-instance state needed to apply the update.
+ */
+const needsServerRefresh = ({
+  resolvedProps,
+  controlInstances,
+  prevProps,
+  prevLeafProps,
+}: {
+  resolvedProps: Record<string, unknown>
+  controlInstances: Record<string, ControlInstance> | null
+  prevProps: Record<string, unknown>
+  prevLeafProps: Set<string>
+}): {
+  needsRefresh: boolean
+  leafInstances: ControlInstance[]
+  leafProps: Set<string>
+  reactNodeInstances: ControlInstance[]
+} => {
+  const { leafInstances, leafProps } = getLeafPropsAndInstances(resolvedProps, controlInstances)
+
+  const combinedLeafProps = setUnion(leafProps, prevLeafProps).values()
+  const updatedLeafProps = new Set(
+    [...combinedLeafProps].filter(
+      propName => getProp(resolvedProps, propName) !== getProp(prevProps, propName),
+    ),
+  )
+
+  const updatedLeafInstances = leafInstances.filter(instance =>
+    updatedLeafProps.has(instance.propPath),
+  )
+
+  const reactNodeInstances = updatedLeafInstances.filter(c => c.resolvesToRenderableNode())
+
+  const reactNodePropKeys = new Set(reactNodeInstances.map(c => c.propPath))
+  const newlyAddedLeafProps = setDifference(leafProps, prevLeafProps)
+
+  // A server refresh is needed if some of the updated props are not `ReactNode` props, or we
+  // have newly observed props (typically `List` items). Even when newly observed props are
+  // `ReactNode` props, we have to first render them on the server to get them in the element
+  // tree before they can be updated client-side.
+  const needsRefresh =
+    setDifference(updatedLeafProps, reactNodePropKeys).size > 0 || newlyAddedLeafProps.size > 0
+
+  return {
+    needsRefresh,
+    leafInstances,
+    leafProps,
+    reactNodeInstances,
+  }
+}
+
+/**
+ *  Returns terminal prop paths with the corresponding control instances.
+ */
+const getLeafPropsAndInstances = (
+  props: Record<string, unknown>,
+  controlInstances: Record<string, ControlInstance> | null,
+): {
+  leafProps: Set<string>
+  leafInstances: ControlInstance[]
+} => {
+  const topLevelInstances = Object.keys(props)
+    .map(prop => controlInstances?.[prop])
+    .filter(inst => inst != null)
+
+  const leafInstances = getLeafInstances(topLevelInstances)
+  const leafProps = new Set(leafInstances.map(c => c.propPath))
+  return { leafProps, leafInstances }
+}
+
+/**
+ * Flattens a control instance tree to its leaf (terminal) instances.
+ */
+const getLeafInstances = (instances: ControlInstance[]): ControlInstance[] =>
+  instances.flatMap(instance =>
+    instance.isCompositeProp() ? getLeafInstances(instance.children()) : [instance],
+  )

--- a/packages/runtime/src/runtimes/react/server/components/element-data.tsx
+++ b/packages/runtime/src/runtimes/react/server/components/element-data.tsx
@@ -1,0 +1,76 @@
+import { type ReactNode } from 'react'
+
+import { partitionRecord } from '../../../../utils/partition'
+
+import {
+  type State,
+  type ElementData,
+  getReactComponent,
+  getBreakpoints,
+  getComponentPropControllerDescriptors,
+} from '../../../../state/read-only-state'
+
+import { FallbackComponent } from '../../../../components/shared/FallbackComponent'
+import { isLegacyDescriptor } from '../../../../prop-controllers/descriptors'
+
+import {
+  ServerCSSCollector,
+  createCollectingServerStylesheet,
+  InjectServerCSS,
+} from '../css/server-css'
+import { type ServerRenderContext, getStore } from '../render-context'
+import { resolveProps } from '../resolve-props'
+
+export async function ServerElementData({
+  documentKey,
+  context,
+  elementData,
+}: {
+  documentKey: string
+  context: ServerRenderContext
+  elementData: ElementData
+}): Promise<ReactNode> {
+  const state = getStore(context).getState()
+
+  const Component = getReactComponent(state, elementData.type)
+  if (Component == null) {
+    return (
+      <FallbackComponent
+        text="Component not found"
+        details={`Unknown component '${elementData.type}'`}
+      />
+    )
+  }
+
+  const [legacyDescriptors, definitions] = getControlDefs(state, elementData)
+  const legacyKeys = Object.keys(legacyDescriptors)
+  if (legacyKeys.length > 0) {
+    console.warn(`Unexpected legacy control data in server element '${elementData.key}`, {
+      elementData,
+      legacyKeys,
+    })
+  }
+
+  const cssCollector = new ServerCSSCollector()
+  const stylesheet = createCollectingServerStylesheet(
+    cssCollector,
+    getBreakpoints(state),
+    elementData.key,
+  )
+
+  const props = await resolveProps(context, elementData, documentKey, definitions, stylesheet)
+
+  return (
+    <>
+      {/* Make the component the first child so that `findDOMNode` resolves to its first
+        rendered DOM node (if any) rather than the component's `<style>` element */}
+      <Component key={elementData.key} {...props} />
+      <InjectServerCSS collector={cssCollector} elementKey={elementData.key} />
+    </>
+  )
+}
+
+const getControlDefs = (state: State, elementData: ElementData) => {
+  const descriptors = getComponentPropControllerDescriptors(state, elementData.type) ?? {}
+  return partitionRecord(descriptors, isLegacyDescriptor)
+}

--- a/packages/runtime/src/runtimes/react/server/components/element.tsx
+++ b/packages/runtime/src/runtimes/react/server/components/element.tsx
@@ -1,0 +1,48 @@
+import { ReactNode } from 'react'
+
+import {
+  isElementReference,
+  getComponentsMeta,
+  type Element as ElementDataOrRef,
+} from '../../../../state/read-only-state'
+
+import { FallbackComponent } from '../../../../components/shared/FallbackComponent'
+
+import { Element as ClientElement } from '../../components/Element'
+
+import { type ServerRenderContext, getStore } from '../render-context'
+
+import { ServerElementData } from './element-data'
+
+export function ServerElement({
+  context,
+  element,
+  documentKey,
+}: {
+  context: ServerRenderContext
+  element: ElementDataOrRef
+  documentKey: string
+}): ReactNode {
+  // check for element references first to avoid looking them up as regular components
+  if (isElementReference(element)) {
+    return <FallbackComponent text="Element reference is not supported on server yet" />
+  }
+
+  const state = getStore(context).getState()
+  const elementMeta = getComponentsMeta(state).get(element.type)
+  if (elementMeta == null) {
+    return (
+      <FallbackComponent
+        text="Component not found"
+        details={`Missing component metadata for '${element.type}'`}
+      />
+    )
+  }
+
+  const isRSC = elementMeta.server ?? false
+  if (!isRSC) {
+    return <ClientElement key={element.key} element={element} />
+  }
+
+  return <ServerElementData documentKey={documentKey} context={context} elementData={element} />
+}

--- a/packages/runtime/src/runtimes/react/server/components/makeswift-component.tsx
+++ b/packages/runtime/src/runtimes/react/server/components/makeswift-component.tsx
@@ -1,0 +1,15 @@
+import { type ComponentProps } from 'react'
+
+import { MakeswiftComponent as MakeswiftClientComponent } from '../../components/MakeswiftComponent'
+
+import { RSCSnapshotRenderer } from './snapshot-renderer'
+
+/**
+ * Renders Makeswift component snapshot with server-element support. RSC counterpart of
+ * https://docs.makeswift.com/developer/docs/reference/components/makeswift-component#props
+ */
+export const MakeswiftComponent = (props: ComponentProps<typeof MakeswiftClientComponent>) => (
+  <RSCSnapshotRenderer {...props}>
+    <MakeswiftClientComponent {...props} />
+  </RSCSnapshotRenderer>
+)

--- a/packages/runtime/src/runtimes/react/server/components/renderer.tsx
+++ b/packages/runtime/src/runtimes/react/server/components/renderer.tsx
@@ -1,0 +1,47 @@
+import { type PropsWithChildren } from 'react'
+
+import { type CacheData } from '../../../../api/api-resources-client'
+import { type Document } from '../../../../state/modules/read-only-documents'
+
+import { ClientCSSProvider } from '../css/client-css'
+
+import { type ServerRenderContext, getStore } from '../render-context'
+import { collectServerElements } from '../collect-server-elements'
+import { updateApiResourceCache } from '../update-api-resource-cache'
+
+import { ServerElementsCache } from './server-elements-cache'
+
+/**
+ * Helper for rendering a Makeswift document containing server elements. Makes
+ * the server-rendered nodes available to the client renderer and enables
+ * client-side style updates for editable server elements.
+ */
+export function RSCRenderer({
+  context,
+  document,
+  cacheData,
+  children,
+}: PropsWithChildren<{ context: ServerRenderContext; document: Document; cacheData: CacheData }>) {
+  const serverElements = collectServerElements(context, document, cacheData)
+
+  return (
+    <ServerElementsCache value={serverElements}>
+      <ClientCSSProvider>{children}</ClientCSSProvider>
+    </ServerElementsCache>
+  )
+}
+
+/**
+ * Helper for (re-)rendering an isolated server element. Updates the server
+ * state with the context's API resource cache.
+ */
+export function RSCElementRenderer({
+  context,
+  cacheData,
+  children,
+}: PropsWithChildren<{ context: ServerRenderContext; cacheData: CacheData }>) {
+  const store = getStore(context)
+
+  updateApiResourceCache(store, cacheData)
+  return <>{children}</>
+}

--- a/packages/runtime/src/runtimes/react/server/components/server-elements-cache.tsx
+++ b/packages/runtime/src/runtimes/react/server/components/server-elements-cache.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { createContext, ReactNode, useCallback, useContext, useState, useMemo } from 'react'
+
+import { type ElementsMap } from '../collect-server-elements'
+
+type ContextValue = {
+  getElement: (elementKey: string) => ReactNode
+  updateElement: (elementKey: string, node: ReactNode) => void
+  removeElement: (elementKey: string) => void
+}
+
+const Context = createContext<ContextValue>({
+  getElement: () => null,
+  updateElement: () => {},
+  removeElement: () => {},
+})
+
+/**
+ * Client-side "cache" of server-rendered elements; this is one of the key pieces in our RSC
+ * implementation, with React doing the majority of the heavy lifting: when `ReactNode`s are
+ * passed as props across a 'use client' boundary, React's flight serializer automatically
+ * renders and encodes them in the RSC stream and then reconstructs them on the client. All
+ * we need to do on the client is to make these React elements available for lookup/
+ * manipulation when editing in the builder.
+ */
+export const ServerElementsCache = ({
+  children,
+  value,
+}: {
+  children: ReactNode
+  value: ElementsMap
+}) => {
+  // An RSC re-render does not inherently remount client components; React can reconcile
+  // the new server tree with the existing client tree, so we need to handle the `value`
+  // prop updates
+  const [nodes, setNodes] = useState(value)
+  const [previousValue, setPreviousValue] = useState(value)
+
+  // this is okay to do on render, see https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+  if (value !== previousValue) {
+    setPreviousValue(value)
+    setNodes(value)
+  }
+
+  const getElement = useCallback((elementKey: string): ReactNode => nodes.get(elementKey), [nodes])
+
+  const updateElement = useCallback(
+    (elementKey: string, node: ReactNode) => setNodes(prev => new Map(prev).set(elementKey, node)),
+    [],
+  )
+
+  const removeElement = useCallback(
+    (elementKey: string) =>
+      setNodes(prev => {
+        const next = new Map(prev)
+        next.delete(elementKey)
+        return next
+      }),
+    [],
+  )
+
+  const cache = useMemo(
+    () => ({ getElement, updateElement, removeElement }),
+    [getElement, updateElement, removeElement],
+  )
+
+  return <Context.Provider value={cache}>{children}</Context.Provider>
+}
+
+export const useServerElementsCache = () => useContext(Context)

--- a/packages/runtime/src/runtimes/react/server/components/slot.tsx
+++ b/packages/runtime/src/runtimes/react/server/components/slot.tsx
@@ -1,0 +1,17 @@
+import { type ComponentProps } from 'react'
+
+import { MakeswiftComponentType } from '../../../../components/builtin/constants'
+
+import { Slot as ClientSlot } from '../../components/Slot'
+
+import { RSCSnapshotRenderer } from './snapshot-renderer'
+
+/**
+ * Renders Makeswift snapshot or its fallback with server-element support. RSC
+ * counterpart of https://docs.makeswift.com/developer/docs/reference/components/slot
+ */
+export const Slot = ({ label, snapshot, fallback }: ComponentProps<typeof ClientSlot>) => (
+  <RSCSnapshotRenderer snapshot={snapshot} label={label} type={MakeswiftComponentType.Slot}>
+    <ClientSlot {...{ label, snapshot, fallback }} />
+  </RSCSnapshotRenderer>
+)

--- a/packages/runtime/src/runtimes/react/server/components/snapshot-renderer.tsx
+++ b/packages/runtime/src/runtimes/react/server/components/snapshot-renderer.tsx
@@ -1,0 +1,39 @@
+import { type ComponentProps, type PropsWithChildren } from 'react'
+
+import { componentDocumentToRootEmbeddedDocument } from '../../../../client/component-snapshot'
+import { MakeswiftComponent } from '../../components/MakeswiftComponent'
+
+import { getRenderContext } from '../render-context'
+
+import { RSCRenderer } from './renderer'
+
+/**
+ * High-level helper for rendering server versions of snapshot-backed components
+ * (`MakeswiftComponent`, `Slot`). Creates a root document from the snapshot
+ * and delegates to `RSCRenderer` to render the server elements and make them
+ * editable on the client.
+ */
+export const RSCSnapshotRenderer = ({
+  snapshot,
+  label,
+  type,
+  description,
+  children,
+}: PropsWithChildren<ComponentProps<typeof MakeswiftComponent>>) => {
+  const rootDocument = componentDocumentToRootEmbeddedDocument({
+    document: snapshot.document,
+    documentKey: snapshot.key,
+    name: label,
+    type,
+    description,
+    meta: snapshot.meta,
+  })
+
+  const context = getRenderContext()
+
+  return (
+    <RSCRenderer context={context} cacheData={snapshot.cacheData} document={rootDocument}>
+      {children}
+    </RSCRenderer>
+  )
+}

--- a/packages/runtime/src/runtimes/react/server/css/client-css.tsx
+++ b/packages/runtime/src/runtimes/react/server/css/client-css.tsx
@@ -1,0 +1,108 @@
+'use client'
+
+import { createContext, ReactNode, useContext, useEffect, useRef, useCallback } from 'react'
+
+import { MAKESWIFT_RSC_STYLE_TAG_ID_PREFIX } from './css-runtime'
+
+type ClientCSSContextValue = {
+  updateStyle: (elementKey: string, propName: string, cssString: string) => void
+}
+
+const ClientCSSContext = createContext<ClientCSSContextValue>({
+  updateStyle(elementKey: string, propName: string, cssString: string) {
+    console.error(
+      `Attempt to update client style for server component ${elementKey}'s '${propName}' prop outside of 'ClientCSSProvider'`,
+      cssString,
+    )
+  },
+})
+
+export function ClientCSSProvider({ children }: { children: ReactNode }) {
+  const styleElementsRef = useRef<Map<string, HTMLStyleElement>>(new Map())
+  const serverStylesRef = useRef<Map<string, string>>(new Map())
+  const dynamicStylesRef = useRef<Map<string, Map<string, string>>>(new Map())
+
+  const updateStyleElement = useCallback(
+    (elementKey: string, elementStyles: Map<string, string>) => {
+      const styleElement = styleElementsRef.current.get(elementKey)
+      if (styleElement == null) return
+
+      const serverCss = serverStylesRef.current.get(elementKey) ?? ''
+      const dynamicCss = Array.from(elementStyles.values()).join('\n')
+      const combinedStyles =
+        dynamicCss === serverCss ? serverCss : [serverCss, dynamicCss].filter(Boolean).join('\n')
+
+      if (styleElement.textContent !== combinedStyles) {
+        styleElement.textContent = combinedStyles
+      }
+    },
+    [],
+  )
+
+  const registerStyleElement = useCallback(
+    (styleElement: HTMLStyleElement) => {
+      const href = styleElement.dataset['href']
+      if (href == null || !href.startsWith(MAKESWIFT_RSC_STYLE_TAG_ID_PREFIX)) return
+
+      const elementKey = href.substring(MAKESWIFT_RSC_STYLE_TAG_ID_PREFIX.length)
+      if (elementKey == '') {
+        console.error('Ignoring style element with a missing element key', styleElement)
+        return
+      }
+
+      // don't recapture elements that we're already tracking
+      if (styleElement === styleElementsRef.current.get(elementKey)) return
+
+      styleElementsRef.current.set(elementKey, styleElement)
+      serverStylesRef.current.set(elementKey, styleElement.textContent)
+
+      const elementStyles = dynamicStylesRef.current.get(elementKey)
+      if (elementStyles != null) {
+        updateStyleElement(elementKey, elementStyles)
+      }
+    },
+    [updateStyleElement],
+  )
+
+  useEffect(() => {
+    // initialize style elements map and capture server styles for existing
+    // RSC-rendered elements, if any
+    document.head
+      .querySelectorAll<HTMLStyleElement>(
+        `style[data-href^="${MAKESWIFT_RSC_STYLE_TAG_ID_PREFIX}"]`,
+      )
+      .forEach(registerStyleElement)
+
+    // set up a `document.head` observer to capture dynamically added RSC `<style>` nodes
+    const observer = new MutationObserver(mutationList => {
+      for (const mutation of mutationList) {
+        for (const node of mutation.addedNodes) {
+          if (node instanceof HTMLStyleElement) registerStyleElement(node)
+        }
+      }
+    })
+
+    observer.observe(document.head, { childList: true })
+
+    return () => {
+      observer.disconnect()
+    }
+  }, [registerStyleElement])
+
+  const updateStyle = useCallback(
+    (elementKey: string, propName: string, cssString: string) => {
+      const elementStyles = dynamicStylesRef.current.get(elementKey) ?? new Map()
+      elementStyles.set(propName, cssString)
+      dynamicStylesRef.current.set(elementKey, elementStyles)
+
+      updateStyleElement(elementKey, elementStyles)
+    },
+    [updateStyleElement],
+  )
+
+  return <ClientCSSContext.Provider value={{ updateStyle }}>{children}</ClientCSSContext.Provider>
+}
+
+export function useClientCSS(): ClientCSSContextValue {
+  return useContext(ClientCSSContext)
+}

--- a/packages/runtime/src/runtimes/react/server/css/css-runtime.ts
+++ b/packages/runtime/src/runtimes/react/server/css/css-runtime.ts
@@ -1,0 +1,104 @@
+import type { CSSInterpolation, CSSObject } from '@emotion/serialize'
+import { type Breakpoints, type Stylesheet, type ResolvedStyle } from '@makeswift/controls'
+import { resolvedStyleToCss } from '../../lib/resolved-style-to-css'
+
+export const MAKESWIFT_RSC_STYLE_TAG_ID_PREFIX = 'makeswift-rsc-'
+
+function cssObjectToString(cssObject: CSSObject, className: string): string {
+  const cssRules: string[] = []
+  const mediaRules: string[] = []
+  const baseStyles: Record<string, CSSInterpolation> = {}
+
+  Object.entries(cssObject).forEach(([property, value]) => {
+    if (property.startsWith('@media')) {
+      const mediaQueryStyles = value as CSSObject
+      const mediaCSS = Object.entries(mediaQueryStyles)
+        .map(([prop, val]) => formatCSSProperty(prop, val))
+        .filter(Boolean)
+        .join(' ')
+
+      if (mediaCSS) {
+        mediaRules.push(`${property} { .${className} { ${mediaCSS} } }`)
+      }
+    } else {
+      baseStyles[property] = value
+    }
+  })
+
+  const baseCSS = Object.entries(baseStyles)
+    .map(([prop, val]) => formatCSSProperty(prop, val))
+    .filter(Boolean)
+    .join(' ')
+
+  if (baseCSS) {
+    cssRules.push(`.${className} { ${baseCSS} }`)
+  }
+
+  cssRules.push(...mediaRules)
+  return cssRules.join('\n')
+}
+
+function formatCSSProperty(property: string, value: any): string {
+  if (value == null || value === '') return ''
+
+  if (Array.isArray(value)) {
+    return value.length > 0 ? `${kebabCase(property)}: ${value.join(' ')};` : ''
+  }
+
+  return `${kebabCase(property)}: ${value};`
+}
+
+function kebabCase(str: string): string {
+  return str.replace(/[A-Z]/g, letter => `-${letter.toLowerCase()}`)
+}
+
+function generateClassName(elementKey?: string, propName?: string, counter?: number): string {
+  const parts = ['makeswift-rsc']
+  if (elementKey) parts.push(elementKey)
+  if (propName) parts.push(propName)
+  if (counter !== undefined) parts.push(counter.toString())
+  return parts.join('-')
+}
+
+type OnStyleGenerated = (
+  className: string,
+  css: string,
+  elementKey?: string,
+  propName?: string,
+) => void
+
+// Unified stylesheet engine that handles both server and client modes
+export class StylesheetEngine implements Stylesheet {
+  private styleCounter = 0
+
+  constructor(
+    private breakpointsData: Breakpoints,
+    private elementKey?: string,
+    private basePropName?: string,
+    private onStyleGenerated?: OnStyleGenerated,
+  ) {}
+
+  breakpoints(): Breakpoints {
+    return this.breakpointsData
+  }
+
+  defineStyle(style: ResolvedStyle): string {
+    const className = generateClassName(this.elementKey, this.basePropName, ++this.styleCounter)
+
+    const cssObject = resolvedStyleToCss(this.breakpointsData, style)
+    const cssString = cssObjectToString(cssObject, className)
+
+    this.onStyleGenerated?.(className, cssString, this.elementKey, this.basePropName)
+
+    return className
+  }
+
+  child(propName: string): Stylesheet {
+    return new StylesheetEngine(
+      this.breakpointsData,
+      this.elementKey,
+      [this.basePropName, propName].filter(Boolean).join('-'),
+      this.onStyleGenerated,
+    )
+  }
+}

--- a/packages/runtime/src/runtimes/react/server/css/server-css.tsx
+++ b/packages/runtime/src/runtimes/react/server/css/server-css.tsx
@@ -1,0 +1,56 @@
+import { type Breakpoints, type Stylesheet } from '@makeswift/controls'
+
+import { StylesheetEngine, MAKESWIFT_RSC_STYLE_TAG_ID_PREFIX } from './css-runtime'
+
+export class ServerCSSCollector {
+  private styles = new Map<string, string>()
+
+  collect(className: string, css: string) {
+    if (this.styles.has(className)) return
+    this.styles.set(className, css)
+  }
+
+  hasStyles(): boolean {
+    return this.styles.size > 0
+  }
+
+  getAllStyles(): string {
+    return Array.from(this.styles.values()).join('\n')
+  }
+
+  clear() {
+    this.styles.clear()
+  }
+}
+
+export function createCollectingServerStylesheet(
+  collector: ServerCSSCollector,
+  breakpoints: Breakpoints,
+  elementKey?: string,
+): Stylesheet {
+  return new StylesheetEngine(breakpoints, elementKey, undefined, (className, css) => {
+    collector.collect(className, css)
+  })
+}
+
+export function InjectServerCSS({
+  collector,
+  elementKey,
+}: {
+  collector: ServerCSSCollector
+  elementKey: string
+}) {
+  if (!collector.hasStyles()) return null
+
+  const css = collector.getAllStyles()
+  const styleTagId = `${MAKESWIFT_RSC_STYLE_TAG_ID_PREFIX}${elementKey}`
+
+  return (
+    // `precedence` and `href` props are required to opt the `<style>` element into React 19's stylesheet
+    // hoisting; `href` here serves as a unique identifier, and doesn't have to be a valid URL; React
+    // converts it to a `data-href` attribute in the actual HTML output
+    <style href={styleTagId} precedence={styleTagId}>
+      {css}
+    </style>
+  )
+}

--- a/packages/runtime/src/runtimes/react/server/index.ts
+++ b/packages/runtime/src/runtimes/react/server/index.ts
@@ -1,0 +1,12 @@
+export { ServerElement } from './components/element'
+export { MakeswiftComponent } from './components/makeswift-component'
+export { Slot } from './components/slot'
+export { RSCElementRenderer } from './components/renderer'
+export { ServerCSSCollector } from './css/server-css'
+export {
+  type ServerRenderContext,
+  RenderContext,
+  setRenderContext,
+  getRenderContext,
+} from './render-context'
+export { RenderElementPayload } from './render-element-payload'

--- a/packages/runtime/src/runtimes/react/server/render-context.tsx
+++ b/packages/runtime/src/runtimes/react/server/render-context.tsx
@@ -1,0 +1,52 @@
+import { cache, type PropsWithChildren } from 'react'
+
+import { ReactRuntime } from '../../react/react-runtime'
+import { type Store } from '../../../state/store'
+
+import { type SiteVersion } from '../../../api/site-version'
+import { MakeswiftClient } from '../../../client'
+
+/**
+ * Request-scoped dependencies used to render Makeswift server elements.
+ *
+ * Framework integrations create a context for each request and install it with
+ * `RenderContext` or `setRenderContext` so nested renderers can access it without
+ * threading it through every component. The runtime must be request-bound;
+ * together with `siteVersion` and `locale`, it selects the store and API resource
+ * cache used during rendering.
+ */
+export type ServerRenderContext = {
+  request: Request
+  runtime: ReactRuntime
+  client: MakeswiftClient
+  siteVersion: SiteVersion | null
+  locale: string | undefined
+}
+
+const requestContext = cache((): { current?: ServerRenderContext } => ({}))
+
+export const setRenderContext = (context: ServerRenderContext) => {
+  requestContext().current = context
+}
+
+export const getRenderContext = (): ServerRenderContext => {
+  const context = requestContext().current
+  if (!context) throw Error('Makeswift render context was not set.')
+  return context
+}
+
+export const getStore = ({ runtime, siteVersion, locale }: ServerRenderContext): Store => {
+  if (runtime.requestKey == null) {
+    throw Error('Expected a runtime instance that is bound to a specific request key')
+  }
+
+  return runtime.getOrCreateStore({ siteVersion, locale })
+}
+
+export const RenderContext = ({
+  context,
+  children,
+}: PropsWithChildren<{ context: ServerRenderContext }>) => {
+  setRenderContext(context)
+  return children
+}

--- a/packages/runtime/src/runtimes/react/server/render-element-payload.ts
+++ b/packages/runtime/src/runtimes/react/server/render-element-payload.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod'
+
+import { Schema } from '@makeswift/controls'
+
+import { type CacheData } from '../../../api/api-resources-client'
+
+const documentContext = z.object({
+  key: z.string(),
+  locale: z.string().optional(),
+})
+
+const cacheData = z.object({
+  apiResources: z.custom<CacheData['apiResources']>(),
+  localizedResourcesMap: z.custom<CacheData['localizedResourcesMap']>(),
+})
+
+/**
+ * Client-to-server payload for rendering a single server element
+ */
+export const RenderElementPayload = {
+  schema: z.object({
+    elementData: Schema.elementData,
+    cacheData,
+    documentContext,
+  }),
+}
+
+export type RenderElementPayload = z.infer<typeof RenderElementPayload.schema>

--- a/packages/runtime/src/runtimes/react/server/resolve-props.ts
+++ b/packages/runtime/src/runtimes/react/server/resolve-props.ts
@@ -1,0 +1,53 @@
+import { type ElementData, ControlDefinition, mapValues, Stylesheet } from '@makeswift/controls'
+
+import { type ServerRenderContext } from './render-context'
+import { serverResourceResolver } from './resource-resolver'
+
+import { propErrorHandlingProxy } from '../utils/prop-error-handling-proxy'
+
+/**
+ * Server-side counterpart of the `useResolvedProps` hook.
+ */
+export async function resolveProps(
+  context: ServerRenderContext,
+  element: ElementData,
+  documentKey: string,
+  propDefs: Record<string, ControlDefinition>,
+  stylesheet: Stylesheet,
+): Promise<Record<string, unknown>> {
+  const resourceResolver = serverResourceResolver({ ...context, documentKey })
+
+  const resolveProp = (def: ControlDefinition, propName: string) => {
+    const data = element.props[propName]
+
+    // Create a "placeholder" control instance so that controls that resolve to
+    // React nodes can use `instanceKey` to reconstruct themselves on the client
+    // (see `react/controls/slot/render-slot.tsx`).
+    const control = def.createInstance({
+      // these are top-level controls, so passing `propName` for `propPath` is appropriate
+      instanceKey: { elementKey: element.key, propPath: propName },
+      sendMessage: () => {},
+    })
+
+    return def.resolveValue(data, resourceResolver, stylesheet.child(propName), control)
+  }
+
+  const resolvables = mapValues(propDefs, (def, propName) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const defaultValue = (def.config as any)?.defaultValue
+    return propErrorHandlingProxy(resolveProp(def, propName), defaultValue, error => {
+      console.warn(
+        `Error reading value for prop "${propName}", falling back to \`${defaultValue}\`.`,
+        { control: def, error },
+      )
+    })
+  })
+
+  // wait for side-effects (resource fetching, updating list child controls)
+  await Promise.all(Object.entries(resolvables).map(([_, sub]) => sub.triggerResolve()))
+
+  return Object.entries(resolvables).reduce<Record<string, unknown>>(
+    (result, [propName, subscription]) => ({ ...result, [propName]: subscription.readStable() }),
+    {},
+  )
+}

--- a/packages/runtime/src/runtimes/react/server/resource-resolver.ts
+++ b/packages/runtime/src/runtimes/react/server/resource-resolver.ts
@@ -1,0 +1,17 @@
+import { type ResourceResolver, createResourceResolver } from '../resource-resolver'
+
+import { type ServerRenderContext, getStore } from './render-context'
+
+export function serverResourceResolver(
+  context: ServerRenderContext & { documentKey: string },
+): ResourceResolver {
+  const store = getStore(context)
+  const apiClient = store.apiResourcesClient
+
+  return createResourceResolver({
+    store,
+    apiClient,
+    documentKey: context.documentKey,
+    locale: context.locale ?? null,
+  })
+}

--- a/packages/runtime/src/runtimes/react/server/update-api-resource-cache.ts
+++ b/packages/runtime/src/runtimes/react/server/update-api-resource-cache.ts
@@ -1,0 +1,9 @@
+import { type CacheData } from '../../../api/api-resources-client'
+
+import { updateAPIClientCache } from '../../../state/actions/internal/read-write-actions'
+
+import { type Store } from '../../../state/store'
+
+export function updateApiResourceCache(store: Store, cacheData: CacheData) {
+  store.apiResourcesClient.store.dispatch(updateAPIClientCache(cacheData))
+}

--- a/packages/runtime/src/runtimes/react/testing/react-runtime.tsx
+++ b/packages/runtime/src/runtimes/react/testing/react-runtime.tsx
@@ -2,12 +2,34 @@ import { type BreakpointsInput } from '../../../state/modules/breakpoints'
 import { TestOrigins } from '../../../testing/fixtures'
 import { ReactRuntime } from '../react-runtime'
 
-export function createReactRuntime({ breakpoints }: { breakpoints?: BreakpointsInput } = {}) {
-  return new ReactRuntime({
+type RuntimeEnv = 'client' | 'ssr' | 'rsc'
+
+class TestReactRuntime extends ReactRuntime {
+  readonly env: RuntimeEnv
+
+  constructor({
+    env,
+    ...args
+  }: ConstructorParameters<typeof ReactRuntime>[0] & { env?: RuntimeEnv }) {
+    super(args)
+    this.env = env ?? 'client'
+  }
+
+  protected isRSCEnv() {
+    return this.env === 'rsc'
+  }
+}
+
+export function createReactRuntime({
+  breakpoints,
+  env,
+}: { breakpoints?: BreakpointsInput; env?: RuntimeEnv } = {}) {
+  return new TestReactRuntime({
     // Mock Service Worker patches global `fetch` for interception; make sure our test calls go
     // through the patched version instead of an eagerly captured reference to the original
     fetch: (...args) => globalThis.fetch(...args),
     breakpoints,
+    env,
     ...TestOrigins,
   })
 }

--- a/packages/runtime/src/state/modules/components-meta.ts
+++ b/packages/runtime/src/state/modules/components-meta.ts
@@ -46,6 +46,7 @@ export type ComponentMeta = {
   unstable_migration?: {
     replacementType: string
   }
+  server?: boolean
 }
 
 export type State = Map<string, ComponentMeta>

--- a/packages/runtime/src/unstable-framework-support/index.ts
+++ b/packages/runtime/src/unstable-framework-support/index.ts
@@ -28,6 +28,7 @@ export { MakeswiftComponent } from '../runtimes/react/components/MakeswiftCompon
 export { Page } from '../runtimes/react/components/page'
 export { RuntimeProvider } from '../runtimes/react/components/RuntimeProvider'
 export { Slot } from '../runtimes/react/components/Slot'
+export { RenderElementPayload } from '../runtimes/react/server/render-element-payload'
 
 export { GoogleFontLink } from '../runtimes/react/components/GoogleFontLink'
 export { MakeswiftFonts } from '../runtimes/react/components/MakeswiftFonts'

--- a/packages/runtime/src/utils/__tests__/prop-by-path.test.ts
+++ b/packages/runtime/src/utils/__tests__/prop-by-path.test.ts
@@ -1,0 +1,39 @@
+import { getProp } from '../prop-by-path'
+
+const record = {
+  a: 'apple',
+  b: {
+    c: 'carrot',
+    d: [{ e: 'eggplant' }, { e: 'elderberry' }, { f: 'fennel' }],
+    g: {
+      i: 'izote',
+      100: 'horseradish',
+    },
+  },
+  j: ['jackfruit', 'jalapeno', 'jicama'],
+}
+
+describe('getProp', () => {
+  test.each([
+    ['a', 'apple'],
+    ['b.c', 'carrot'],
+    ['b.d.e', undefined],
+    ['b.d.0.e', 'eggplant'],
+    ['b.d.1.e', 'elderberry'],
+    ['b.d.1.f', undefined],
+    ['b.d.2.f', 'fennel'],
+    ['b.d.3.f', undefined],
+    ['b.g.i', 'izote'],
+    ['b.g.100', 'horseradish'],
+    ['b.g.10', undefined],
+    ['j', ['jackfruit', 'jalapeno', 'jicama']],
+    ['j.0', 'jackfruit'],
+    ['j.1', 'jalapeno'],
+    ['j.2', 'jicama'],
+    ['j.17', undefined],
+    ['j.k', undefined],
+    ['35', undefined],
+  ])('prop path "%s" returns %s', (propPath, expected) => {
+    expect(getProp(record, propPath)).toStrictEqual(expected)
+  })
+})

--- a/packages/runtime/src/utils/prop-by-path.ts
+++ b/packages/runtime/src/utils/prop-by-path.ts
@@ -1,0 +1,10 @@
+export const getPropByPath = (
+  props: Record<string, unknown> | Array<unknown>,
+  [key, ...path]: string[],
+): unknown => {
+  const r = Array.isArray(props) ? props[Number.parseInt(key, 10)] : props[key]
+  return path.length > 0 && r != null ? getPropByPath(r as typeof props, path) : r
+}
+
+export const getProp = (props: Record<string, unknown>, path: string): unknown =>
+  getPropByPath(props, path.split('.'))

--- a/packages/runtime/src/utils/set.ts
+++ b/packages/runtime/src/utils/set.ts
@@ -1,0 +1,11 @@
+// Compatibility helpers for older browsers
+
+// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/union
+export const setUnion = <T>(a: Set<T>, b: Set<T>) =>
+  Set.prototype.union != null ? a.union(b) : new Set([...a, ...b.keys()])
+
+// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/difference
+export const setDifference = <T>(a: Set<T>, b: Set<T>) =>
+  Set.prototype.difference != null
+    ? a.difference(b)
+    : new Set([...a].filter(value => !b.has(value)))


### PR DESCRIPTION
Adds core runtime infrastructure for React Server Components support.

Pure additions; outside of minor diagnostic output, nothing in this PR changes the semantics of the existing code.

Supersedes https://github.com/makeswift/makeswift/pull/1402 which was stacked on top of a now-removed branch, which made Github lose its mind.