### PR TITLE
fix(runtime): do not rely on `requestKey` for server store persistence

### DIFF
--- a/apps/vite-rsc-hono-react-cloudflare/src/framework/render-context.ts
+++ b/apps/vite-rsc-hono-react-cloudflare/src/framework/render-context.ts
@@ -2,13 +2,21 @@ import { type Context } from 'hono'
 
 import { getSiteVersion } from '@makeswift/hono-react/server'
 
+import { type HonoEnv } from '../lib/hono'
+
 export const createRenderContext = async (
-  c: Context,
+  c: Context<HonoEnv>,
   { request, locale }: { request: Request; locale: string | undefined },
-) => ({
-  request,
-  runtime: c.var.makeswiftRuntime,
-  client: c.var.makeswiftClient,
-  siteVersion: await getSiteVersion(c),
-  locale,
-})
+) => {
+  const runtime = c.var.makeswiftRuntime
+  const siteVersion = await getSiteVersion(c)
+
+  return {
+    request,
+    runtime,
+    client: c.var.makeswiftClient,
+    siteVersion,
+    locale,
+    store: runtime.getOrCreateStore({ siteVersion, locale }),
+  }
+}

--- a/packages/runtime/src/runtimes/react/server/components/__tests__/element.test.tsx
+++ b/packages/runtime/src/runtimes/react/server/components/__tests__/element.test.tsx
@@ -46,6 +46,7 @@ describe('ServerElement', () => {
       client: new MakeswiftClient('test-api-key', { runtime }),
       siteVersion,
       locale,
+      store: runtime.getOrCreateStore({ siteVersion, locale }),
     }
 
     return { renderContext }

--- a/packages/runtime/src/runtimes/react/server/render-context.tsx
+++ b/packages/runtime/src/runtimes/react/server/render-context.tsx
@@ -21,6 +21,7 @@ export type ServerRenderContext = {
   client: MakeswiftClient
   siteVersion: SiteVersion | null
   locale: string | undefined
+  store: Store
 }
 
 const requestContext = cache((): { current?: ServerRenderContext } => ({}))
@@ -35,13 +36,7 @@ export const getRenderContext = (): ServerRenderContext => {
   return context
 }
 
-export const getStore = ({ runtime, siteVersion, locale }: ServerRenderContext): Store => {
-  if (runtime.requestKey == null) {
-    throw Error('Expected a runtime instance that is bound to a specific request key')
-  }
-
-  return runtime.getOrCreateStore({ siteVersion, locale })
-}
+export const getStore = ({ store }: ServerRenderContext): Store => store
 
 export const RenderContext = ({
   context,


### PR DESCRIPTION
Move the store into the render context.