### PR TITLE
refactor(hono-react)!: `ReactRuntime` no longer registers built-ins

### DIFF
--- a/.changeset/whole-houses-care.md
+++ b/.changeset/whole-houses-care.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/hono-react': minor
+---
+
+BREAKING CHANGE: `ReactRuntime` no longer registers built-in components, allows passing of `apiKey`

--- a/packages/hono-react/src/index.ts
+++ b/packages/hono-react/src/index.ts
@@ -10,4 +10,4 @@ export {
 } from '@makeswift/runtime/unstable-framework-support'
 
 export { Makeswift } from './client'
-export { HonoReactRuntime as ReactRuntime } from './runtime'
+export { ReactRuntime } from './runtime'

--- a/packages/hono-react/src/runtime.ts
+++ b/packages/hono-react/src/runtime.ts
@@ -1,19 +1,16 @@
-import {
-  type Breakpoints,
-  type StoreKey,
-  ReactRuntime,
-} from '@makeswift/runtime/unstable-framework-support'
+import { ReactRuntimeCore } from '@makeswift/runtime/react/core'
 
-export class HonoReactRuntime extends ReactRuntime {
-  constructor(args: {
-    requestKey?: StoreKey
-    appOrigin?: string
-    apiOrigin?: string
-    breakpoints?: Breakpoints
-  }) {
+type Args = Omit<ConstructorParameters<typeof ReactRuntimeCore>[0], 'fetch'>
+
+/**
+ * Note that this runtime class does not automatically register Makeswift's
+ * built-in components.
+ */
+export class ReactRuntime extends ReactRuntimeCore {
+  constructor(args: Args = {}) {
     super({
       ...args,
-      fetch: (url, init) => fetch(url, init), // TODO: revalidation support
+      fetch: (url, init) => fetch(url, init), // TODO: revalidation support?
     })
   }
 }

--- a/packages/hono-react/src/server/index.ts
+++ b/packages/hono-react/src/server/index.ts
@@ -1,3 +1,3 @@
 export { createApiHandler } from './api-handler'
 export { createPreviewMiddleware } from './preview'
-export { getSiteVersion } from './site-version'
+export { type SiteVersion, getSiteVersion } from './site-version'

--- a/packages/hono-react/src/server/preview.ts
+++ b/packages/hono-react/src/server/preview.ts
@@ -10,8 +10,9 @@ import {
   SearchParams,
   secondsUntilSiteVersionExpiration,
   serializeSiteVersion,
-  ReactRuntime,
 } from '@makeswift/runtime/unstable-framework-support'
+
+import { ReactRuntimeCore } from '@makeswift/runtime/react/core'
 
 import { Makeswift as MakeswiftClient } from '../client'
 
@@ -40,7 +41,7 @@ export function createPreviewMiddleware<E extends Env>({
   runtime,
 }: {
   apiKey: string
-  runtime: ReactRuntime
+  runtime: ReactRuntimeCore
 }): MiddlewareHandler {
   return async function apiHandler(c: Context<E>, next: Next): Promise<Response | void> {
     const { pathname, searchParams } = new URL(c.req.url, `https://example.com`)

--- a/packages/hono-react/src/server/site-version.tsx
+++ b/packages/hono-react/src/server/site-version.tsx
@@ -7,6 +7,8 @@ import {
   MAKESWIFT_SITE_VERSION_COOKIE,
 } from '@makeswift/runtime/unstable-framework-support'
 
+export { type SiteVersion } from '@makeswift/runtime/unstable-framework-support'
+
 export async function getSiteVersion(c: Context): Promise<SiteVersion | null> {
   const cookie = getCookie(c, MAKESWIFT_SITE_VERSION_COOKIE)
   return cookie != null ? deserializeSiteVersion(cookie) : null


### PR DESCRIPTION
`hono-react`'s `ReactRuntime` no longer registers built-in components, allows passing of `apiKey`.