### PR TITLE
feat: option to inject `elementKey` et al into server component props

### DIFF
--- a/.changeset/odd-pets-cut.md
+++ b/.changeset/odd-pets-cut.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Add `unstable_injectedProps` option to server component registration to enable injection of `elementKey` et al into component props.

--- a/packages/runtime/src/next/components/tests/controls/page-control-prop-rendering.tsx
+++ b/packages/runtime/src/next/components/tests/controls/page-control-prop-rendering.tsx
@@ -1,5 +1,4 @@
 import { type ReactNode, Fragment, forwardRef, useRef, isValidElement, act } from 'react'
-import { renderToReadableStream } from 'react-dom/server'
 import { JSDOM } from 'jsdom'
 import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
@@ -14,6 +13,8 @@ import { ReactRuntime } from '../../../../runtimes/react/react-runtime'
 import { MakeswiftComponent } from '../../../../runtimes/react/components/MakeswiftComponent'
 import { Page } from '../../page'
 import { isServer } from '../../../../utils/is-server'
+
+import { renderToString } from '../../../../runtimes/react/testing/render-to-string'
 import * as Testing from '../../../testing'
 
 const ROOT_ID = '00000000-0000-0000-0000-000000000000'
@@ -26,25 +27,6 @@ const propSnapshot = (prop: HTMLElement | null) =>
   prop?.childElementCount ? prop.childNodes : parseStringifiedProp(prop?.textContent ?? '')
 
 const parseStringifiedProp = (prop: string) => (prop === 'undefined' ? undefined : JSON.parse(prop))
