### PR TITLE
refactor(runtime): move rich text plugins out of config

### DIFF
--- a/packages/runtime/src/controls/rich-text-v2/__tests__/__snapshots__/serialization.test.ts.snap
+++ b/packages/runtime/src/controls/rich-text-v2/__tests__/__snapshots__/serialization.test.ts.snap
@@ -5,141 +5,141 @@ RichTextV2Definition {
   "config": {
     "defaultValue": "[generated random text]",
     "mode": undefined,
-    "plugins": [
-      {
-        "control": {
-          "definition": SelectDefinition {
-            "config": {
-              "defaultValue": "paragraph",
-              "label": "Block",
-              "labelOrientation": "horizontal",
-              "options": [
-                {
-                  "label": "Paragraph",
-                  "value": "paragraph",
-                },
-                {
-                  "label": "Heading 1",
-                  "value": "heading-one",
-                },
-                {
-                  "label": "Heading 2",
-                  "value": "heading-two",
-                },
-                {
-                  "label": "Heading 3",
-                  "value": "heading-three",
-                },
-                {
-                  "label": "Heading 4",
-                  "value": "heading-four",
-                },
-                {
-                  "label": "Heading 5",
-                  "value": "heading-five",
-                },
-                {
-                  "label": "Heading 6",
-                  "value": "heading-six",
-                },
-                {
-                  "label": "Bulleted list",
-                  "value": "unordered-list",
-                },
-                {
-                  "label": "Numbered list",
-                  "value": "ordered-list",
-                },
-                {
-                  "label": "Quote",
-                  "value": "blockquote",
-                },
-              ],
-            },
+  },
+  "plugins": [
+    {
+      "control": {
+        "definition": SelectDefinition {
+          "config": {
+            "defaultValue": "paragraph",
+            "label": "Block",
+            "labelOrientation": "horizontal",
+            "options": [
+              {
+                "label": "Paragraph",
+                "value": "paragraph",
+              },
+              {
+                "label": "Heading 1",
+                "value": "heading-one",
+              },
+              {
+                "label": "Heading 2",
+                "value": "heading-two",
+              },
+              {
+                "label": "Heading 3",
+                "value": "heading-three",
+              },
+              {
+                "label": "Heading 4",
+                "value": "heading-four",
+              },
+              {
+                "label": "Heading 5",
+                "value": "heading-five",
+              },
+              {
+                "label": "Heading 6",
+                "value": "heading-six",
+              },
+              {
+                "label": "Bulleted list",
+                "value": "unordered-list",
+              },
+              {
+                "label": "Numbered list",
+                "value": "ordered-list",
+              },
+              {
+                "label": "Quote",
+                "value": "blockquote",
+              },
+            ],
           },
         },
       },
-      {
-        "control": {
-          "definition": Typography {
-            "config": {},
-          },
+    },
+    {
+      "control": {
+        "definition": Typography {
+          "config": {},
         },
       },
-      {
-        "control": {
-          "definition": StyleV2Definition {
-            "config": {
-              "getStyle": [Function],
-              "type": IconRadioGroupDefinition {
-                "config": {
-                  "defaultValue": "left",
-                  "label": "Alignment",
-                  "options": [
-                    {
-                      "icon": "text-align-left",
-                      "label": "Left Align",
-                      "value": "left",
-                    },
-                    {
-                      "icon": "text-align-center",
-                      "label": "Center Align",
-                      "value": "center",
-                    },
-                    {
-                      "icon": "text-align-right",
-                      "label": "Right Align",
-                      "value": "right",
-                    },
-                    {
-                      "icon": "text-align-justify",
-                      "label": "Justify",
-                      "value": "justify",
-                    },
-                  ],
-                },
+    },
+    {
+      "control": {
+        "definition": StyleV2Definition {
+          "config": {
+            "getStyle": [Function],
+            "type": IconRadioGroupDefinition {
+              "config": {
+                "defaultValue": "left",
+                "label": "Alignment",
+                "options": [
+                  {
+                    "icon": "text-align-left",
+                    "label": "Left Align",
+                    "value": "left",
+                  },
+                  {
+                    "icon": "text-align-center",
+                    "label": "Center Align",
+                    "value": "center",
+                  },
+                  {
+                    "icon": "text-align-right",
+                    "label": "Right Align",
+                    "value": "right",
+                  },
+                  {
+                    "icon": "text-align-justify",
+                    "label": "Justify",
+                    "value": "justify",
+                  },
+                ],
               },
             },
           },
         },
       },
-      {
-        "control": {
-          "definition": IconRadioGroupDefinition {
-            "config": {
-              "label": "Inline",
-              "options": [
-                {
-                  "icon": "superscript",
-                  "label": "Superscript",
-                  "value": "superscript",
-                },
-                {
-                  "icon": "subscript",
-                  "label": "Subscript",
-                  "value": "subscript",
-                },
-                {
-                  "icon": "code",
-                  "label": "Code",
-                  "value": "code",
-                },
-              ],
-            },
+    },
+    {
+      "control": {
+        "definition": IconRadioGroupDefinition {
+          "config": {
+            "label": "Inline",
+            "options": [
+              {
+                "icon": "superscript",
+                "label": "Superscript",
+                "value": "superscript",
+              },
+              {
+                "icon": "subscript",
+                "label": "Subscript",
+                "value": "subscript",
+              },
+              {
+                "icon": "code",
+                "label": "Code",
+                "value": "code",
+              },
+            ],
           },
         },
       },
-      {
-        "control": {
-          "definition": LinkDefinition {
-            "config": {
-              "label": "On Click",
-            },
+    },
+    {
+      "control": {
+        "definition": LinkDefinition {
+          "config": {
+            "label": "On Click",
           },
         },
       },
-    ],
-  },
+    },
+  ],
 }
 `;
 
@@ -310,10 +310,10 @@ RichTextV2Definition {
   "config": {
     "defaultValue": "Edit this text",
     "mode": "makeswift::controls::rich-text-v2::mode::inline",
-    "plugins": [
-      {},
-    ],
   },
+  "plugins": [
+    {},
+  ],
 }
 `;
 

--- a/packages/runtime/src/controls/rich-text-v2/rich-text-v2.ts
+++ b/packages/runtime/src/controls/rich-text-v2/rich-text-v2.ts
@@ -41,22 +41,31 @@ type InstanceType = RichTextV2Control
 type UserConfig = z.infer<typeof Definition.schema.userConfig>
 type Config = UserConfig & {
   defaultValue: string
-  plugins: RichTextV2Plugin[]
 }
 
 class Definition extends BaseRichTextDefinition<ReactNode, Config, InstanceType> {
+  readonly plugins: RichTextV2Plugin[]
+
   constructor({ mode, defaultValue }: UserConfig, plugins?: RichTextV2Plugin[]) {
     super({
       mode,
       defaultValue:
         defaultValue ??
         (mode === Definition.Mode.Inline ? 'Edit this text' : Definition.generateParagraph()),
-      plugins:
-        plugins ??
-        (mode === Definition.Mode.Inline
-          ? [InlineModePlugin()]
-          : [BlockPlugin(), TypographyPlugin(), TextAlignPlugin(), InlinePlugin(), LinkPlugin()]),
     })
+
+    // The built-in plugin set is currently determined entirely by `mode` and
+    // has remained stable across runtime versions, so it does not need to be
+    // stored in the internal config. When that changes, we should:
+    //  - introduce a plugin registry
+    //  - have the config carry the IDs of selected plugins
+    //  - use the current inline and block plugin sets as defaults when
+    //    deserializing a legacy config that does not include plugin IDs
+    this.plugins =
+      plugins ??
+      (mode === Definition.Mode.Inline
+        ? [InlineModePlugin()]
+        : [BlockPlugin(), TypographyPlugin(), TextAlignPlugin(), InlinePlugin(), LinkPlugin()])
   }
 
   static generateParagraph(): string {
@@ -71,15 +80,15 @@ class Definition extends BaseRichTextDefinition<ReactNode, Config, InstanceType>
       throw new Error(`RichText: expected type ${Definition.type}, got ${data.type}`)
     }
 
-    const { config } = Definition.fullSchema({
+    const { config, plugins } = Definition.fullSchema({
       pluginDef: SerializationSchema.deserializedRecord,
     }).definition.parse(data)
 
-    const { plugins, ...userConfig } = config
+    const { plugins: configPlugins, ...userConfig } = config
 
     return new RichTextV2Definition(
       userConfig,
-      plugins.map(({ control }) =>
+      (plugins ?? configPlugins ?? []).map(({ control }) =>
         control ? { control: { definition: deserializeCallback(control?.definition) } } : {},
       ),
     )
@@ -95,9 +104,13 @@ class Definition extends BaseRichTextDefinition<ReactNode, Config, InstanceType>
         .optional(),
     })
 
-    const config = baseSchema.userConfig.extend({
-      defaultValue: z.string(),
-      plugins: z.array(plugin),
+    const plugins = z.array(plugin)
+
+    const config = Definition.configSchema().extend({
+      // plugins have been moved from config to the definition itself; keeping
+      // the field here as optional so we can deserialize definitions coming from
+      // older runtimes
+      plugins: plugins.optional(),
     })
 
     return {
@@ -105,13 +118,21 @@ class Definition extends BaseRichTextDefinition<ReactNode, Config, InstanceType>
       config,
       definition: z.object({
         type: baseSchema.type,
+        // marked as optional for backward compatibility with older runtimes
+        plugins: plugins.optional(),
         config,
       }),
     }
   }
 
+  static configSchema() {
+    return super.schema.userConfig.extend({
+      defaultValue: z.string(),
+    })
+  }
+
   get configSchema(): SchemaType<Config> {
-    return Definition.fullSchema({ pluginDef: z.any() as SchemaType<ControlDefinition> }).config
+    return Definition.configSchema()
   }
 
   createInstance(args: ControlInstanceArgs) {
@@ -137,11 +158,11 @@ class Definition extends BaseRichTextDefinition<ReactNode, Config, InstanceType>
 
   getTranslatableData(data: DataType | undefined): Data {
     if (data == null) return null
-    return getTranslatableData(Definition.dataToNodes(data), this.config.plugins)
+    return getTranslatableData(Definition.dataToNodes(data), this.plugins)
   }
 
   get pluginControls(): RichTextPluginControl[] {
-    return this.config.plugins.map(plugin => plugin.control).filter(isNotNil)
+    return this.plugins.map(plugin => plugin.control).filter(isNotNil)
   }
 
   pluginControlAt(index: number): RichTextPluginControl | undefined {

--- a/packages/runtime/src/controls/serialization/base/visitor.ts
+++ b/packages/runtime/src/controls/serialization/base/visitor.ts
@@ -19,10 +19,8 @@ export class BaseControlSerializationVisitor extends ControlSerializationVisitor
   }
 
   visitRichTextV2(def: RichTextV2Definition): SerializedRecord {
-    const { plugins, ...config } = def.config
-
     // serialize only the plugin control definition, if any
-    const pluginDefs = plugins.map(({ control }) =>
+    const pluginDefs = def.plugins.map(({ control }) =>
       control
         ? {
             control: {
@@ -37,7 +35,10 @@ export class BaseControlSerializationVisitor extends ControlSerializationVisitor
     )
 
     const serialized = serializeObject(
-      { config: { ...config, plugins: pluginDefs } },
+      // Continue serializing plugins as part of the config for the time being
+      // for builder compatibility; the current runtime accept plugins either in
+      // the config or at the definition level -- see `RichTextV2Definition.fullSchema`
+      { config: { ...def.config, plugins: pluginDefs } },
       this.serializationPlugins,
     ) as SerializedRecord
 

--- a/packages/runtime/src/controls/visitors/merge-translations-visitor.ts
+++ b/packages/runtime/src/controls/visitors/merge-translations-visitor.ts
@@ -19,7 +19,7 @@ export class ReactMergeTranslationsVisitor extends MergeTranslationsVisitor {
       descendants: mergeTranslatedNodes(
         descendants,
         translatedData as RichTextTranslationDto,
-        def.config.plugins,
+        def.plugins,
       ),
     }
   }

--- a/packages/runtime/src/runtimes/react/controls/rich-text-v2/EditableTextV2/editable-text-v2.tsx
+++ b/packages/runtime/src/runtimes/react/controls/rich-text-v2/EditableTextV2/editable-text-v2.tsx
@@ -49,7 +49,7 @@ type Props = {
 }
 
 export function EditableTextV2({ text, config, control }: Props) {
-  const plugins = useMemo(() => config.plugins, [config])
+  const plugins = useMemo(() => new RichTextV2Definition(config).plugins, [config])
 
   const [editor] = useState(() =>
     plugins.reduceRight(

--- a/packages/runtime/src/runtimes/react/controls/rich-text-v2/EditableTextV2/index.tsx
+++ b/packages/runtime/src/runtimes/react/controls/rich-text-v2/EditableTextV2/index.tsx
@@ -1,3 +1,2 @@
-export * from './editable-text-v2'
 import { EditableTextV2 } from './editable-text-v2'
 export default EditableTextV2

--- a/packages/runtime/src/runtimes/react/controls/rich-text-v2/ReadOnlyTextV2.tsx
+++ b/packages/runtime/src/runtimes/react/controls/rich-text-v2/ReadOnlyTextV2.tsx
@@ -25,7 +25,7 @@ const ReadOnlyTextV2 = forwardRef(function ReadOnlyText(
   ref: ForwardedRef<HTMLDivElement>,
 ) {
   const descendants = useMemo(() => text?.descendants ?? [], [text?.descendants])
-  const plugins = useMemo(() => config?.plugins ?? [], [config])
+  const plugins = useMemo(() => (config ? new RichTextV2Definition(config).plugins : []), [config])
   const descendantsAsString = toText(descendants, config?.mode ?? RichText.Mode.Block)
 
   return (


### PR DESCRIPTION
RSC rendering prep, part 3: Move rich text plugins out of config and into the definition itself. Backward compatible with older runtimes/current builder. Following up https://github.com/makeswift/makeswift/pull/1432.

Smoke test:

https://github.com/user-attachments/assets/7210c8b7-99e2-4c88-a1f0-a5ffabefb522

