### PR TITLE
fix: correct comment typo in rich text control instance

### DIFF
--- a/.changeset/kind-spies-trade.md
+++ b/.changeset/kind-spies-trade.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Fix comment typo on the rich text control instance editor onchange handler

--- a/packages/runtime/src/controls/rich-text/control.ts
+++ b/packages/runtime/src/controls/rich-text/control.ts
@@ -122,7 +122,7 @@ export class RichTextControl extends ControlInstance<Message> {
 
       // if onChange is local then it will include an operation(s)
       // that is the only case in which we want to push updates
-      // this prevent infinite loops that can occur when collaborating
+      // this prevents infinite loops that can occur when collaborating
       if (options?.operation != null) {
         this.sendMessage({
           type: RichTextControl.CHANGE_EDITOR_VALUE,


### PR DESCRIPTION
Fixes a typo on a comment within the rich text control instance