### PR TITLE
feat(table): replace table query with host api GET endpoint

### DIFF
--- a/.changeset/red-3673-table-query-host-api.md
+++ b/.changeset/red-3673-table-query-host-api.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+The runtime now fetches table schemas via the Makeswift Host API REST endpoint instead of the GraphQL API, continuing the migration away from GraphQL/Builder API dependencies.

--- a/packages/runtime/src/api/__tests__/rest-api-client.get-resources.test.ts
+++ b/packages/runtime/src/api/__tests__/rest-api-client.get-resources.test.ts
@@ -128,6 +128,51 @@ describe('getFile', () => {
   })
 })
 
+describe('getTable', () => {
+  const tableId = 'myTable'
+  const resourceUrl = `${TestOrigins.apiOrigin}/v1/tables/${tableId}`
+
+  test('returns null on 404', async () => {
+    // Arrange
+    const client = createTestClient()
+
+    server.use(
+      http.get(resourceUrl, () => HttpResponse.text('', { status: 404 }), {
+        once: true,
+      }),
+    )
+
+    // Act
+    const result = await client.getTable(tableId)
+
+    // Assert
+    expect(result).toBeNull()
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+  })
+
+  test('throws on other errors, attaching the details to the error', async () => {
+    // Arrange
+    const client = createTestClient()
+
+    server.use(
+      http.get(resourceUrl, () => HttpResponse.json('Internal server error', { status: 500 }), {
+        once: true,
+      }),
+    )
+
+    // Act
+    const error = await captureClientError(client.getTable(tableId))
+
+    // Assert
+    expect(error.name).toBe('RestApiClientError')
+    expect(error.message).toBe("Failed to get table 'myTable': 500 Internal Server Error")
+    expect(error.status).toBe(500)
+    expect(error.cause).toEqual({
+      body: 'Internal server error',
+    })
+  })
+})
+
 describe('getTypography', () => {
   const typographyId = 'myTypography'
   const resourceUrl = `${baseUrl}/typographies/${typographyId}`

--- a/packages/runtime/src/api/graphql-api-client.ts
+++ b/packages/runtime/src/api/graphql-api-client.ts
@@ -1,15 +1,11 @@
 import { GraphQLClient } from './graphql/client'
 
-import { TableQuery, UnversionedResourcesQuery } from './graphql/documents'
+import { UnversionedResourcesQuery } from './graphql/documents'
 
 import {
-  type TableQueryResult,
-  type TableQueryVariables,
   type UnversionedResourcesQueryResult,
   type UnversionedResourcesQueryVariables,
 } from './graphql/generated/types'
-
-import { type Table } from './types'
 
 export class MakeswiftGraphQLApiClient {
   readonly graphqlClient: GraphQLClient
@@ -28,14 +24,5 @@ export class MakeswiftGraphQLApiClient {
       UnversionedResourcesQueryResult,
       UnversionedResourcesQueryVariables
     >(UnversionedResourcesQuery, { fileIds, tableIds })
-  }
-
-  async getTable(tableId: string): Promise<Table | null> {
-    const result = await this.graphqlClient.request<TableQueryResult, TableQueryVariables>(
-      TableQuery,
-      { tableId },
-    )
-
-    return result.table
   }
 }

--- a/packages/runtime/src/api/graphql/documents/queries.ts
+++ b/packages/runtime/src/api/graphql/documents/queries.ts
@@ -41,16 +41,6 @@ export const TypographyQuery = /* GraphQL */ `
   ${TypographyFragment}
 `
 
-export const TableQuery = /* GraphQL */ `
-  query Table($tableId: ID!) {
-    table(id: $tableId) {
-      ...Table
-    }
-  }
-
-  ${TableFragment}
-`
-
 export const TypographiesQuery = /* GraphQL */ `
   query Typographies($typographyIds: [ID!]!) {
     typographies(ids: $typographyIds) {

--- a/packages/runtime/src/api/graphql/generated/types.ts
+++ b/packages/runtime/src/api/graphql/generated/types.ts
@@ -234,39 +234,6 @@ export type TypographyQueryResult = {
   } | null
 }
 
-export type TableQueryVariables = Exact<{
-  tableId: Scalars['ID']
-}>
-
-export type TableQueryResult = {
-  table: {
-    __typename: 'Table'
-    id: string
-    name: string
-    columns: Array<
-      | { __typename: 'CheckboxTableColumn'; id: string; name: string }
-      | { __typename: 'EmailTableColumn'; id: string; name: string }
-      | { __typename: 'LongTextTableColumn'; id: string; name: string }
-      | {
-          __typename: 'MultipleSelectTableColumn'
-          id: string
-          name: string
-          options: Array<{ id: string; name: string }>
-        }
-      | { __typename: 'NumberTableColumn'; id: string; name: string }
-      | { __typename: 'PhoneNumberTableColumn'; id: string; name: string }
-      | { __typename: 'SingleLineTextTableColumn'; id: string; name: string }
-      | {
-          __typename: 'SingleSelectTableColumn'
-          id: string
-          name: string
-          options: Array<{ id: string; name: string }>
-        }
-      | { __typename: 'URLTableColumn'; id: string; name: string }
-    >
-  } | null
-}
-
 export type TypographiesQueryVariables = Exact<{
   typographyIds: Array<Scalars['ID']> | Scalars['ID']
 }>

--- a/packages/runtime/src/api/makeswift-api-resources-client.ts
+++ b/packages/runtime/src/api/makeswift-api-resources-client.ts
@@ -16,7 +16,6 @@ import { ApiResourcesClient } from './api-resources-client'
 import { type SiteVersion } from './site-version'
 
 // see the comment in `MakeswiftApiResourcesClient` constructor below
-import { type MakeswiftGraphQLApiClient } from './graphql-api-client'
 import { type MakeswiftRestAPIClient } from './rest-api-client'
 
 /**
@@ -28,19 +27,16 @@ import { type MakeswiftRestAPIClient } from './rest-api-client'
  */
 export class MakeswiftApiResourcesClient extends ApiResourcesClient {
   private restApiClient: Promise<MakeswiftRestAPIClient>
-  private graphQlClient: Promise<MakeswiftGraphQLApiClient>
 
   constructor({
     fetch,
     apiKey,
     apiOrigin,
-    graphqlApiEndpoint,
     preloadedState,
   }: {
     fetch: HttpFetch
     apiKey: string
     apiOrigin: string
-    graphqlApiEndpoint: string
     preloadedState: Partial<ApiClientState>
   }) {
     super({
@@ -48,8 +44,8 @@ export class MakeswiftApiResourcesClient extends ApiResourcesClient {
     })
 
     // `MakeswiftApiResourcesClient` is used by the runtime and therefore will be imported
-    // on the client; lazy import server-side REST/GraphQL clients to avoid unnecessarily
-    // pulling their code into a client bundle.
+    // on the client; lazy import the server-side REST client to avoid unnecessarily
+    // pulling its code into a client bundle.
     //
     // (we can't easily lazy-load `MakeswiftApiResourcesClient` itself, at it will make its
     // construction async, but because it shares most of its implementation with
@@ -57,11 +53,6 @@ export class MakeswiftApiResourcesClient extends ApiResourcesClient {
     this.restApiClient = (async () => {
       const { MakeswiftRestAPIClient } = await import('./rest-api-client')
       return new MakeswiftRestAPIClient({ fetch, apiKey, apiOrigin })
-    })()
-
-    this.graphQlClient = (async () => {
-      const { MakeswiftGraphQLApiClient } = await import('./graphql-api-client')
-      return new MakeswiftGraphQLApiClient({ endpoint: graphqlApiEndpoint })
     })()
   }
 
@@ -106,6 +97,6 @@ export class MakeswiftApiResourcesClient extends ApiResourcesClient {
 
   protected async fetchTableImpl(id: string, _version: SiteVersion | null): Promise<Table | null> {
     // tables are unversioned
-    return (await this.graphQlClient).getTable(id)
+    return (await this.restApiClient).getTable(id)
   }
 }

--- a/packages/runtime/src/api/rest-api-client.ts
+++ b/packages/runtime/src/api/rest-api-client.ts
@@ -6,6 +6,7 @@ import {
   type LocalizedGlobalElement,
   type PagePathnameSlice,
   type Swatch,
+  type Table,
   type Typography,
   type HttpFetch,
 } from './types'
@@ -162,6 +163,23 @@ export class MakeswiftRestAPIClient {
     const localizedGlobalElement = await response.json()
 
     return localizedGlobalElement
+  }
+
+  async getTable(tableId: string): Promise<Table | null> {
+    const response = await this.fetch(`v1/tables/${tableId}`, null)
+
+    if (!response.ok) {
+      const failedBody = await failedResponseBody(response)
+      if (response.status === 404) return null
+
+      throw new RestApiClientError(`Failed to get table '${tableId}'`, response, {
+        body: failedBody,
+      })
+    }
+
+    const table = await response.json()
+
+    return table
   }
 
   async getPagePathnameSlices(

--- a/packages/runtime/src/client/index.ts
+++ b/packages/runtime/src/client/index.ts
@@ -10,7 +10,6 @@ import {
   type GlobalElement,
   type LocalizedGlobalElement,
   type Swatch,
-  type Table,
   type Typography,
 } from '../api/types'
 
@@ -950,10 +949,6 @@ export class MakeswiftClient extends MakeswiftRestAPIClient {
         },
       )
     }
-  }
-
-  async getTable(tableId: string): Promise<Table | null> {
-    return this.graphqlClient.getTable(tableId)
   }
 
   getTranslatableData(elementTree: ElementData): Record<string, Data> {

--- a/packages/runtime/src/runtimes/react/runtime-core.ts
+++ b/packages/runtime/src/runtimes/react/runtime-core.ts
@@ -161,7 +161,6 @@ export class RuntimeCore {
         fetch: this.fetch,
         apiKey: this.apiKey,
         apiOrigin: this.apiOrigin,
-        graphqlApiEndpoint: this.graphqlApiEndpoint,
         preloadedState,
       })
     }


### PR DESCRIPTION
## What?

- Fetches a table's schema through the Host API's `GET v1/tables/:id` REST endpoint instead of the GraphQL `Table` query.
- Removes the now-unused GraphQL `Table` query path (`MakeswiftGraphQLApiClient.getTable`, the `Table` query document, and its generated types) and the `graphqlApiEndpoint` plumbing into `MakeswiftApiResourcesClient`, which had no other use.

## Why?

Part of the Makeswift CDN effort to remove GraphQL from the runtime and route requests through the host API instead, mirroring the earlier `createTableRecord` migration to `POST /v1/table-records`.