### PR TITLE
chore(runtime): fix 'missing display name' warning in rich text v2

### DIFF
--- a/packages/runtime/src/runtimes/react/controls/rich-text-v2/EditableTextV2/render-element.tsx
+++ b/packages/runtime/src/runtimes/react/controls/rich-text-v2/EditableTextV2/render-element.tsx
@@ -16,20 +16,24 @@ export function RichTextV2Element({ definition, plugins, ...props }: RichTextV2E
   }
 
   const renderElement = plugins.reduce(
-    (renderFn, plugin) => (props: RenderElementProps) => {
-      const { control, renderElement } = plugin
+    (renderFn, plugin) =>
+      function RenderElementPlugin(props: RenderElementProps) {
+        const { control, renderElement } = plugin
 
-      if (renderElement == null) return renderFn(props)
+        if (renderElement == null) return renderFn(props)
 
-      if (control == null || control.getElementValue == null)
-        return renderElement(renderFn, undefined)(props)
+        if (control == null || control.getElementValue == null)
+          return renderElement(renderFn, undefined)(props)
 
-      return (
-        <ControlValue definition={control.definition} data={control.getElementValue(props.element)}>
-          {value => renderElement(renderFn, value)(props)}
-        </ControlValue>
-      )
-    },
+        return (
+          <ControlValue
+            definition={control.definition}
+            data={control.getElementValue(props.element)}
+          >
+            {value => renderElement(renderFn, value)(props)}
+          </ControlValue>
+        )
+      },
     initialRenderElement,
   )
 

--- a/packages/runtime/src/runtimes/react/controls/rich-text-v2/EditableTextV2/render-leaf.tsx
+++ b/packages/runtime/src/runtimes/react/controls/rich-text-v2/EditableTextV2/render-leaf.tsx
@@ -19,19 +19,20 @@ export function RichTextV2Leaf({ definition, plugins, ...props }: RichTextV2Leaf
   }
 
   const renderLeaf = plugins.reduce(
-    (renderFn, plugin) => (props: RenderLeafProps) => {
-      const { control, renderLeaf } = plugin
+    (renderFn, plugin) =>
+      function RenderLeafPlugin(props: RenderLeafProps) {
+        const { control, renderLeaf } = plugin
 
-      if (control?.definition == null || renderLeaf == null) return renderFn(props)
+        if (control?.definition == null || renderLeaf == null) return renderFn(props)
 
-      if (control.getLeafValue == null) return renderLeaf(renderFn, undefined)(props)
+        if (control.getLeafValue == null) return renderLeaf(renderFn, undefined)(props)
 
-      return (
-        <ControlValue definition={control.definition} data={control.getLeafValue(props.leaf)}>
-          {value => renderLeaf(renderFn, value)(props)}
-        </ControlValue>
-      )
-    },
+        return (
+          <ControlValue definition={control.definition} data={control.getLeafValue(props.leaf)}>
+            {value => renderLeaf(renderFn, value)(props)}
+          </ControlValue>
+        )
+      },
     initialRenderLeaf,
   )
 

--- a/packages/runtime/src/runtimes/react/controls/rich-text-v2/ReadOnlyTextV2.tsx
+++ b/packages/runtime/src/runtimes/react/controls/rich-text-v2/ReadOnlyTextV2.tsx
@@ -80,19 +80,20 @@ export function LeafComponent({ plugins, ...props }: LeafProps) {
   }
 
   const renderLeaf = plugins.reduce(
-    (renderFn, plugin) => (props: RenderLeafProps) => {
-      const { control, renderLeaf } = plugin
+    (renderFn, plugin) =>
+      function RenderLeafPlugin(props: RenderLeafProps) {
+        const { control, renderLeaf } = plugin
 
-      if (control?.definition == null || renderLeaf == null) return renderFn(props)
+        if (control?.definition == null || renderLeaf == null) return renderFn(props)
 
-      if (control.getLeafValue == null) return renderLeaf(renderFn, undefined)(props)
+        if (control.getLeafValue == null) return renderLeaf(renderFn, undefined)(props)
 
-      return (
-        <ControlValue definition={control.definition} data={control.getLeafValue(props.leaf)}>
-          {value => renderLeaf(renderFn, value)(props)}
-        </ControlValue>
-      )
-    },
+        return (
+          <ControlValue definition={control.definition} data={control.getLeafValue(props.leaf)}>
+            {value => renderLeaf(renderFn, value)(props)}
+          </ControlValue>
+        )
+      },
     initialRenderLeaf,
   )
 
@@ -110,19 +111,23 @@ function ElementComponent({ plugins, ...props }: ElementProps) {
   }
 
   const renderElement = plugins.reduce(
-    (renderFn, plugin) => (props: RenderElementProps) => {
-      const { control, renderElement } = plugin
+    (renderFn, plugin) =>
+      function RenderElementPlugin(props: RenderElementProps) {
+        const { control, renderElement } = plugin
 
-      if (control?.definition == null || renderElement == null) return renderFn(props)
+        if (control?.definition == null || renderElement == null) return renderFn(props)
 
-      if (control.getElementValue == null) return renderElement(renderFn, undefined)(props)
+        if (control.getElementValue == null) return renderElement(renderFn, undefined)(props)
 
-      return (
-        <ControlValue definition={control.definition} data={control.getElementValue(props.element)}>
-          {value => renderElement(renderFn, value)(props)}
-        </ControlValue>
-      )
-    },
+        return (
+          <ControlValue
+            definition={control.definition}
+            data={control.getElementValue(props.element)}
+          >
+            {value => renderElement(renderFn, value)(props)}
+          </ControlValue>
+        )
+      },
     initialRenderElement,
   )
 


### PR DESCRIPTION
Fix 'Component definition is missing display name' warning. No semantic changes. Best reviewed with "Hide whitespace" setting on.