### PR TITLE
feat(runtime): replace file gql query with new host api get endpoint

### DIFF
--- a/.changeset/tame-donuts-cheer.md
+++ b/.changeset/tame-donuts-cheer.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+File fetching now goes through the Host API's `GET v1/files/:id` REST endpoint instead of the GraphQL `file` query.

--- a/packages/runtime/src/api/__tests__/rest-api-client.get-resources.test.ts
+++ b/packages/runtime/src/api/__tests__/rest-api-client.get-resources.test.ts
@@ -83,6 +83,51 @@ describe('getSwatch', () => {
   })
 })
 
+describe('getFile', () => {
+  const fileId = 'myFile'
+  const resourceUrl = `${TestOrigins.apiOrigin}/v1/files/${fileId}`
+
+  test('returns null on 404', async () => {
+    // Arrange
+    const client = createTestClient()
+
+    server.use(
+      http.get(resourceUrl, () => HttpResponse.text('', { status: 404 }), {
+        once: true,
+      }),
+    )
+
+    // Act
+    const result = await client.getFile(fileId)
+
+    // Assert
+    expect(result).toBeNull()
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+  })
+
+  test('throws on other errors, attaching the details to the error', async () => {
+    // Arrange
+    const client = createTestClient()
+
+    server.use(
+      http.get(resourceUrl, () => HttpResponse.json('Internal server error', { status: 500 }), {
+        once: true,
+      }),
+    )
+
+    // Act
+    const error = await captureClientError(client.getFile(fileId))
+
+    // Assert
+    expect(error.name).toBe('RestApiClientError')
+    expect(error.message).toBe("Failed to get file 'myFile': 500 Internal Server Error")
+    expect(error.status).toBe(500)
+    expect(error.cause).toEqual({
+      body: 'Internal server error',
+    })
+  })
+})
+
 describe('getTypography', () => {
   const typographyId = 'myTypography'
   const resourceUrl = `${baseUrl}/typographies/${typographyId}`

--- a/packages/runtime/src/api/graphql-api-client.ts
+++ b/packages/runtime/src/api/graphql-api-client.ts
@@ -2,7 +2,6 @@ import { GraphQLClient } from './graphql/client'
 
 import {
   CreateTableRecordMutation,
-  FileQuery,
   TableQuery,
   UnversionedResourcesQuery,
 } from './graphql/documents'
@@ -10,15 +9,13 @@ import {
 import {
   type CreateTableRecordMutationResult,
   type CreateTableRecordMutationVariables,
-  type FileQueryResult,
-  type FileQueryVariables,
   type TableQueryResult,
   type TableQueryVariables,
   type UnversionedResourcesQueryResult,
   type UnversionedResourcesQueryVariables,
 } from './graphql/generated/types'
 
-import { type File, type Table } from './types'
+import { type Table } from './types'
 
 export class MakeswiftGraphQLApiClient {
   readonly graphqlClient: GraphQLClient
@@ -44,15 +41,6 @@ export class MakeswiftGraphQLApiClient {
       UnversionedResourcesQueryResult,
       UnversionedResourcesQueryVariables
     >(UnversionedResourcesQuery, { fileIds, tableIds })
-  }
-
-  async getFile(fileId: string): Promise<File | null> {
-    const result = await this.graphqlClient.request<FileQueryResult, FileQueryVariables>(
-      FileQuery,
-      { fileId },
-    )
-
-    return result.file
   }
 
   async getTable(tableId: string): Promise<Table | null> {

--- a/packages/runtime/src/api/graphql/documents/queries.ts
+++ b/packages/runtime/src/api/graphql/documents/queries.ts
@@ -31,16 +31,6 @@ export const SwatchQuery = /* GraphQL */ `
   ${SwatchFragment}
 `
 
-export const FileQuery = /* GraphQL */ `
-  query File($fileId: ID!) {
-    file(id: $fileId) {
-      ...File
-    }
-  }
-
-  ${FileFragment}
-`
-
 export const TypographyQuery = /* GraphQL */ `
   query Typography($typographyId: ID!) {
     typography(id: $typographyId) {

--- a/packages/runtime/src/api/graphql/generated/types.ts
+++ b/packages/runtime/src/api/graphql/generated/types.ts
@@ -206,21 +206,6 @@ export type SwatchQueryResult = {
   } | null
 }
 
-export type FileQueryVariables = Exact<{
-  fileId: Scalars['ID']
-}>
-
-export type FileQueryResult = {
-  file: {
-    __typename: 'File'
-    id: string
-    name: string
-    extension: string | null
-    publicUrl: string
-    dimensions: { width: number; height: number } | null
-  } | null
-}
-
 export type TypographyQueryVariables = Exact<{
   typographyId: Scalars['ID']
 }>

--- a/packages/runtime/src/api/makeswift-api-resources-client.ts
+++ b/packages/runtime/src/api/makeswift-api-resources-client.ts
@@ -71,7 +71,7 @@ export class MakeswiftApiResourcesClient extends ApiResourcesClient {
 
   protected async fetchFileImpl(id: string, _version: SiteVersion | null): Promise<File | null> {
     // files are unversioned
-    return (await this.graphQlClient).getFile(id)
+    return (await this.restApiClient).getFile(id)
   }
 
   protected async fetchTypographyImpl(

--- a/packages/runtime/src/api/rest-api-client.ts
+++ b/packages/runtime/src/api/rest-api-client.ts
@@ -1,6 +1,7 @@
 import ky, { HTTPError, isHTTPError, type KyInstance } from './ky'
 
 import {
+  type File,
   type GlobalElement,
   type LocalizedGlobalElement,
   type PagePathnameSlice,
@@ -76,6 +77,23 @@ export class MakeswiftRestAPIClient {
     const swatch = await response.json()
 
     return swatch
+  }
+
+  async getFile(fileId: string): Promise<File | null> {
+    const response = await this.fetch(`v1/files/${fileId}`, null)
+
+    if (!response.ok) {
+      const failedBody = await failedResponseBody(response)
+      if (response.status === 404) return null
+
+      throw new RestApiClientError(`Failed to get file '${fileId}'`, response, {
+        body: failedBody,
+      })
+    }
+
+    const file = await response.json()
+
+    return file
   }
 
   async getTypography(

--- a/packages/runtime/src/client/index.ts
+++ b/packages/runtime/src/client/index.ts
@@ -7,7 +7,6 @@ import {
 
 import {
   APIResourceType,
-  type File,
   type GlobalElement,
   type LocalizedGlobalElement,
   type Swatch,
@@ -927,10 +926,6 @@ export class MakeswiftClient extends MakeswiftRestAPIClient {
         meta: { allowLocaleFallback, requestedLocale: locale ?? null },
       }
     })
-  }
-
-  async getFile(fileId: string): Promise<File | null> {
-    return this.graphqlClient.getFile(fileId)
   }
 
   async getTable(tableId: string): Promise<Table | null> {


### PR DESCRIPTION
## What?

- Swaps the runtime's server-side file-fetching from the GraphQL `file(id)` query to the new Host API REST endpoint (`GET v1/files/:id`), following the pattern already used for `swatch`, `typography`, `global-element`, `localized-global-element`, and `page-pathname-slice`. 
- Removes the now-dead `FileQuery` GraphQL code.


https://github.com/user-attachments/assets/4af51006-4364-43f7-8d1f-e63b763ceac2



## Why?

This is part of the Makeswift CDN efforts to move reads to http endpoints that can be cached. RED-3488 scoped the work to add a new host api endpoint to get files (same behavior as the `file(id)` gql query).