### PR TITLE
fix: prevent host styles from overriding typography styles

### DIFF
--- a/.changeset/twenty-geckos-reply.md
+++ b/.changeset/twenty-geckos-reply.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+fix: ensure typography styles also win over host styles

--- a/packages/runtime/src/next/components/tests/__snapshots__/global-element-rendering.test.tsx.snap
+++ b/packages/runtime/src/next/components/tests/__snapshots__/global-element-rendering.test.tsx.snap
@@ -56,31 +56,31 @@ exports[`Page correctly renders a global element 1`] = `
 
 @media only screen and (min-width: 769px) {
   .emotion-4 {
-    font-family: Lato;
-    font-size: 30px;
-    font-weight: 700;
-    line-height: 1.5;
-    font-style: initial;
+    font-family: Lato!important;
+    font-size: 30px!important;
+    font-weight: 700!important;
+    line-height: 1.5!important;
+    font-style: initial!important;
   }
 }
 
 @media only screen and (min-width: 576px) and (max-width: 768px) {
   .emotion-4 {
-    font-family: Lato;
-    font-size: 30px;
-    font-weight: 700;
-    line-height: 1.5;
-    font-style: initial;
+    font-family: Lato!important;
+    font-size: 30px!important;
+    font-weight: 700!important;
+    line-height: 1.5!important;
+    font-style: initial!important;
   }
 }
 
 @media only screen and (max-width: 575px) {
   .emotion-4 {
-    font-family: Lato;
-    font-size: 16px;
-    font-weight: 700;
-    line-height: 1.5;
-    font-style: initial;
+    font-family: Lato!important;
+    font-size: 16px!important;
+    font-weight: 700!important;
+    line-height: 1.5!important;
+    font-style: initial!important;
   }
 }
 
@@ -213,34 +213,34 @@ exports[`Page correctly renders a localized global element 1`] = `
 
 @media only screen and (min-width: 769px) {
   .emotion-4 {
-    color: hsla(238,87%,49%,1);
-    font-family: Lato;
-    font-size: 30px;
-    font-weight: 700;
-    line-height: 1.5;
-    font-style: initial;
+    color: hsla(238,87%,49%,1)!important;
+    font-family: Lato!important;
+    font-size: 30px!important;
+    font-weight: 700!important;
+    line-height: 1.5!important;
+    font-style: initial!important;
   }
 }
 
 @media only screen and (min-width: 576px) and (max-width: 768px) {
   .emotion-4 {
-    color: hsla(238,87%,49%,1);
-    font-family: Lato;
-    font-size: 30px;
-    font-weight: 700;
-    line-height: 1.5;
-    font-style: initial;
+    color: hsla(238,87%,49%,1)!important;
+    font-family: Lato!important;
+    font-size: 30px!important;
+    font-weight: 700!important;
+    line-height: 1.5!important;
+    font-style: initial!important;
   }
 }
 
 @media only screen and (max-width: 575px) {
   .emotion-4 {
-    color: hsla(238,87%,49%,1);
-    font-family: Lato;
-    font-size: 16px;
-    font-weight: 700;
-    line-height: 1.5;
-    font-style: initial;
+    color: hsla(238,87%,49%,1)!important;
+    font-family: Lato!important;
+    font-size: 16px!important;
+    font-weight: 700!important;
+    line-height: 1.5!important;
+    font-style: initial!important;
   }
 }
 

