### PR TITLE
fix: prevent host base styles from colliding with rich text

### DIFF
--- a/.changeset/loud-timers-shake.md
+++ b/.changeset/loud-timers-shake.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+fix: host CSS targeting `span` elements no longer overrides Makeswift text styles in the builder.

--- a/packages/runtime/src/next/components/tests/controls/page-control-prop-rendering.tsx
+++ b/packages/runtime/src/next/components/tests/controls/page-control-prop-rendering.tsx
@@ -75,6 +75,27 @@ async function serverSideRender(children: ReactNode) {
   return dom.window.document
 }
 
+/**
+ * In read-write mode, the runtime opens a `MessageChannel` to the builder
+ * parent frame; jsdom doesn't implement `MessageChannel`, so stub them to keep
+ * the read-write setup from throwing.
+ */
+function stubBuilderMessageChannel(): () => void {
+  const postMessageSpy = jest.spyOn(window, 'postMessage').mockImplementation(() => {})
+
+  const originalMessageChannel = window.MessageChannel
+  const stubPort = () => ({ onmessage: null, postMessage: () => {}, close: () => {} })
+  window.MessageChannel = class {
+    port1 = stubPort()
+    port2 = stubPort()
+  } as unknown as typeof MessageChannel
+
+  return () => {
+    postMessageSpy.mockRestore()
+    window.MessageChannel = originalMessageChannel
+  }
+}
+
 export async function testPageControlPropRendering<D extends ControlDefinition>(
   controlDefinition: D,
   {
@@ -87,6 +108,7 @@ export async function testPageControlPropRendering<D extends ControlDefinition>(
     action,
     rootElements = [],
     isInBuilder = false,
+    isReadOnly = true,
   }: {
     toData?: (value: ValueType<D>) => DataType<D>
     value: ValueType<D> | undefined
@@ -97,6 +119,7 @@ export async function testPageControlPropRendering<D extends ControlDefinition>(
     action?: (element: HTMLElement) => Promise<void>
     rootElements?: ElementData[]
     isInBuilder?: boolean
+    isReadOnly?: boolean
   },
 ) {
   // Arrange
@@ -143,11 +166,20 @@ export async function testPageControlPropRendering<D extends ControlDefinition>(
     },
   )
 
-  const testElementTree = (component: ReactNode) => (
-    <Testing.ReactProvider runtime={runtime}>{component}</Testing.ReactProvider>
-  )
+  const testElementTree = (component: ReactNode) => {
+    // The runtime enters the read-write state when a non-null site version is
+    // passed
+    const siteVersion = isReadOnly ? null : { token: 'test-token', version: 'draft' }
+    return (
+      <Testing.ReactProvider runtime={runtime} siteVersion={siteVersion}>
+        {component}
+      </Testing.ReactProvider>
+    )
+  }
 
   if (!isServer()) {
+    const restoreMessageChannel = isReadOnly ? null : stubBuilderMessageChannel()
+
     const rootElementData: ElementData = Testing.createRootComponent(
       [elementData, ...rootElements],
       ROOT_ID,
@@ -170,6 +202,8 @@ export async function testPageControlPropRendering<D extends ControlDefinition>(
     if (expectedRenders != null) {
       expect(Number(screen.getByTestId(renderCountTestId).textContent)).toBe(expectedRenders)
     }
+
+    restoreMessageChannel?.()
   } else {
     // test server-side rendering using a component snapshot
     console.assert(action == null)

--- a/packages/runtime/src/next/components/tests/controls/rich-text-v2-control/__snapshots__/client.test.tsx.snap
+++ b/packages/runtime/src/next/components/tests/controls/rich-text-v2-control/__snapshots__/client.test.tsx.snap
@@ -1,5 +1,679 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`editable text reverts host styles on slate-internal text spans: resolvedValue 1`] = `
+NodeList [
+  .emotion-0 [data-slate-string],
+.emotion-0 [data-slate-zero-width] {
+  all: revert!important;
+}
+
+.emotion-1 {
+  margin: 0;
+}
+
+.emotion-1 {
+  margin: 0;
+}
+
+.emotion-4 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-4 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+@media only screen and (min-width: 769px) {
+  .emotion-5 {
+    color: hsla(238,87%,49%,1);
+    font-family: Lato;
+    font-size: 16px;
+  }
+}
+
+@media only screen and (min-width: 576px) and (max-width: 768px) {
+  .emotion-5 {
+    color: hsla(238,87%,49%,1);
+    font-family: Lato;
+    font-size: 16px;
+  }
+}
+
+@media only screen and (max-width: 575px) {
+  .emotion-5 {
+    color: hsla(238,87%,49%,1);
+    font-family: Lato;
+    font-size: 16px;
+  }
+}
+
+@media only screen and (min-width: 769px) {
+  .emotion-5 {
+    color: hsla(238,87%,49%,1);
+    font-family: Lato;
+    font-size: 16px;
+  }
+}
+
+@media only screen and (min-width: 576px) and (max-width: 768px) {
+  .emotion-5 {
+    color: hsla(238,87%,49%,1);
+    font-family: Lato;
+    font-size: 16px;
+  }
+}
+
+@media only screen and (max-width: 575px) {
+  .emotion-5 {
+    color: hsla(238,87%,49%,1);
+    font-family: Lato;
+    font-size: 16px;
+  }
+}
+
+<div
+    autocapitalize="false"
+    autocorrect="false"
+    class="emotion-0"
+    contenteditable="false"
+    data-slate-editor="true"
+    data-slate-node="value"
+    spellcheck="false"
+    style="position: relative; outline: none; white-space: pre-wrap; word-wrap: break-word;"
+    zindex="-1"
+  >
+    <p
+      class="emotion-1 emotion-2"
+      data-slate-node="element"
+    >
+      <span
+        data-slate-node="text"
+      >
+        <span
+          class="emotion-2"
+          data-slate-leaf="true"
+        >
+          <span
+            data-slate-length="0"
+            data-slate-zero-width="z"
+          >
+            ﻿
+          </span>
+        </span>
+      </span>
+      <a
+        class="emotion-4"
+        data-slate-inline="true"
+        data-slate-node="element"
+        href="https://www.bigcommerce.com/adyen"
+        target="_blank"
+      >
+        <span
+          data-slate-node="text"
+        >
+          <span
+            class="emotion-5"
+            data-slate-leaf="true"
+          >
+            <span
+              data-slate-string="true"
+            >
+              Adyen
+            </span>
+          </span>
+        </span>
+      </a>
+      <span
+        data-slate-node="text"
+      >
+        <span
+          class="emotion-2"
+          data-slate-leaf="true"
+        >
+          <span
+            data-slate-length="0"
+            data-slate-zero-width="z"
+          >
+            ﻿
+          </span>
+        </span>
+      </span>
+    </p>
+    <p
+      class="emotion-1 emotion-2"
+      data-slate-node="element"
+    >
+      <span
+        data-slate-node="text"
+      >
+        <span
+          class="emotion-2"
+          data-slate-leaf="true"
+        >
+          <span
+            data-slate-length="0"
+            data-slate-zero-width="z"
+          >
+            ﻿
+          </span>
+        </span>
+      </span>
+      <a
+        class="emotion-4"
+        data-slate-inline="true"
+        data-slate-node="element"
+        href="http://www.authorize.net/"
+        target="_blank"
+      >
+        <span
+          data-slate-node="text"
+        >
+          <span
+            class="emotion-5"
+            data-slate-leaf="true"
+          >
+            <span
+              data-slate-string="true"
+            >
+              Authorize.net
+            </span>
+          </span>
+        </span>
+      </a>
+      <span
+        data-slate-node="text"
+      >
+        <span
+          class="emotion-2"
+          data-slate-leaf="true"
+        >
+          <span
+            data-slate-length="0"
+            data-slate-zero-width="z"
+          >
+            ﻿
+          </span>
+        </span>
+      </span>
+    </p>
+    <p
+      class="emotion-1 emotion-2"
+      data-slate-node="element"
+    >
+      <span
+        data-slate-node="text"
+      >
+        <span
+          class="emotion-2"
+          data-slate-leaf="true"
+        >
+          <span
+            data-slate-length="0"
+            data-slate-zero-width="z"
+          >
+            ﻿
+          </span>
+        </span>
+      </span>
+      <a
+        class="emotion-4"
+        data-slate-inline="true"
+        data-slate-node="element"
+        href="https://www.bigcommerce.com/bluesnap/"
+        target="_blank"
+      >
+        <span
+          data-slate-node="text"
+        >
+          <span
+            class="emotion-5"
+            data-slate-leaf="true"
+          >
+            <span
+              data-slate-string="true"
+            >
+              BlueSnap
+            </span>
+          </span>
+        </span>
+      </a>
+      <span
+        data-slate-node="text"
+      >
+        <span
+          class="emotion-2"
+          data-slate-leaf="true"
+        >
+          <span
+            data-slate-length="0"
+            data-slate-zero-width="z"
+          >
+            ﻿
+          </span>
+        </span>
+      </span>
+    </p>
+    <p
+      class="emotion-1 emotion-2"
+      data-slate-node="element"
+    >
+      <span
+        data-slate-node="text"
+      >
+        <span
+          class="emotion-2"
+          data-slate-leaf="true"
+        >
+          <span
+            data-slate-length="0"
+            data-slate-zero-width="z"
+          >
+            ﻿
+          </span>
+        </span>
+      </span>
+      <a
+        class="emotion-4"
+        data-slate-inline="true"
+        data-slate-node="element"
+        href="https://support.bigcommerce.com/s/article/Connecting-with-Checkoutcom/"
+        target="_blank"
+      >
+        <span
+          data-slate-node="text"
+        >
+          <span
+            class="emotion-5"
+            data-slate-leaf="true"
+          >
+            <span
+              data-slate-string="true"
+            >
+              Checkout.com
+            </span>
+          </span>
+        </span>
+      </a>
+      <span
+        data-slate-node="text"
+      >
+        <span
+          class="emotion-2"
+          data-slate-leaf="true"
+        >
+          <span
+            data-slate-length="0"
+            data-slate-zero-width="z"
+          >
+            ﻿
+          </span>
+        </span>
+      </span>
+    </p>
+    <p
+      class="emotion-1 emotion-2"
+      data-slate-node="element"
+    >
+      <span
+        data-slate-node="text"
+      >
+        <span
+          class="emotion-2"
+          data-slate-leaf="true"
+        >
+          <span
+            data-slate-length="0"
+            data-slate-zero-width="z"
+          >
+            ﻿
+          </span>
+        </span>
+      </span>
+      <a
+        class="emotion-4"
+        data-slate-inline="true"
+        data-slate-node="element"
+        href="http://www.cybersource.com/"
+        target="_blank"
+      >
+        <span
+          data-slate-node="text"
+        >
+          <span
+            class="emotion-5"
+            data-slate-leaf="true"
+          >
+            <span
+              data-slate-string="true"
+            >
+              CyberSource Direct
+            </span>
+          </span>
+        </span>
+      </a>
+      <span
+        data-slate-node="text"
+      >
+        <span
+          class="emotion-2"
+          data-slate-leaf="true"
+        >
+          <span
+            data-slate-length="0"
+            data-slate-zero-width="z"
+          >
+            ﻿
+          </span>
+        </span>
+      </span>
+    </p>
+  </div>,
+]
+`;
+
+exports[`editable text reverts host styles on slate-internal text spans: snapshot 1`] = `
+{
+  "cacheData": {
+    "apiResources": {
+      "Swatch": [
+        {
+          "id": "U3dhdGNoOmJkODYxMWM5LTNiZjItNDM3MS1iMmU4LTBmMmNlMDZjNDE1OA==",
+          "value": {
+            "__typename": "Swatch",
+            "hue": 238,
+            "id": "U3dhdGNoOmJkODYxMWM5LTNiZjItNDM3MS1iMmU4LTBmMmNlMDZjNDE1OA==",
+            "lightness": 49,
+            "saturation": 87,
+          },
+        },
+      ],
+      "Typography": [
+        {
+          "id": "VHlwb2dyYXBoeTowNGI4OTZlMC0wZWEyLTRkMTMtYmU3ZS0xYmY1M2VmMjBiZjc=",
+          "value": {
+            "__typename": "Typography",
+            "id": "VHlwb2dyYXBoeTowNGI4OTZlMC0wZWEyLTRkMTMtYmU3ZS0xYmY1M2VmMjBiZjc=",
+            "name": "Body",
+            "style": [
+              {
+                "deviceId": "desktop",
+                "value": {
+                  "color": null,
+                  "fontFamily": "Lato",
+                  "fontSize": {
+                    "unit": "px",
+                    "value": 16,
+                  },
+                  "fontWeight": null,
+                  "italic": null,
+                  "letterSpacing": null,
+                  "lineHeight": null,
+                  "strikethrough": null,
+                  "textAlign": null,
+                  "underline": null,
+                  "uppercase": null,
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+    "localizedResourcesMap": {},
+  },
+  "document": {
+    "data": {
+      "key": "00000000-0000-0000-0000-000000000000",
+      "props": {
+        "children": {
+          "columns": [
+            {
+              "deviceId": "desktop",
+              "value": {
+                "count": 12,
+                "spans": [
+                  [
+                    12,
+                  ],
+                ],
+              },
+            },
+          ],
+          "elements": [
+            {
+              "key": "11111111-1111-1111-1111-111111111111",
+              "props": {
+                "propKey": {
+                  "descendants": [
+                    {
+                      "children": [
+                        {
+                          "text": "",
+                        },
+                        {
+                          "children": [
+                            {
+                              "text": "Adyen",
+                              "typography": {
+                                "id": "VHlwb2dyYXBoeTowNGI4OTZlMC0wZWEyLTRkMTMtYmU3ZS0xYmY1M2VmMjBiZjc=",
+                                "style": [
+                                  {
+                                    "deviceId": "desktop",
+                                    "value": {
+                                      "color": {
+                                        "alpha": 1,
+                                        "swatchId": "U3dhdGNoOmJkODYxMWM5LTNiZjItNDM3MS1iMmU4LTBmMmNlMDZjNDE1OA==",
+                                      },
+                                    },
+                                  },
+                                ],
+                              },
+                            },
+                          ],
+                          "link": {
+                            "payload": {
+                              "openInNewTab": true,
+                              "url": "https://www.bigcommerce.com/adyen",
+                            },
+                            "type": "OPEN_URL",
+                          },
+                          "type": "link",
+                        },
+                        {
+                          "text": "",
+                        },
+                      ],
+                      "type": "paragraph",
+                    },
+                    {
+                      "children": [
+                        {
+                          "text": "",
+                        },
+                        {
+                          "children": [
+                            {
+                              "text": "Authorize.net",
+                              "typography": {
+                                "id": "VHlwb2dyYXBoeTowNGI4OTZlMC0wZWEyLTRkMTMtYmU3ZS0xYmY1M2VmMjBiZjc=",
+                                "style": [
+                                  {
+                                    "deviceId": "desktop",
+                                    "value": {
+                                      "color": {
+                                        "alpha": 1,
+                                        "swatchId": "U3dhdGNoOmJkODYxMWM5LTNiZjItNDM3MS1iMmU4LTBmMmNlMDZjNDE1OA==",
+                                      },
+                                    },
+                                  },
+                                ],
+                              },
+                            },
+                          ],
+                          "link": {
+                            "payload": {
+                              "openInNewTab": true,
+                              "url": "http://www.authorize.net/",
+                            },
+                            "type": "OPEN_URL",
+                          },
+                          "type": "link",
+                        },
+                        {
+                          "text": "",
+                        },
+                      ],
+                      "type": "paragraph",
+                    },
+                    {
+                      "children": [
+                        {
+                          "text": "",
+                        },
+                        {
+                          "children": [
+                            {
+                              "text": "BlueSnap",
+                              "typography": {
+                                "id": "VHlwb2dyYXBoeTowNGI4OTZlMC0wZWEyLTRkMTMtYmU3ZS0xYmY1M2VmMjBiZjc=",
+                                "style": [
+                                  {
+                                    "deviceId": "desktop",
+                                    "value": {
+                                      "color": {
+                                        "alpha": 1,
+                                        "swatchId": "U3dhdGNoOmJkODYxMWM5LTNiZjItNDM3MS1iMmU4LTBmMmNlMDZjNDE1OA==",
+                                      },
+                                    },
+                                  },
+                                ],
+                              },
+                            },
+                          ],
+                          "link": {
+                            "payload": {
+                              "openInNewTab": true,
+                              "url": "https://www.bigcommerce.com/bluesnap/",
+                            },
+                            "type": "OPEN_URL",
+                          },
+                          "type": "link",
+                        },
+                        {
+                          "text": "",
+                        },
+                      ],
+                      "type": "paragraph",
+                    },
+                    {
+                      "children": [
+                        {
+                          "text": "",
+                        },
+                        {
+                          "children": [
+                            {
+                              "text": "Checkout.com",
+                              "typography": {
+                                "id": "VHlwb2dyYXBoeTowNGI4OTZlMC0wZWEyLTRkMTMtYmU3ZS0xYmY1M2VmMjBiZjc=",
+                                "style": [
+                                  {
+                                    "deviceId": "desktop",
+                                    "value": {
+                                      "color": {
+                                        "alpha": 1,
+                                        "swatchId": "U3dhdGNoOmJkODYxMWM5LTNiZjItNDM3MS1iMmU4LTBmMmNlMDZjNDE1OA==",
+                                      },
+                                    },
+                                  },
+                                ],
+                              },
+                            },
+                          ],
+                          "link": {
+                            "payload": {
+                              "openInNewTab": true,
+                              "url": "https://support.bigcommerce.com/s/article/Connecting-with-Checkoutcom/",
+                            },
+                            "type": "OPEN_URL",
+                          },
+                          "type": "link",
+                        },
+                        {
+                          "text": "",
+                        },
+                      ],
+                      "type": "paragraph",
+                    },
+                    {
+                      "children": [
+                        {
+                          "text": "",
+                        },
+                        {
+                          "children": [
+                            {
+                              "text": "CyberSource Direct",
+                              "typography": {
+                                "id": "VHlwb2dyYXBoeTowNGI4OTZlMC0wZWEyLTRkMTMtYmU3ZS0xYmY1M2VmMjBiZjc=",
+                                "style": [
+                                  {
+                                    "deviceId": "desktop",
+                                    "value": {
+                                      "color": {
+                                        "alpha": 1,
+                                        "swatchId": "U3dhdGNoOmJkODYxMWM5LTNiZjItNDM3MS1iMmU4LTBmMmNlMDZjNDE1OA==",
+                                      },
+                                    },
+                                  },
+                                ],
+                              },
+                            },
+                          ],
+                          "link": {
+                            "payload": {
+                              "openInNewTab": true,
+                              "url": "http://www.cybersource.com/",
+                            },
+                            "type": "OPEN_URL",
+                          },
+                          "type": "link",
+                        },
+                        {
+                          "text": "",
+                        },
+                      ],
+                      "type": "paragraph",
+                    },
+                  ],
+                  "key": "c438a1d3-fee2-4eb4-b49b-f1856c12de42",
+                  "type": "makeswift::controls::rich-text-v2",
+                  "version": 2,
+                },
+              },
+              "type": "TestComponent",
+            },
+          ],
+        },
+      },
+      "type": "./components/Root/index.js",
+    },
+    "fonts": [],
+    "id": "test-page-id",
+    "locale": null,
+    "localizedPages": [],
+    "meta": {},
+    "seo": {},
+    "site": {
+      "id": "test-site-id",
+    },
+    "snippets": [],
+  },
+}
+`;
+
 exports[`renders a makeswift::controls::rich-text-v2::mode::block placeholder when empty: resolvedValue 1`] = `
 NodeList [
   .emotion-0 {

--- a/packages/runtime/src/next/components/tests/controls/rich-text-v2-control/client.test.tsx
+++ b/packages/runtime/src/next/components/tests/controls/rich-text-v2-control/client.test.tsx
@@ -21,3 +21,23 @@ test(`renders provided text content`, async () => {
     expectedRenders: 1,
   })
 })
+
+test(`editable text reverts host styles on slate-internal text spans`, async () => {
+  const slateInternalNodeAttributes = ['data-slate-string', 'data-slate-zero-width']
+
+  await testPageControlPropRendering(RichText(), {
+    value,
+    cacheData: cacheData(),
+    isInBuilder: true,
+    isReadOnly: false,
+  })
+
+  for (const attribute of slateInternalNodeAttributes) {
+    const internalNodes = Array.from(document.querySelectorAll(`[${attribute}]`))
+    expect(internalNodes.length).toBeGreaterThan(0)
+
+    for (const node of internalNodes) {
+      expect(window.getComputedStyle(node).getPropertyValue('all')).toBe('revert')
+    }
+  }
+})

--- a/packages/runtime/src/runtimes/react/controls/rich-text-v2/EditableTextV2/editable-text-v2.tsx
+++ b/packages/runtime/src/runtimes/react/controls/rich-text-v2/EditableTextV2/editable-text-v2.tsx
@@ -30,6 +30,7 @@ import {
 } from '../../../../../controls/rich-text-v2'
 
 import { useBuilderEditMode } from '../../..'
+import { useSlateReset } from '../../use-slate-reset'
 import { BuilderEditMode } from '../../../../../state/modules/builder-edit-mode'
 import { pollBoxModel } from '../../../poll-box-model'
 import { withBuilder, withLocalChanges } from '../../../../../slate'
@@ -184,9 +185,12 @@ export function EditableTextV2({ text, definition, control }: Props) {
       isPreservingFocus.current = false
   }, [])
 
+  const slateReset = useSlateReset()
+
   return (
     <Slate editor={editor} value={initialValue}>
       <Editable
+        className={slateReset}
         renderLeaf={renderLeaf}
         renderElement={renderElement}
         onFocus={handleFocus}

--- a/packages/runtime/src/runtimes/react/controls/rich-text/EditableText/editable-text.tsx
+++ b/packages/runtime/src/runtimes/react/controls/rich-text/EditableText/editable-text.tsx
@@ -21,6 +21,7 @@ import { Slate as SlateReact, Editable, withReact, ReactEditor } from 'slate-rea
 import { Slate, richTextDTOtoDAO, type RichTextValue } from '@makeswift/controls'
 
 import { useBuilderEditMode } from '../../..'
+import { useSlateReset } from '../../use-slate-reset'
 import { DescriptorsPropControllers } from '../../../../../prop-controllers/instances'
 import { withBlock, withTypography, withBuilder, onKeyDown } from '../../../../../slate'
 import { BuilderEditMode } from '../../../../../state/modules/builder-edit-mode'
@@ -102,6 +103,8 @@ export const EditableText = forwardRef(function EditableText(
     [controller, editor],
   )
 
+  const slateReset = useSlateReset()
+
   const handleBlur = useCallback((e: FocusEvent) => {
     // When clicking outside of the iframe (`relatedTarget` is null) we want to preserve the DOM selection.
     if (e.relatedTarget == null) return
@@ -119,7 +122,7 @@ export const EditableText = forwardRef(function EditableText(
         onFocus={handleFocus}
         onKeyDown={handleKeyDown}
         onBlur={handleBlur}
-        className={cx(width, margin)}
+        className={cx(slateReset, width, margin)}
         readOnly={editMode !== BuilderEditMode.CONTENT}
         placeholder="Write some text..."
       />

--- a/packages/runtime/src/runtimes/react/controls/use-slate-reset.ts
+++ b/packages/runtime/src/runtimes/react/controls/use-slate-reset.ts
@@ -1,0 +1,43 @@
+import { useStyle } from '../use-style'
+
+/**
+ * `slate-react` renders read-only rich-text within a `<p>` tag containing
+ * multiple spans. Makeswift text-styles are applied to these spans via a class
+ * on the span tags directly:
+ *
+ * <p class="...">
+ *    <span class="mswft-12345">My text</span>
+ * </p>
+ *
+ * HOWEVER: in the builder, `slate-react` renders the same content as editable
+ * text with additional DOM structure; namely, intermediate nested spans (with
+ * data attributes like `data-slate-string`, `data-slate-zero-width`) between
+ * the `<span>` that carries Makeswift's typography class and the text content:
+ *
+ * <p data-slate-node="element" class="...">
+ *    <span data-slate-node="text">
+ *        <span class="mswft-12345" data-slate-leaf="true">
+ *            <span data-slate-string="true">My text</span>
+ *        </span>
+ *    </span>
+ * </p>
+ *
+ * If the host contains CSS that matches spans directly (ex: a global `span {
+ * color: ... }` rule), the host CSS applies to the innermost spans and beats
+ * the Makeswift text styles in terms of specificity. Therefore, setting text
+ * styles won't work in the builder: the top-level host styles will win. On the
+ * live page, the Makeswift styles win since the intermediate DOM elements are
+ * not present.
+ *
+ * These style updates address this by reverting base styles on these spans,
+ * restoring inheritance from Makeswift defined styles, thus matching the live
+ * page where the text is a direct child of the classed leaf span.
+ */
+export function useSlateReset(): string {
+  return useStyle({
+    // @ts-expect-error: csstype's `all` doesn't accept `!important` annotations
+    '& [data-slate-string], & [data-slate-zero-width]': {
+      all: 'revert !important',
+    },
+  })
+}


### PR DESCRIPTION
Prevent top-level styles from the host (typically those that target all elements of a particular type) from colliding with text styles set in Makeswift. Due to how react-slate renders editable text + specifity arguments, these top-level styles from the host can often supersede Makeswift styles, preventing the user from editing in the builder.

Original issue repro:

https://github.com/user-attachments/assets/89cc37c6-92d0-457c-b6d2-94a4b1ebdc64

Demo of fix:

https://github.com/user-attachments/assets/e11365d4-1501-403c-b1de-7ada22cebd98