-
-async function streamToString(stream: ReadableStream) {
-  const reader = stream.getReader()
-  const decoder = new TextDecoder()
-
-  let result = ''
-
-  while (true) {
-    const { done, value } = await reader.read()
-    if (done) break
-    result += decoder.decode(value, { stream: true })
-  }
-
-  return result
-}
-
-async function renderToString(element: ReactNode) {
-  return await streamToString(await renderToReadableStream(element))
-}
 
 async function serverSideRender(children: ReactNode) {
   // wrap the children in a context provider to capture server-inserted HTML, see

--- a/packages/runtime/src/runtimes/react/__tests__/react-runtime.register-component.test.tsx
+++ b/packages/runtime/src/runtimes/react/__tests__/react-runtime.register-component.test.tsx
@@ -1,5 +1,5 @@
 /** @jest-environment jsdom */
-import { type MouseEvent } from 'react'
+import { forwardRef, type ForwardedRef, type MouseEvent } from 'react'
 import {
   Checkbox,
   Combobox,
@@ -32,74 +32,134 @@ type Entity = {
   name: string
 }
 
-function Sandbox(props: {
+type SandboxProps = {
   cards: Card[]
   entityId?: Entity['id']
   theme: 'light' | 'dark'
   background: string
   boolean: boolean
   number?: number
-}) {
+}
+
+function Sandbox(props: SandboxProps) {
+  return <div>{JSON.stringify(props)}</div>
+}
+
+const SandboxWithRef = forwardRef(function SandboxWithRef(
+  props: SandboxProps,
+  ref: ForwardedRef<HTMLDivElement>,
+) {
+  return <div ref={ref}>{JSON.stringify(props)}</div>
+})
+
+function SandboxWithIncorrectRef(props: SandboxProps & { ref?: number }) {
+  return <div>{JSON.stringify(props)}</div>
+}
+
+function ServerSandbox(props: SandboxProps & { widgetId: string }) {
   return <div>{JSON.stringify(props)}</div>
 }
 
 const runtime = createReactRuntime()
+
+const sandboxProps = {
+  cards: List({
+    label: 'Cards',
+    type: Shape({
+      type: {
+        imageSrc: Image({ label: 'Image' }),
+        imageAlt: TextInput({
+          label: 'Alt text',
+          defaultValue: 'Image',
+        }),
+        title: TextInput({
+          label: 'Title',
+          defaultValue: 'This is a title',
+        }),
+        text: TextArea({
+          label: 'Text',
+          defaultValue: 'Lorem ipsum',
+        }),
+        link: Link({ label: 'On click' }),
+      },
+    }),
+    getItemLabel(item) {
+      return item?.title ?? 'This is a title'
+    },
+  }),
+  entityId: Combobox({
+    async getOptions() {
+      return fetch(`/api/entities`)
+        .then(r => r.json())
+        .then((entities: Entity[]) =>
+          entities.map(entity => ({
+            id: entity.id.toString(),
+            label: entity.name,
+            value: entity.id,
+          })),
+        )
+    },
+    label: 'Entity',
+  }),
+  theme: Select({
+    label: 'Text color',
+    options: [
+      { value: 'light', label: 'Light' },
+      { value: 'dark', label: 'Dark' },
+    ],
+    defaultValue: 'light',
+  }),
+  background: Color({ label: 'Background color', defaultValue: '#fff' }),
+  boolean: Checkbox({ label: 'Boolean', defaultValue: true }),
+  number: Number({ label: 'Number' }),
+  text: TextInput({ label: 'Text' }),
+}
 
 describe('registerComponent', () => {
   test("correctly deduces control definitions' resolved value types", () => {
     runtime.registerComponent(Sandbox, {
       type: 'sandbox',
       label: 'Sandbox',
-      props: {
-        cards: List({
-          label: 'Cards',
-          type: Shape({
-            type: {
-              imageSrc: Image({ label: 'Image' }),
-              imageAlt: TextInput({
-                label: 'Alt text',
-                defaultValue: 'Image',
-              }),
-              title: TextInput({
-                label: 'Title',
-                defaultValue: 'This is a title',
-              }),
-              text: TextArea({
-                label: 'Text',
-                defaultValue: 'Lorem ipsum',
-              }),
-              link: Link({ label: 'On click' }),
-            },
-          }),
-          getItemLabel(item) {
-            return item?.title ?? 'This is a title'
-          },
-        }),
-        entityId: Combobox({
-          async getOptions() {
-            return fetch(`/api/entities`)
-              .then(r => r.json())
-              .then((entities: Entity[]) =>
-                entities.map(entity => ({
-                  id: entity.id.toString(),
-                  label: entity.name,
-                  value: entity.id,
-                })),
-              )
-          },
-          label: 'Entity',
-        }),
-        theme: Select({
-          label: 'Text color',
-          options: [
-            { value: 'light', label: 'Light' },
-            { value: 'dark', label: 'Dark' },
-          ],
-          defaultValue: 'light',
-        }),
-        background: Color({ label: 'Background color', defaultValue: '#fff' }),
-        boolean: Checkbox({ label: 'Boolean', defaultValue: true }),
-        number: Number({ label: 'Number' }),
+      props: sandboxProps,
+    })
+
+    runtime.registerComponent(SandboxWithRef, {
+      type: 'sandbox-with-ref',
+      label: 'SandboxWithRef',
+      props: sandboxProps,
+    })
+  })
+
+  test('rejects registration of a component with a React-incompatible `ref` prop', () => {
+    // @ts-expect-error Types of property ref are incompatible
+    runtime.registerComponent(SandboxWithIncorrectRef, {
+      type: 'sandbox-with-ref',
+      label: 'SandboxWithRef',
+      props: sandboxProps,
+    })
+  })
+
+  test('specified injected server props are type-checked against the component props', () => {
+    runtime.registerComponent(ServerSandbox, {
+      type: 'server-sandbox',
+      label: 'ServerSandbox',
+      props: sandboxProps,
+      server: {
+        unstable_injectedProps: {
+          widgetId: 'elementKey',
+        },
+      },
+    })
+
+    // @ts-expect-error Property widgetId is missing in type
+    runtime.registerComponent(ServerSandbox, {
+      type: 'invalid-server-sandbox',
+      label: 'InvalidServerSandbox',
+      props: sandboxProps,
+      server: {
+        unstable_injectedProps: {
+          gadgetId: 'elementKey',
+        },
       },
     })
   })

--- a/packages/runtime/src/runtimes/react/react-runtime-core.ts
+++ b/packages/runtime/src/runtimes/react/react-runtime-core.ts
@@ -1,3 +1,5 @@
+import { type Component, type PropsWithoutRef, type ReactNode, type RefAttributes } from 'react'
+
 import { ControlDefinition as UnifiedControlDefinition } from '@makeswift/controls'
 
 import { type LegacyDescriptor, type DescriptorValueType } from '../../prop-controllers/descriptors'
@@ -11,6 +13,8 @@ import {
 
 import { ComponentIcon } from '../../state/modules/components-meta'
 import type { ComponentType } from '../../state/read-only-state'
+
+import { type InjectableProps } from './server/injectable-props'
 
 import { RuntimeCore } from './runtime-core'
 
@@ -28,11 +32,48 @@ function validateComponentType({
   }
 }
 
+type InjectedPropsConfig = Record<string, keyof InjectableProps>
+
+type ServerComponentConfig<I extends InjectedPropsConfig> =
+  | boolean
+  | {
+      unstable_injectedProps: I
+    }
+
+type InjectedProps<I extends InjectedPropsConfig> = {
+  [K in keyof I]: InjectableProps[I[K]]
+}
+
+type ResolvedProps<P extends Record<string, LegacyDescriptor | UnifiedControlDefinition>> = {
+  [K in keyof P]: DescriptorValueType<P[K]>
+}
+
+type RegisteredComponentType<
+  P extends Record<string, LegacyDescriptor | UnifiedControlDefinition>,
+  I extends InjectedPropsConfig,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  T = any,
+> =
+  | {
+      new (
+        props: PropsWithoutRef<ResolvedProps<P>> & InjectedProps<I> & RefAttributes<T>,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        context?: any,
+      ): Component<ResolvedProps<P> & InjectedProps<I>>
+    }
+  | ((
+      props: PropsWithoutRef<ResolvedProps<P>> & InjectedProps<I> & RefAttributes<T>,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      context?: any,
+    ) => ReactNode)
+
 export class ReactRuntimeCore extends RuntimeCore {
   registerComponent<
     ControlDef extends UnifiedControlDefinition,
     P extends Record<string, LegacyDescriptor | ControlDef>,
-    C extends ComponentType<{ [K in keyof P]: DescriptorValueType<P[K]> }>,
+    // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+    const I extends InjectedPropsConfig = {},
+    C extends RegisteredComponentType<P, I> = RegisteredComponentType<P, I>,
   >(
     component: C,
     {
@@ -63,14 +104,17 @@ export class ReactRuntimeCore extends RuntimeCore {
        * update existing instances.
        */
       unstable_migration?: { replacementType: string }
-      server?: boolean
+      server?: ServerComponentConfig<I>
       props?: P
     },
   ): () => void {
+    const isServerComponent = server !== false
+    const injectedProps = typeof server === 'object' ? server.unstable_injectedProps : {}
+
     validateComponentType(
       // make sure we don't access `component?.name` and trigger loading of the server
       // component unless we're running in the RSC environment
-      server && !this.isRSCEnv()
+      isServerComponent && !this.isRSCEnv()
         ? { type, componentName: label || 'Unknown server component' }
         : {
             type,
@@ -81,7 +125,16 @@ export class ReactRuntimeCore extends RuntimeCore {
     const unregisterComponent = this.protoStore.dispatch(
       registerComponentEffect(
         type,
-        { label, icon, hidden, description, builtinSuspense, unstable_migration, server },
+        {
+          label,
+          icon,
+          hidden,
+          description,
+          builtinSuspense,
+          unstable_migration,
+          server: isServerComponent,
+          injectedProps,
+        },
         props ?? {},
       ),
     )
@@ -92,7 +145,7 @@ export class ReactRuntimeCore extends RuntimeCore {
       )
     }
 
-    if (server && !this.isRSCEnv()) {
+    if (isServerComponent && !this.isRSCEnv()) {
       // we can't load server components code outside of the RSC environment, but we also
       // don't need to: if everything is set up correctly, React has already rendered and
       // streamed the corresponding React elements to the client for us -- see

--- a/packages/runtime/src/runtimes/react/server/components/__tests__/element.test.tsx
+++ b/packages/runtime/src/runtimes/react/server/components/__tests__/element.test.tsx
@@ -1,0 +1,70 @@
+import { MakeswiftClient } from '../../../../../client'
+import { type ServerRenderContext } from '../../render-context'
+
+import { ServerElement } from '../element'
+
+import { createReactRuntime } from '../../../testing'
+import { renderToString } from '../../../testing/render-to-string'
+import { SiteVersion } from '../../../../../next'
+
+const elementKey = 'test-element-key'
+const documentKey = 'test-document-key'
+const componentType = 'TestComponent'
+
+const TestComponent = ({ widgetId, documentId }: { widgetId: string; documentId: string }) => (
+  <div data-widget-id={widgetId} data-document-id={documentId} />
+)
+
+describe('ServerElement', () => {
+  const createFixture = ({
+    siteVersion,
+    locale,
+  }: {
+    siteVersion: SiteVersion | null
+    locale?: string
+  }) => {
+    const runtime = createReactRuntime({
+      env: 'rsc',
+      requestKey: { siteVersion, locale },
+    })
+
+    runtime.registerComponent(TestComponent, {
+      type: componentType,
+      label: 'Test component',
+      props: {},
+      server: {
+        unstable_injectedProps: {
+          widgetId: 'elementKey',
+          documentId: 'documentKey',
+        },
+      },
+    })
+
+    const renderContext: ServerRenderContext = {
+      request: new Request('https://example.com'),
+      runtime,
+      client: new MakeswiftClient('test-api-key', { runtime }),
+      siteVersion,
+      locale,
+    }
+
+    return { renderContext }
+  }
+
+  test('injects configured values into component props', async () => {
+    const { renderContext } = createFixture({ siteVersion: null })
+    const element = {
+      key: elementKey,
+      type: componentType,
+      props: {},
+    }
+
+    const html = await renderToString(
+      <ServerElement context={renderContext} documentKey={documentKey} element={element} />,
+    )
+
+    expect(html).toEqual(
+      `<div data-widget-id="${element.key}" data-document-id="${documentKey}"></div>`,
+    )
+  })
+})

--- a/packages/runtime/src/runtimes/react/server/components/element-data.tsx
+++ b/packages/runtime/src/runtimes/react/server/components/element-data.tsx
@@ -25,10 +25,12 @@ export async function ServerElementData({
   documentKey,
   context,
   elementData,
+  injectedProps,
 }: {
   documentKey: string
   context: ServerRenderContext
   elementData: ElementData
+  injectedProps: Record<string, unknown>
 }): Promise<ReactNode> {
   const state = getStore(context).getState()
 
@@ -58,7 +60,10 @@ export async function ServerElementData({
     elementData.key,
   )
 
-  const props = await resolveProps(context, elementData, documentKey, definitions, stylesheet)
+  const props = {
+    ...(await resolveProps(context, elementData, documentKey, definitions, stylesheet)),
+    ...injectedProps,
+  }
 
   return (
     <>

--- a/packages/runtime/src/runtimes/react/server/components/element.tsx
+++ b/packages/runtime/src/runtimes/react/server/components/element.tsx
@@ -1,5 +1,7 @@
 import { ReactNode } from 'react'
 
+import { mapValues } from '@makeswift/controls'
+
 import {
   isElementReference,
   getComponentsMeta,
@@ -11,6 +13,7 @@ import { FallbackComponent } from '../../../../components/shared/FallbackCompone
 import { Element as ClientElement } from '../../components/Element'
 
 import { type ServerRenderContext, getStore } from '../render-context'
+import { type InjectableProps } from '../injectable-props'
 
 import { ServerElementData } from './element-data'
 
@@ -39,10 +42,28 @@ export function ServerElement({
     )
   }
 
+  const elementKey = element.key
   const isRSC = elementMeta.server ?? false
   if (!isRSC) {
-    return <ClientElement key={element.key} element={element} />
+    return <ClientElement key={elementKey} element={element} />
   }
 
-  return <ServerElementData documentKey={documentKey} context={context} elementData={element} />
+  const injectableProps: InjectableProps = {
+    elementKey,
+    documentKey,
+  }
+
+  const injectedProps = mapValues(
+    elementMeta.injectedProps ?? {},
+    propName => injectableProps[propName],
+  )
+
+  return (
+    <ServerElementData
+      documentKey={documentKey}
+      context={context}
+      elementData={element}
+      injectedProps={injectedProps}
+    />
+  )
 }

--- a/packages/runtime/src/runtimes/react/server/injectable-props.ts
+++ b/packages/runtime/src/runtimes/react/server/injectable-props.ts
@@ -1,0 +1,4 @@
+export type InjectableProps = {
+  documentKey: string
+  elementKey: string
+}

--- a/packages/runtime/src/runtimes/react/testing/react-runtime.tsx
+++ b/packages/runtime/src/runtimes/react/testing/react-runtime.tsx
@@ -1,16 +1,13 @@
-import { type BreakpointsInput } from '../../../state/modules/breakpoints'
 import { TestOrigins } from '../../../testing/fixtures'
 import { ReactRuntime } from '../react-runtime'
 
 type RuntimeEnv = 'client' | 'ssr' | 'rsc'
+type RuntimeArgs = ConstructorParameters<typeof ReactRuntime>[0]
 
 class TestReactRuntime extends ReactRuntime {
   readonly env: RuntimeEnv
 
-  constructor({
-    env,
-    ...args
-  }: ConstructorParameters<typeof ReactRuntime>[0] & { env?: RuntimeEnv }) {
+  constructor({ env, ...args }: RuntimeArgs & { env?: RuntimeEnv }) {
     super(args)
     this.env = env ?? 'client'
   }
@@ -22,13 +19,19 @@ class TestReactRuntime extends ReactRuntime {
 
 export function createReactRuntime({
   breakpoints,
+  requestKey,
   env,
-}: { breakpoints?: BreakpointsInput; env?: RuntimeEnv } = {}) {
+}: {
+  breakpoints?: RuntimeArgs['breakpoints']
+  requestKey?: RuntimeArgs['requestKey']
+  env?: RuntimeEnv
+} = {}) {
   return new TestReactRuntime({
     // Mock Service Worker patches global `fetch` for interception; make sure our test calls go
     // through the patched version instead of an eagerly captured reference to the original
     fetch: (...args) => globalThis.fetch(...args),
     breakpoints,
+    requestKey,
     env,
     ...TestOrigins,
   })

--- a/packages/runtime/src/runtimes/react/testing/render-to-string.ts
+++ b/packages/runtime/src/runtimes/react/testing/render-to-string.ts
@@ -1,0 +1,21 @@
+import { type ReactNode } from 'react'
+import { renderToReadableStream } from 'react-dom/server'
+
+async function streamToString(stream: ReadableStream) {
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+
+  let result = ''
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    result += decoder.decode(value, { stream: true })
+  }
+
+  return result
+}
+
+export async function renderToString(element: ReactNode) {
+  return await streamToString(await renderToReadableStream(element))
+}

--- a/packages/runtime/src/state/modules/components-meta.ts
+++ b/packages/runtime/src/state/modules/components-meta.ts
@@ -1,3 +1,4 @@
+import { InjectableProps } from '../../runtimes/react/server/injectable-props'
 import { type Action, type UnknownAction, isKnownAction } from '../actions'
 import { ReadOnlyActionTypes } from '../actions/internal/read-only-action-types'
 
@@ -47,6 +48,7 @@ export type ComponentMeta = {
     replacementType: string
   }
   server?: boolean
+  injectedProps?: Record<string, keyof InjectableProps>
 }
 
 export type State = Map<string, ComponentMeta>


### PR DESCRIPTION
Add `unstable_injectedProps` option to server component registration to enable injection of `elementKey` et al into component props, e.g.

```ts
const MyWidget = async ({ widgetId }: { widgetId: string }) => { 
  ... 
}

runtime.registerComponent(MyWidget, {
  type: 'my-widget,
  label: 'My Widget',
  props: { ... },
  server: {
    unstable_injectedProps: {
      widgetId: 'elementKey',
    },
  },
})
```

See background discussion [here](https://github.com/makeswift/makeswift/pull/1420/changes#r3832005676).

Best reviewed commit-by-commit.