--- a/packages/runtime/src/next/components/tests/controls/rich-text-v2-control/__snapshots__/client.test.tsx.snap
+++ b/packages/runtime/src/next/components/tests/controls/rich-text-v2-control/__snapshots__/client.test.tsx.snap
@@ -27,49 +27,49 @@ NodeList [
 
 @media only screen and (min-width: 769px) {
   .emotion-5 {
-    color: hsla(238,87%,49%,1);
-    font-family: Lato;
-    font-size: 16px;
+    color: hsla(238,87%,49%,1)!important;
+    font-family: Lato!important;
+    font-size: 16px!important;
   }
 }
 
 @media only screen and (min-width: 576px) and (max-width: 768px) {
   .emotion-5 {
-    color: hsla(238,87%,49%,1);
-    font-family: Lato;
-    font-size: 16px;
+    color: hsla(238,87%,49%,1)!important;
+    font-family: Lato!important;
+    font-size: 16px!important;
   }
 }
 
 @media only screen and (max-width: 575px) {
   .emotion-5 {
-    color: hsla(238,87%,49%,1);
-    font-family: Lato;
-    font-size: 16px;
+    color: hsla(238,87%,49%,1)!important;
+    font-family: Lato!important;
+    font-size: 16px!important;
   }
 }
 
 @media only screen and (min-width: 769px) {
   .emotion-5 {
-    color: hsla(238,87%,49%,1);
-    font-family: Lato;
-    font-size: 16px;
+    color: hsla(238,87%,49%,1)!important;
+    font-family: Lato!important;
+    font-size: 16px!important;
   }
 }
 
 @media only screen and (min-width: 576px) and (max-width: 768px) {
   .emotion-5 {
-    color: hsla(238,87%,49%,1);
-    font-family: Lato;
-    font-size: 16px;
+    color: hsla(238,87%,49%,1)!important;
+    font-family: Lato!important;
+    font-size: 16px!important;
   }
 }
 
 @media only screen and (max-width: 575px) {
   .emotion-5 {
-    color: hsla(238,87%,49%,1);
-    font-family: Lato;
-    font-size: 16px;
+    color: hsla(238,87%,49%,1)!important;
+    font-family: Lato!important;
+    font-size: 16px!important;
   }
 }
 
@@ -844,25 +844,25 @@ NodeList [
 
 @media only screen and (min-width: 769px) {
   .emotion-4 {
-    color: hsla(238,87%,49%,1);
-    font-family: Lato;
-    font-size: 16px;
+    color: hsla(238,87%,49%,1)!important;
+    font-family: Lato!important;
+    font-size: 16px!important;
   }
 }
 
 @media only screen and (min-width: 576px) and (max-width: 768px) {
   .emotion-4 {
-    color: hsla(238,87%,49%,1);
-    font-family: Lato;
-    font-size: 16px;
+    color: hsla(238,87%,49%,1)!important;
+    font-family: Lato!important;
+    font-size: 16px!important;
   }
 }
 
 @media only screen and (max-width: 575px) {
   .emotion-4 {
-    color: hsla(238,87%,49%,1);
-    font-family: Lato;
-    font-size: 16px;
+    color: hsla(238,87%,49%,1)!important;
+    font-family: Lato!important;
+    font-size: 16px!important;
   }
 }
 

--- a/packages/runtime/src/next/components/tests/controls/rich-text-v2-control/__snapshots__/server.test.tsx.snap
+++ b/packages/runtime/src/next/components/tests/controls/rich-text-v2-control/__snapshots__/server.test.tsx.snap
@@ -42,7 +42,7 @@ NodeList [
 
 exports[`renders provided text content: component styles 1`] = `
 [
-  ".mswft-ytumd6{-webkit-text-decoration:none;text-decoration:none;}.mswft-1uk1gs8{margin:0;}.mswft-vz2etd{padding:0.5em 10px;font-size:1.25em;font-weight:300;border-left:5px solid rgba(0, 0, 0, 0.1);}.mswft-99zmsg{list-style-position:inside;-webkit-padding-start:20px;padding-inline-start:20px;list-style-type:disc;}.mswft-99zmsg ul{list-style-type:circle;}.mswft-99zmsg ul ul{list-style-type:square;}.mswft-dgqoak{list-style-position:inside;-webkit-padding-start:20px;padding-inline-start:20px;list-style-type:decimal;}@media only screen and (min-width: 769px){.mswft-144fjko{color:hsla(238,87%,49%,1);font-family:Lato;font-size:16px;}}@media only screen and (min-width: 576px) and (max-width: 768px){.mswft-144fjko{color:hsla(238,87%,49%,1);font-family:Lato;font-size:16px;}}@media only screen and (max-width: 575px){.mswft-144fjko{color:hsla(238,87%,49%,1);font-family:Lato;font-size:16px;}}",
+  ".mswft-ytumd6{-webkit-text-decoration:none;text-decoration:none;}.mswft-1uk1gs8{margin:0;}.mswft-vz2etd{padding:0.5em 10px;font-size:1.25em;font-weight:300;border-left:5px solid rgba(0, 0, 0, 0.1);}.mswft-99zmsg{list-style-position:inside;-webkit-padding-start:20px;padding-inline-start:20px;list-style-type:disc;}.mswft-99zmsg ul{list-style-type:circle;}.mswft-99zmsg ul ul{list-style-type:square;}.mswft-dgqoak{list-style-position:inside;-webkit-padding-start:20px;padding-inline-start:20px;list-style-type:decimal;}@media only screen and (min-width: 769px){.mswft-1vbo0y6{color:hsla(238,87%,49%,1)!important;font-family:Lato!important;font-size:16px!important;}}@media only screen and (min-width: 576px) and (max-width: 768px){.mswft-1vbo0y6{color:hsla(238,87%,49%,1)!important;font-family:Lato!important;font-size:16px!important;}}@media only screen and (max-width: 575px){.mswft-1vbo0y6{color:hsla(238,87%,49%,1)!important;font-family:Lato!important;font-size:16px!important;}}",
 ]
 `;
 
@@ -65,7 +65,7 @@ NodeList [
         target="_blank"
       >
         <span
-          class="mswft-144fjko"
+          class="mswft-1vbo0y6"
         >
           Adyen
         </span>
@@ -90,7 +90,7 @@ NodeList [
         target="_blank"
       >
         <span
-          class="mswft-144fjko"
+          class="mswft-1vbo0y6"
         >
           Authorize.net
         </span>
@@ -115,7 +115,7 @@ NodeList [
         target="_blank"
       >
         <span
-          class="mswft-144fjko"
+          class="mswft-1vbo0y6"
         >
           BlueSnap
         </span>
@@ -140,7 +140,7 @@ NodeList [
         target="_blank"
       >
         <span
-          class="mswft-144fjko"
+          class="mswft-1vbo0y6"
         >
           Checkout.com
         </span>
@@ -165,7 +165,7 @@ NodeList [
         target="_blank"
       >
         <span
-          class="mswft-144fjko"
+          class="mswft-1vbo0y6"
         >
           CyberSource Direct
         </span>

--- a/packages/runtime/src/runtimes/react/controls/typography.ts
+++ b/packages/runtime/src/runtimes/react/controls/typography.ts
@@ -154,6 +154,14 @@ export default function useEnhancedTypography(
     .filter(isNonNullable)
 }
 
+// Prevent typography styles from being overriden by top level host styles by
+// applying the "!important" modifier.
+function important(styles: CSSObject): CSSObject {
+  return Object.fromEntries(
+    Object.entries(styles).map(([property, value]) => [property, `${value} !important`]),
+  )
+}
+
 function typographyToCssObject(value: EnhancedTypographyValue): CSSObject {
   let styles: CSSObject = {}
   if (value.color != null) styles.color = colorToString(value.color)
@@ -174,7 +182,7 @@ function typographyToCssObject(value: EnhancedTypographyValue): CSSObject {
       .join(' ')
   if (value.italic != null) styles.fontStyle = value.italic === true ? 'italic' : 'initial'
 
-  return styles
+  return important(styles)
 }
 
 export function typographyCss(breakpoints: Breakpoints, style: EnhancedTypography): CSSObject {


### PR DESCRIPTION
Prevent host styles from overriding rich text typography styles by applying the important attribute to all generated typography styles.

Problem:

https://github.com/user-attachments/assets/7f973f12-8283-427d-8d4b-58ff554b9647

Demo of fix:

https://github.com/user-attachments/assets/05e29a3a-f052-4728-91d1-0a1c80aa5976
