### PR TITLE
chore: exports `collectServerElements` and `ServerElementsProvider`

### DIFF
--- a/.changeset/kind-meals-shine.md
+++ b/.changeset/kind-meals-shine.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Exports `collectServerElements` and `ServerElementsProvider` for frameworks that have separate collection and rendering steps.

--- a/packages/runtime/src/react/server/index.ts
+++ b/packages/runtime/src/react/server/index.ts
@@ -1,5 +1,6 @@
 export {
   type ServerRenderContext,
+  collectServerElements,
   RenderElementPayload,
   RenderContext as MakeswiftRenderContext,
   setRenderContext,

--- a/packages/runtime/src/runtimes/react/server/components/renderer.tsx
+++ b/packages/runtime/src/runtimes/react/server/components/renderer.tsx
@@ -3,13 +3,11 @@ import { type PropsWithChildren } from 'react'
 import { type CacheData } from '../../../../api/api-resources-client'
 import { type Document } from '../../../../state/modules/read-only-documents'
 
-import { ClientCSSProvider } from '../css/client-css'
-
 import { type ServerRenderContext, getStore } from '../render-context'
 import { collectServerElements } from '../collect-server-elements'
 import { updateApiResourceCache } from '../update-api-resource-cache'
 
-import { ServerElementsCache } from './server-elements-cache'
+import { ServerElementsProvider } from './server-elements-cache'
 
 /**
  * Helper for rendering a Makeswift document containing server elements. Makes
@@ -24,11 +22,7 @@ export function RSCRenderer({
 }: PropsWithChildren<{ context: ServerRenderContext; document: Document; cacheData: CacheData }>) {
   const serverElements = collectServerElements(context, document, cacheData)
 
-  return (
-    <ServerElementsCache value={serverElements}>
-      <ClientCSSProvider>{children}</ClientCSSProvider>
-    </ServerElementsCache>
-  )
+  return <ServerElementsProvider elements={serverElements}>{children}</ServerElementsProvider>
 }
 
 /**

--- a/packages/runtime/src/runtimes/react/server/components/server-elements-cache.tsx
+++ b/packages/runtime/src/runtimes/react/server/components/server-elements-cache.tsx
@@ -3,6 +3,7 @@
 import { createContext, ReactNode, useCallback, useContext, useState, useMemo } from 'react'
 
 import { type ElementsMap } from '../collect-server-elements'
+import { ClientCSSProvider } from '../css/client-css'
 
 type ContextValue = {
   getElement: (elementKey: string) => ReactNode
@@ -67,5 +68,17 @@ export const ServerElementsCache = ({
 
   return <Context.Provider value={cache}>{children}</Context.Provider>
 }
+
+export const ServerElementsProvider = ({
+  children,
+  elements,
+}: {
+  children: ReactNode
+  elements: ElementsMap
+}) => (
+  <ServerElementsCache value={elements}>
+    <ClientCSSProvider>{children}</ClientCSSProvider>
+  </ServerElementsCache>
+)
 
 export const useServerElementsCache = () => useContext(Context)

--- a/packages/runtime/src/runtimes/react/server/index.ts
+++ b/packages/runtime/src/runtimes/react/server/index.ts
@@ -1,3 +1,4 @@
+export { collectServerElements } from './collect-server-elements'
 export { ServerElement } from './components/element'
 export { MakeswiftComponent } from './components/makeswift-component'
 export { Slot } from './components/slot'

--- a/packages/runtime/src/unstable-framework-support/index.ts
+++ b/packages/runtime/src/unstable-framework-support/index.ts
@@ -29,6 +29,7 @@ export { Page } from '../runtimes/react/components/page'
 export { RuntimeProvider } from '../runtimes/react/components/RuntimeProvider'
 export { Slot } from '../runtimes/react/components/Slot'
 export { RenderElementPayload } from '../runtimes/react/server/render-element-payload'
+export { ServerElementsProvider } from '../runtimes/react/server/components/server-elements-cache'
 
 export { GoogleFontLink } from '../runtimes/react/components/GoogleFontLink'
 export { MakeswiftFonts } from '../runtimes/react/components/MakeswiftFonts'


### PR DESCRIPTION
I think it's better to let the host use `ServerElementsProvider` directly, instead of shoving it to `ViteRSCFrameworkProvider` like in https://github.com/makeswift/makeswift/pull/1401