### PR TITLE
refactor(runtime): pass config instead of full rich text definition

### DIFF
--- a/packages/runtime/src/controls/rich-text-v2/rich-text-v2.ts
+++ b/packages/runtime/src/controls/rich-text-v2/rich-text-v2.ts
@@ -126,7 +126,7 @@ class Definition extends BaseRichTextDefinition<ReactNode, Config, InstanceType>
   ): Resolvable<ReactNode | undefined> {
     const stableValue = StableValue({
       name: Definition.type,
-      read: () => renderRichTextV2(data, this, control ?? null),
+      read: () => renderRichTextV2(data, this.config, control ?? null),
     })
 
     return {

--- a/packages/runtime/src/runtimes/react/controls/rich-text-v2/EditableTextV2/editable-text-v2.tsx
+++ b/packages/runtime/src/runtimes/react/controls/rich-text-v2/EditableTextV2/editable-text-v2.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import {
-  FocusEvent,
-  KeyboardEvent,
-  MouseEvent,
+  type FocusEvent,
+  type KeyboardEvent,
+  type MouseEvent,
   useCallback,
   useEffect,
   useMemo,
@@ -21,6 +21,8 @@ import {
   Editable,
 } from 'slate-react'
 
+import { type ConfigType } from '@makeswift/controls'
+
 import {
   RichTextV2Definition,
   RichText,
@@ -28,11 +30,12 @@ import {
   type RichTextDataV2,
 } from '../../../../../controls/rich-text-v2'
 
-import { useBuilderEditMode } from '../../..'
+import { useBuilderEditMode } from '../../../hooks/use-builder-edit-mode'
 import { useSlateReset } from '../../use-slate-reset'
 import { BuilderEditMode } from '../../../../../state/modules/builder-edit-mode'
 import { pollBoxModel } from '../../../poll-box-model'
 import { withBuilder, withLocalChanges } from '../../../../../slate'
+
 import { useSyncDOMSelection } from './useSyncDOMSelection'
 import { RichTextV2Element } from './render-element'
 import { RichTextV2Leaf } from './render-leaf'
@@ -41,12 +44,12 @@ import { defaultValue, usePresetValue } from './usePresetValue'
 
 type Props = {
   text?: RichTextDataV2
-  definition: RichTextV2Definition
+  config: ConfigType<RichTextV2Definition>
   control: RichTextV2Control | null
 }
 
-export function EditableTextV2({ text, definition, control }: Props) {
-  const plugins = useMemo(() => definition.config.plugins, [definition])
+export function EditableTextV2({ text, config, control }: Props) {
+  const plugins = useMemo(() => config.plugins, [config])
 
   const [editor] = useState(() =>
     plugins.reduceRight(
@@ -81,7 +84,7 @@ export function EditableTextV2({ text, definition, control }: Props) {
       isPreservingFocus.current = false
       ReactEditor.deselect(editor)
     }
-  }, [editMode])
+  }, [editMode, editor])
 
   // ------ Syncing remote changes ------
 
@@ -89,7 +92,7 @@ export function EditableTextV2({ text, definition, control }: Props) {
 
   // ------ Default value ------
 
-  const presetValue = usePresetValue(definition)
+  const presetValue = usePresetValue(config)
 
   const initialValue = useMemo(
     () => (text && RichText.dataToNodes(text)) ?? presetValue,
@@ -114,16 +117,16 @@ export function EditableTextV2({ text, definition, control }: Props) {
 
   const renderElement = useCallback(
     (props: RenderElementProps) => {
-      return <RichTextV2Element {...props} definition={definition} plugins={plugins} />
+      return <RichTextV2Element {...props} plugins={plugins} />
     },
-    [plugins, definition],
+    [plugins],
   )
 
   const renderLeaf = useCallback(
     (props: RenderLeafProps) => {
-      return <RichTextV2Leaf {...props} definition={definition} plugins={plugins} />
+      return <RichTextV2Leaf {...props} plugins={plugins} />
     },
-    [plugins, definition],
+    [plugins],
   )
 
   // ------ Event handlers ------
@@ -159,7 +162,7 @@ export function EditableTextV2({ text, definition, control }: Props) {
         e.preventDefault()
       }
     },
-    [control, editor, editMode],
+    [editMode],
   )
 
   const handleClick = useCallback(
@@ -199,5 +202,3 @@ export function EditableTextV2({ text, definition, control }: Props) {
     </Slate>
   )
 }
-
-export default EditableTextV2

--- a/packages/runtime/src/runtimes/react/controls/rich-text-v2/EditableTextV2/index.tsx
+++ b/packages/runtime/src/runtimes/react/controls/rich-text-v2/EditableTextV2/index.tsx
@@ -1,3 +1,3 @@
 export * from './editable-text-v2'
-import EditableTextV2 from './editable-text-v2'
+import { EditableTextV2 } from './editable-text-v2'
 export default EditableTextV2

--- a/packages/runtime/src/runtimes/react/controls/rich-text-v2/EditableTextV2/render-element.tsx
+++ b/packages/runtime/src/runtimes/react/controls/rich-text-v2/EditableTextV2/render-element.tsx
@@ -1,16 +1,14 @@
 import { RenderElementProps } from 'slate-react'
 
-import { RichTextV2Definition } from '../../../../../controls/rich-text-v2'
 import { RichTextV2Plugin } from '../../../../../controls/rich-text-v2/plugin'
 
 import { ControlValue } from '../../control'
 
 type RichTextV2ElementProps = RenderElementProps & {
-  definition: RichTextV2Definition
   plugins: RichTextV2Plugin[]
 }
 
-export function RichTextV2Element({ definition, plugins, ...props }: RichTextV2ElementProps) {
+export function RichTextV2Element({ plugins, ...props }: RichTextV2ElementProps) {
   function initialRenderElement(props: RenderElementProps) {
     return props.children
   }

--- a/packages/runtime/src/runtimes/react/controls/rich-text-v2/EditableTextV2/render-leaf.tsx
+++ b/packages/runtime/src/runtimes/react/controls/rich-text-v2/EditableTextV2/render-leaf.tsx
@@ -1,15 +1,13 @@
 import { ReactNode } from 'react'
 import { RenderLeafProps } from 'slate-react'
-import { RichTextV2Definition } from '../../../../../controls/rich-text-v2'
 import { RichTextV2Plugin } from '../../../../../controls/rich-text-v2/plugin'
 import { ControlValue } from '../../control'
 
 type RichTextV2LeafProps = RenderLeafProps & {
-  definition: RichTextV2Definition
   plugins: RichTextV2Plugin[]
 }
 
-export function RichTextV2Leaf({ definition, plugins, ...props }: RichTextV2LeafProps) {
+export function RichTextV2Leaf({ plugins, ...props }: RichTextV2LeafProps) {
   function initialRenderLeaf({ attributes, children, leaf }: RenderLeafProps): ReactNode {
     return (
       <span className={leaf.className} {...attributes}>

--- a/packages/runtime/src/runtimes/react/controls/rich-text-v2/EditableTextV2/usePresetValue.tsx
+++ b/packages/runtime/src/runtimes/react/controls/rich-text-v2/EditableTextV2/usePresetValue.tsx
@@ -1,12 +1,13 @@
 import { useMemo } from 'react'
 import { Descendant } from 'slate'
-import { Slate, getBaseBreakpoint } from '@makeswift/controls'
+
+import { type ConfigType, Slate, getBaseBreakpoint } from '@makeswift/controls'
 
 import { DefaultBreakpointID } from '../../../../../state/modules/breakpoints'
 import { useBreakpoints } from '../../../hooks/use-breakpoints'
 import { RichTextV2Definition, RichText } from '../../../../../controls'
 
-export function usePresetValue(definition: RichTextV2Definition): Descendant[] {
+export function usePresetValue(config: ConfigType<RichTextV2Definition>): Descendant[] {
   const breakpoints = useBreakpoints()
   return useMemo(
     () => [
@@ -14,8 +15,8 @@ export function usePresetValue(definition: RichTextV2Definition): Descendant[] {
         type: Slate.BlockType.Default,
         children: [
           {
-            text: definition.config.defaultValue ?? '',
-            ...(definition.config.mode === RichText.Mode.Inline
+            text: config.defaultValue ?? '',
+            ...(config.mode === RichText.Mode.Inline
               ? {}
               : {
                   typography: {
@@ -43,7 +44,7 @@ export function usePresetValue(definition: RichTextV2Definition): Descendant[] {
         ],
       },
     ],
-    [definition.config.mode, definition.config.defaultValue, breakpoints],
+    [config.mode, config.defaultValue, breakpoints],
   )
 }
 

--- a/packages/runtime/src/runtimes/react/controls/rich-text-v2/ReadOnlyTextV2.tsx
+++ b/packages/runtime/src/runtimes/react/controls/rich-text-v2/ReadOnlyTextV2.tsx
@@ -1,28 +1,32 @@
-import { ForwardedRef, forwardRef, ReactNode } from 'react'
-import { Descendant, Element, Text } from 'slate'
-import { RenderElementProps, RenderLeafProps } from 'slate-react'
+import { type ReactNode, type ForwardedRef, forwardRef, useMemo } from 'react'
+import { type Descendant, type Element, type Text } from 'slate'
+import { type RenderElementProps, type RenderLeafProps } from 'slate-react'
 
-import { RichTextV2Definition, RichText } from '../../../../controls/rich-text-v2'
+import { type ConfigType } from '@makeswift/controls'
+
+import {
+  type RichTextDataV2,
+  RichTextV2Definition,
+  RichText,
+} from '../../../../controls/rich-text-v2'
 import { useStyle } from '../../use-style'
 import { toText } from '../../../../slate/utils'
 import { RichTextV2Plugin } from '../../../../controls/rich-text-v2/plugin'
-import { RichTextDataV2 } from '../../../../controls/rich-text-v2'
 
 import { ControlValue } from '../control'
 
 type Props = {
   text: RichTextDataV2 | undefined
-  definition: RichTextV2Definition | undefined
+  config: ConfigType<RichTextV2Definition> | undefined
 }
 
 const ReadOnlyTextV2 = forwardRef(function ReadOnlyText(
-  { text, definition }: Props,
+  { text, config }: Props,
   ref: ForwardedRef<HTMLDivElement>,
 ) {
-  const descendantsAsString = toText(
-    text?.descendants ?? [],
-    definition?.config.mode ?? RichText.Mode.Block,
-  )
+  const descendants = useMemo(() => text?.descendants ?? [], [text?.descendants])
+  const plugins = useMemo(() => config?.plugins ?? [], [config])
+  const descendantsAsString = toText(descendants, config?.mode ?? RichText.Mode.Block)
 
   return (
     <div
@@ -41,10 +45,7 @@ const ReadOnlyTextV2 = forwardRef(function ReadOnlyText(
       {descendantsAsString === '' ? (
         <Placeholder />
       ) : (
-        <Descendants
-          plugins={definition?.config.plugins ?? []}
-          descendants={text?.descendants ?? []}
-        />
+        <Descendants plugins={plugins} descendants={descendants} />
       )}
     </div>
   )

--- a/packages/runtime/src/runtimes/react/controls/rich-text-v2/render-rich-text-v2.tsx
+++ b/packages/runtime/src/runtimes/react/controls/rich-text-v2/render-rich-text-v2.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode, lazy } from 'react'
 
-import { type DataType } from '@makeswift/controls'
+import { type DataType, type ConfigType } from '@makeswift/controls'
 
 import { RichTextV2Control, RichTextV2Definition } from '../../../../controls/rich-text-v2'
 
@@ -10,12 +10,12 @@ const ReadOnlyTextV1 = lazy(() => import('../rich-text/ReadOnlyText'))
 
 export function renderRichTextV2(
   data: DataType<RichTextV2Definition> | undefined,
-  definition: RichTextV2Definition,
+  config: ConfigType<RichTextV2Definition>,
   control: RichTextV2Control | null,
 ): ReactNode {
   return RichTextV2Definition.isV1Data(data) ? (
     <ReadOnlyTextV1 text={data} />
   ) : (
-    <RichTextV2Value data={data} definition={definition} control={control} />
+    <RichTextV2Value data={data} config={config} control={control} />
   )
 }

--- a/packages/runtime/src/runtimes/react/controls/rich-text-v2/rich-text-v2-value.tsx
+++ b/packages/runtime/src/runtimes/react/controls/rich-text-v2/rich-text-v2-value.tsx
@@ -2,6 +2,8 @@
 
 import { lazy } from 'react'
 
+import { type ConfigType } from '@makeswift/controls'
+
 import {
   type RichTextDataV2,
   RichTextV2Definition,
@@ -15,16 +17,16 @@ const ReadOnlyText = lazy(() => import('./ReadOnlyTextV2'))
 
 export function RichTextV2Value({
   data,
-  definition,
+  config,
   control,
 }: {
   data: RichTextDataV2 | undefined
-  definition: RichTextV2Definition
+  config: ConfigType<RichTextV2Definition>
   control: RichTextV2Control | null
 }) {
   return useIsReadOnly() ? (
-    <ReadOnlyText text={data} definition={definition} />
+    <ReadOnlyText text={data} config={config} />
   ) : (
-    <EditableText text={data} definition={definition} control={control} />
+    <EditableText text={data} config={config} control={control} />
   )
 }


### PR DESCRIPTION
RSC rendering prep, part 2: Pass config instead of full rich text definition when rendering rich text.

Smoke test:

https://github.com/user-attachments/assets/8ea08705-c58e-4d23-ae8b-36f4e0f162b1


