### PR TITLE
feat(controls): Add provides to additional control configs

### DIFF
--- a/.changeset/wide-cougars-press.md
+++ b/.changeset/wide-cougars-press.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/controls': patch
+---
+
+Add provides (context value) field to additional control configs

--- a/.changeset/wide-cougars-press.md
+++ b/.changeset/wide-cougars-press.md
@@ -2,4 +2,4 @@
 '@makeswift/controls': patch
 ---
 
-Add provides (context value) field to additional control configs
+Add `provides` (context value) field to additional control configs

--- a/packages/controls/src/controls/checkbox/checkbox.test.ts
+++ b/packages/controls/src/controls/checkbox/checkbox.test.ts
@@ -1,5 +1,7 @@
 import { testDefinition, testResolveValue } from '../../testing/test-definition'
 
+import { unstable_ContextValue } from '../context-value'
+
 import { Checkbox, CheckboxDefinition } from './checkbox'
 
 describe('Checkbox', () => {
@@ -36,6 +38,12 @@ describe('Checkbox', () => {
     assignTest(Checkbox({ defaultValue: undefined }))
     assignTest(Checkbox({ label: 'visible', defaultValue: undefined }))
     assignTest(Checkbox({ label: undefined, defaultValue: undefined }))
+    assignTest(
+      Checkbox({
+        defaultValue: true,
+        provides: unstable_ContextValue('checked').ofType<boolean>(),
+      }),
+    )
   })
 })
 

--- a/packages/controls/src/controls/checkbox/checkbox.test.types.ts
+++ b/packages/controls/src/controls/checkbox/checkbox.test.types.ts
@@ -1,7 +1,5 @@
 import { expectTypeOf } from 'expect-type'
 
-import { Flatten } from '../../testing/util-types'
-
 import { ControlDataTypeKey } from '../../common'
 
 import {
@@ -25,7 +23,7 @@ describe('Checkbox Types', () => {
 
     type ConfigType = typeof def.config
 
-    expectTypeOf<Flatten<ConfigType>>().toEqualTypeOf<{
+    expectTypeOf<ConfigType>().toEqualTypeOf<{
       label?: string
       description?: string
       defaultValue: boolean
@@ -46,7 +44,7 @@ describe('Checkbox Types', () => {
     const def = Checkbox()
 
     type ConfigType = typeof def.config
-    expectTypeOf<Flatten<ConfigType>>().toEqualTypeOf<{
+    expectTypeOf<ConfigType>().toEqualTypeOf<{
       label?: string
       description?: string
       defaultValue?: boolean

--- a/packages/controls/src/controls/checkbox/checkbox.test.types.ts
+++ b/packages/controls/src/controls/checkbox/checkbox.test.types.ts
@@ -7,6 +7,7 @@ import {
   type ResolvedValueType,
   type ValueType,
 } from '../associated-types'
+import { unstable_ContextValue } from '../context-value'
 
 import { Checkbox } from './checkbox'
 
@@ -60,5 +61,18 @@ describe('Checkbox Types', () => {
     type Resolved = ResolvedValueType<typeof def>
 
     expectTypeOf<Resolved>().toEqualTypeOf<boolean | undefined>()
+  })
+
+  test('infers types from control definitions (provided context)', () => {
+    const checkedContext = unstable_ContextValue('checked').ofType<boolean>()
+    const def = Checkbox({ defaultValue: true, provides: checkedContext })
+
+    type ConfigType = typeof def.config
+    expectTypeOf<ConfigType>().toEqualTypeOf<{
+      label?: string
+      description?: string
+      defaultValue: boolean
+      provides?: typeof checkedContext
+    }>()
   })
 })

--- a/packages/controls/src/controls/checkbox/checkbox.test.types.ts
+++ b/packages/controls/src/controls/checkbox/checkbox.test.types.ts
@@ -1,5 +1,7 @@
 import { expectTypeOf } from 'expect-type'
 
+import { Flatten } from '../../testing/util-types'
+
 import { ControlDataTypeKey } from '../../common'
 
 import {
@@ -23,10 +25,11 @@ describe('Checkbox Types', () => {
 
     type ConfigType = typeof def.config
 
-    expectTypeOf<ConfigType>().toEqualTypeOf<{
+    expectTypeOf<Flatten<ConfigType>>().toEqualTypeOf<{
       label?: string
       description?: string
       defaultValue: boolean
+      provides?: undefined
     }>()
 
     type Data = DataType<typeof def>
@@ -43,10 +46,11 @@ describe('Checkbox Types', () => {
     const def = Checkbox()
 
     type ConfigType = typeof def.config
-    expectTypeOf<ConfigType>().toEqualTypeOf<{
+    expectTypeOf<Flatten<ConfigType>>().toEqualTypeOf<{
       label?: string
       description?: string
       defaultValue?: boolean
+      provides?: undefined
     }>()
 
     type Data = DataType<typeof def>

--- a/packages/controls/src/controls/checkbox/checkbox.ts
+++ b/packages/controls/src/controls/checkbox/checkbox.ts
@@ -7,11 +7,7 @@ import { ControlDataTypeKey } from '../../common'
 import { type CopyContext } from '../../context'
 import { type DeserializedRecord } from '../../serialization'
 
-import {
-  ContextValueSchema,
-  type AnyContextValue,
-  type ProvidesConfig,
-} from '../context-value'
+import { ContextValueSchema, type AnyContextValue } from '../context-value'
 import {
   ControlDefinition,
   type Resolvable,
@@ -20,15 +16,20 @@ import {
 import { DefaultControlInstance, type ControlInstanceArgs } from '../instance'
 import { ControlDefinitionVisitor } from '../visitor'
 
-type Config<P extends AnyContextValue = AnyContextValue> = z.infer<
-  typeof Definition.schema.relaxed.config
-> &
-  ProvidesConfig<P>
+type DefinitionSchema<P extends AnyContextValue = AnyContextValue> = ReturnType<
+  typeof Definition.schema<P>
+>
 
-type SchemaByDefaultValue<D extends Config['defaultValue']> =
-  undefined extends D
-    ? typeof Definition.schema.relaxed
-    : typeof Definition.schema.strict
+type Config<P extends AnyContextValue = AnyContextValue> = z.infer<
+  DefinitionSchema<P>['relaxed']['config']
+>
+
+type SchemaByDefaultValue<
+  D extends Config['defaultValue'],
+  P extends AnyContextValue = AnyContextValue,
+> = undefined extends D
+  ? DefinitionSchema<P>['relaxed']
+  : DefinitionSchema<P>['strict']
 
 type Schema<C extends Config> = SchemaByDefaultValue<C['defaultValue']>
 type DataType<C extends Config> = z.infer<Schema<C>['data']>
@@ -36,8 +37,8 @@ type ValueType<C extends Config> = z.infer<Schema<C>['value']>
 type ResolvedValueType<C extends Config> = z.infer<Schema<C>['resolvedValue']>
 
 type ReturnedSchemaType<C extends Config> = {
-  definition: typeof Definition.schema.relaxed.definition
-  type: typeof Definition.schema.relaxed.type
+  definition: DefinitionSchema['relaxed']['definition']
+  type: DefinitionSchema['relaxed']['type']
   data: SchemaType<DataType<C>>
   value: SchemaType<ValueType<C>>
   resolvedValue: SchemaType<ResolvedValueType<C>>
@@ -57,7 +58,9 @@ class Definition<C extends Config> extends ControlDefinition<
 
   static readonly type = 'makeswift::controls::checkbox' as const
 
-  static get schema() {
+  static schema<P extends AnyContextValue = AnyContextValue>() {
+    const provides = ContextValueSchema.provides as SchemaType<P>
+
     const version = z.literal(1).optional()
     const versionedData = z.object({
       [ControlDataTypeKey]: z.literal(this.v1DataType),
@@ -71,7 +74,7 @@ class Definition<C extends Config> extends ControlDefinition<
         label: z.string().optional(),
         description: z.string().optional(),
         defaultValue: value,
-        provides: ContextValueSchema.provides.optional(),
+        provides: provides.optional(),
       })
 
       const definition = z.object({
@@ -108,13 +111,14 @@ class Definition<C extends Config> extends ControlDefinition<
         `Checkbox: expected '${Definition.type}', got '${data.type}'`,
       )
 
-    const { config, version } = Definition.schema.relaxed.definition.parse(data)
+    const { config, version } =
+      Definition.schema().relaxed.definition.parse(data)
     return new CheckboxDefinition(config, version)
   }
 
   constructor(
     config: C,
-    readonly version: z.infer<typeof Definition.schema.version>,
+    readonly version: z.infer<DefinitionSchema['version']>,
   ) {
     super(config)
   }
@@ -124,14 +128,14 @@ class Definition<C extends Config> extends ControlDefinition<
   }
 
   get schema(): ReturnedSchemaType<C> {
-    return Definition.schema.relaxed
+    return Definition.schema().relaxed
   }
 
   get dataSchema() {
     return (
       (this.config.defaultValue === undefined
-        ? Definition.schema.relaxed
-        : Definition.schema.strict) as Schema<C>
+        ? Definition.schema().relaxed
+        : Definition.schema().strict) as Schema<C>
     ).data
   }
 
@@ -204,7 +208,7 @@ type UserConfig<
 type NormedConfig<
   D extends Config['defaultValue'],
   P extends AnyContextValue,
-> = z.infer<SchemaByDefaultValue<D>['config']> & ProvidesConfig<P>
+> = z.infer<SchemaByDefaultValue<D, P>['config']>
 
 export function Checkbox<
   D extends Config['defaultValue'],

--- a/packages/controls/src/controls/checkbox/checkbox.ts
+++ b/packages/controls/src/controls/checkbox/checkbox.ts
@@ -8,6 +8,11 @@ import { type CopyContext } from '../../context'
 import { type DeserializedRecord } from '../../serialization'
 
 import {
+  ContextValueSchema,
+  type AnyContextValue,
+  type ProvidesConfig,
+} from '../context-value'
+import {
   ControlDefinition,
   type Resolvable,
   type SchemaType,
@@ -15,7 +20,10 @@ import {
 import { DefaultControlInstance, type ControlInstanceArgs } from '../instance'
 import { ControlDefinitionVisitor } from '../visitor'
 
-type Config = z.infer<typeof Definition.schema.relaxed.config>
+type Config<P extends AnyContextValue = AnyContextValue> = z.infer<
+  typeof Definition.schema.relaxed.config
+> &
+  ProvidesConfig<P>
 
 type SchemaByDefaultValue<D extends Config['defaultValue']> =
   undefined extends D
@@ -63,6 +71,7 @@ class Definition<C extends Config> extends ControlDefinition<
         label: z.string().optional(),
         description: z.string().optional(),
         defaultValue: value,
+        provides: ContextValueSchema.provides.optional(),
       })
 
       const definition = z.object({
@@ -185,16 +194,21 @@ export class CheckboxDefinition<
   C extends Config = Config,
 > extends Definition<C> {}
 
-type UserConfig<D extends Config['defaultValue']> = Config & {
+type UserConfig<
+  D extends Config['defaultValue'],
+  P extends AnyContextValue,
+> = Config<P> & {
   defaultValue?: D
 }
 
-type NormedConfig<D extends Config['defaultValue']> = z.infer<
-  SchemaByDefaultValue<D>['config']
->
+type NormedConfig<
+  D extends Config['defaultValue'],
+  P extends AnyContextValue,
+> = z.infer<SchemaByDefaultValue<D>['config']> & ProvidesConfig<P>
 
-export function Checkbox<D extends Config['defaultValue']>(
-  config?: UserConfig<D>,
-): CheckboxDefinition<NormedConfig<D>> {
-  return new CheckboxDefinition((config ?? {}) as NormedConfig<D>, 1)
+export function Checkbox<
+  D extends Config['defaultValue'],
+  P extends AnyContextValue = never,
+>(config?: UserConfig<D, P>): CheckboxDefinition<NormedConfig<D, P>> {
+  return new CheckboxDefinition((config ?? {}) as NormedConfig<D, P>, 1)
 }

--- a/packages/controls/src/controls/code/code.test.ts
+++ b/packages/controls/src/controls/code/code.test.ts
@@ -1,5 +1,7 @@
 import { testDefinition } from '../../testing/test-definition'
 
+import { unstable_ContextValue } from '../context-value'
+
 import { Code, CodeDefinition } from './code'
 
 describe('Code', () => {
@@ -34,6 +36,12 @@ describe('Code', () => {
     assignTest(Code({ defaultValue: 'text' }))
     assignTest(Code({ label: 'Code', defaultValue: undefined }))
     assignTest(Code({ label: undefined, defaultValue: undefined }))
+    assignTest(
+      Code({
+        defaultValue: 'text',
+        provides: unstable_ContextValue('code').ofType<string>(),
+      }),
+    )
   })
 })
 

--- a/packages/controls/src/controls/code/code.test.types.ts
+++ b/packages/controls/src/controls/code/code.test.types.ts
@@ -7,6 +7,7 @@ import {
   type ResolvedValueType,
   type ValueType,
 } from '../associated-types'
+import { unstable_ContextValue } from '../context-value'
 
 import { Code } from './code'
 
@@ -59,6 +60,22 @@ describe('Code Types', () => {
 
       type Resolved = ResolvedValueType<typeof def>
       expectTypeOf<Resolved>().toEqualTypeOf<{ value: string }>()
+    })
+
+    test('context provided', () => {
+      const codeContext = unstable_ContextValue('code').ofType<string>()
+      const def = Code({
+        defaultValue: 'console.log("hi")',
+        provides: codeContext,
+      })
+
+      type Config = typeof def.config
+      expectTypeOf<Config>().toEqualTypeOf<{
+        label?: string
+        description?: string
+        defaultValue: string
+        provides?: typeof codeContext
+      }>()
     })
   })
 })

--- a/packages/controls/src/controls/code/code.test.types.ts
+++ b/packages/controls/src/controls/code/code.test.types.ts
@@ -1,5 +1,7 @@
 import { expectTypeOf } from 'expect-type'
 
+import { Flatten } from '../../testing/util-types'
+
 import { AcceptedTextDataTypes, ControlDataTypeKey } from '../../common'
 
 import {
@@ -23,10 +25,11 @@ describe('Code Types', () => {
       const def = Code()
 
       type Config = typeof def.config
-      expectTypeOf<Config>().toEqualTypeOf<{
+      expectTypeOf<Flatten<Config>>().toEqualTypeOf<{
         label?: string
         description?: string
         defaultValue?: string
+        provides?: undefined
       }>()
 
       type Data = DataType<typeof def>
@@ -43,10 +46,11 @@ describe('Code Types', () => {
       const def = Code({ defaultValue: 'console.log("hi")' })
 
       type Config = typeof def.config
-      expectTypeOf<Config>().toEqualTypeOf<{
+      expectTypeOf<Flatten<Config>>().toEqualTypeOf<{
         label?: string
         description?: string
         defaultValue: string
+        provides?: undefined
       }>()
 
       type Data = DataType<typeof def>

--- a/packages/controls/src/controls/code/code.test.types.ts
+++ b/packages/controls/src/controls/code/code.test.types.ts
@@ -1,7 +1,5 @@
 import { expectTypeOf } from 'expect-type'
 
-import { Flatten } from '../../testing/util-types'
-
 import { AcceptedTextDataTypes, ControlDataTypeKey } from '../../common'
 
 import {
@@ -25,7 +23,7 @@ describe('Code Types', () => {
       const def = Code()
 
       type Config = typeof def.config
-      expectTypeOf<Flatten<Config>>().toEqualTypeOf<{
+      expectTypeOf<Config>().toEqualTypeOf<{
         label?: string
         description?: string
         defaultValue?: string
@@ -46,7 +44,7 @@ describe('Code Types', () => {
       const def = Code({ defaultValue: 'console.log("hi")' })
 
       type Config = typeof def.config
-      expectTypeOf<Flatten<Config>>().toEqualTypeOf<{
+      expectTypeOf<Config>().toEqualTypeOf<{
         label?: string
         description?: string
         defaultValue: string

--- a/packages/controls/src/controls/code/code.ts
+++ b/packages/controls/src/controls/code/code.ts
@@ -8,11 +8,7 @@ import { TextDataTypes } from '../../common/data-types'
 import { type CopyContext } from '../../context'
 import { type DeserializedRecord } from '../../serialization'
 
-import {
-  ContextValueSchema,
-  type AnyContextValue,
-  type ProvidesConfig,
-} from '../context-value'
+import { ContextValueSchema, type AnyContextValue } from '../context-value'
 import {
   ControlDefinition,
   type Resolvable,
@@ -21,15 +17,20 @@ import {
 import { DefaultControlInstance, type ControlInstanceArgs } from '../instance'
 import { ControlDefinitionVisitor } from '../visitor'
 
-type Config<P extends AnyContextValue = AnyContextValue> = z.infer<
-  typeof Definition.schema.relaxed.config
-> &
-  ProvidesConfig<P>
+type DefinitionSchema<P extends AnyContextValue = AnyContextValue> = ReturnType<
+  typeof Definition.schema<P>
+>
 
-type SchemaByDefaultValue<D extends Config['defaultValue']> =
-  undefined extends D
-    ? typeof Definition.schema.relaxed
-    : typeof Definition.schema.strict
+type Config<P extends AnyContextValue = AnyContextValue> = z.infer<
+  DefinitionSchema<P>['relaxed']['config']
+>
+
+type SchemaByDefaultValue<
+  D extends Config['defaultValue'],
+  P extends AnyContextValue = AnyContextValue,
+> = undefined extends D
+  ? DefinitionSchema<P>['relaxed']
+  : DefinitionSchema<P>['strict']
 
 type Schema<C extends Config> = SchemaByDefaultValue<C['defaultValue']>
 type DataType<C extends Config> = z.infer<Schema<C>['data']>
@@ -37,8 +38,8 @@ type ValueType<C extends Config> = z.infer<Schema<C>['value']>
 type ResolvedValueType<C extends Config> = z.infer<Schema<C>['resolvedValue']>
 
 type ReturnedSchemaType<C extends Config> = {
-  definition: typeof Definition.schema.relaxed.definition
-  type: typeof Definition.schema.relaxed.type
+  definition: DefinitionSchema['relaxed']['definition']
+  type: DefinitionSchema['relaxed']['type']
   data: SchemaType<DataType<C>>
   value: SchemaType<ValueType<C>>
   resolvedValue: SchemaType<ResolvedValueType<C>>
@@ -58,7 +59,9 @@ class Definition<C extends Config> extends ControlDefinition<
 
   static readonly type = 'makeswift::controls::code' as const
 
-  static get schema() {
+  static schema<P extends AnyContextValue = AnyContextValue>() {
+    const provides = ContextValueSchema.provides as SchemaType<P>
+
     const version = z.literal(1)
     const versionedData = z.object({
       [ControlDataTypeKey]: z.enum(AcceptedTextDataTypes),
@@ -80,7 +83,7 @@ class Definition<C extends Config> extends ControlDefinition<
         label: z.string().optional(),
         description: z.string().optional(),
         defaultValue: value,
-        provides: ContextValueSchema.provides.optional(),
+        provides: provides.optional(),
       })
 
       const definition = z.object({
@@ -123,13 +126,14 @@ class Definition<C extends Config> extends ControlDefinition<
       )
     }
 
-    const { version, config } = Definition.schema.relaxed.definition.parse(data)
+    const { version, config } =
+      Definition.schema().relaxed.definition.parse(data)
     return new CodeDefinition(config, version)
   }
 
   constructor(
     config: C,
-    readonly version: z.infer<typeof Definition.schema.relaxed.version>,
+    readonly version: z.infer<DefinitionSchema['relaxed']['version']>,
   ) {
     super(config)
   }
@@ -139,14 +143,14 @@ class Definition<C extends Config> extends ControlDefinition<
   }
 
   get schema(): ReturnedSchemaType<C> {
-    return Definition.schema.relaxed
+    return Definition.schema().relaxed
   }
 
   get dataSchema() {
     return (
       (this.config.defaultValue === undefined
-        ? Definition.schema.relaxed
-        : Definition.schema.strict) as Schema<C>
+        ? Definition.schema().relaxed
+        : Definition.schema().strict) as Schema<C>
     ).data
   }
 
@@ -219,7 +223,7 @@ type UserConfig<
 type NormedConfig<
   D extends Config['defaultValue'],
   P extends AnyContextValue,
-> = z.infer<SchemaByDefaultValue<D>['config']> & ProvidesConfig<P>
+> = z.infer<SchemaByDefaultValue<D, P>['config']>
 
 export function Code<
   D extends Config['defaultValue'],

--- a/packages/controls/src/controls/code/code.ts
+++ b/packages/controls/src/controls/code/code.ts
@@ -9,6 +9,11 @@ import { type CopyContext } from '../../context'
 import { type DeserializedRecord } from '../../serialization'
 
 import {
+  ContextValueSchema,
+  type AnyContextValue,
+  type ProvidesConfig,
+} from '../context-value'
+import {
   ControlDefinition,
   type Resolvable,
   type SchemaType,
@@ -16,7 +21,10 @@ import {
 import { DefaultControlInstance, type ControlInstanceArgs } from '../instance'
 import { ControlDefinitionVisitor } from '../visitor'
 
-type Config = z.infer<typeof Definition.schema.relaxed.config>
+type Config<P extends AnyContextValue = AnyContextValue> = z.infer<
+  typeof Definition.schema.relaxed.config
+> &
+  ProvidesConfig<P>
 
 type SchemaByDefaultValue<D extends Config['defaultValue']> =
   undefined extends D
@@ -72,6 +80,7 @@ class Definition<C extends Config> extends ControlDefinition<
         label: z.string().optional(),
         description: z.string().optional(),
         defaultValue: value,
+        provides: ContextValueSchema.provides.optional(),
       })
 
       const definition = z.object({
@@ -200,16 +209,21 @@ class Definition<C extends Config> extends ControlDefinition<
 
 export class CodeDefinition<C extends Config = Config> extends Definition<C> {}
 
-type UserConfig<D extends Config['defaultValue']> = Config & {
+type UserConfig<
+  D extends Config['defaultValue'],
+  P extends AnyContextValue,
+> = Config<P> & {
   defaultValue?: D
 }
 
-type NormedConfig<D extends Config['defaultValue']> = z.infer<
-  SchemaByDefaultValue<D>['config']
->
+type NormedConfig<
+  D extends Config['defaultValue'],
+  P extends AnyContextValue,
+> = z.infer<SchemaByDefaultValue<D>['config']> & ProvidesConfig<P>
 
-export function Code<D extends Config['defaultValue']>(
-  config?: UserConfig<D>,
-): CodeDefinition<NormedConfig<D>> {
-  return new CodeDefinition((config ?? {}) as NormedConfig<D>, 1)
+export function Code<
+  D extends Config['defaultValue'],
+  P extends AnyContextValue = never,
+>(config?: UserConfig<D, P>): CodeDefinition<NormedConfig<D, P>> {
+  return new CodeDefinition((config ?? {}) as NormedConfig<D, P>, 1)
 }

--- a/packages/controls/src/controls/font/font.test.ts
+++ b/packages/controls/src/controls/font/font.test.ts
@@ -1,3 +1,5 @@
+import { unstable_ContextValue } from '../context-value'
+
 import { Font, FontDefinition } from './font'
 
 describe('Font', () => {
@@ -118,6 +120,15 @@ describe('Font', () => {
       Font({
         variant: false,
         defaultValue: { fontFamily: '' },
+      }),
+    )
+    assignTest(
+      Font({
+        variant: false,
+        defaultValue: { fontFamily: '' },
+        provides: unstable_ContextValue('font').ofType<{
+          fontFamily: string
+        }>(),
       }),
     )
   })

--- a/packages/controls/src/controls/font/font.test.types.ts
+++ b/packages/controls/src/controls/font/font.test.types.ts
@@ -7,6 +7,7 @@ import {
   type ResolvedValueType,
   type ValueType,
 } from '../associated-types'
+import { unstable_ContextValue } from '../context-value'
 
 import { Font, FontDefinition } from './font'
 
@@ -180,5 +181,25 @@ describe('Font Types', () => {
       | ExpectedValueWithoutVariantsType
       | undefined
     >()
+  })
+
+  test('infers types from control function (provided context)', () => {
+    const fontContext =
+      unstable_ContextValue('font').ofType<ExpectedValueWithoutVariantsType>()
+
+    const def = Font({
+      variant: false,
+      defaultValue: { fontFamily: 'Spline Sans' },
+      provides: fontContext,
+    })
+
+    type Config = typeof def.config
+    expectTypeOf<Config>().toEqualTypeOf<{
+      label?: string
+      description?: string
+      defaultValue: ExpectedValueWithoutVariantsType
+      variant: false
+      provides?: typeof fontContext
+    }>()
   })
 })

--- a/packages/controls/src/controls/font/font.test.types.ts
+++ b/packages/controls/src/controls/font/font.test.types.ts
@@ -1,5 +1,7 @@
 import { expectTypeOf } from 'expect-type'
 
+import { Flatten } from '../../testing/util-types'
+
 import { ControlDataTypeKey } from '../../common'
 
 import {
@@ -31,11 +33,12 @@ describe('Font Types', () => {
     })
 
     type Config = typeof def.config
-    expectTypeOf<Config>().toEqualTypeOf<{
+    expectTypeOf<Flatten<Config>>().toEqualTypeOf<{
       label?: string
       description?: string
       defaultValue: ExpectedValueWithoutVariantsType
       variant: false
+      provides?: undefined
     }>()
 
     type Data = DataType<typeof def>
@@ -57,11 +60,12 @@ describe('Font Types', () => {
     })
 
     type Config = typeof def.config
-    expectTypeOf<Config>().toEqualTypeOf<{
+    expectTypeOf<Flatten<Config>>().toEqualTypeOf<{
       label?: string
       description?: string
       defaultValue?: ExpectedValueWithoutVariantsType
       variant: false
+      provides?: undefined
     }>()
 
     type Data = DataType<typeof def>
@@ -96,11 +100,12 @@ describe('Font Types', () => {
     })
 
     type Config = typeof def.config
-    expectTypeOf<Config>().toEqualTypeOf<{
+    expectTypeOf<Flatten<Config>>().toEqualTypeOf<{
       label?: string
       description?: string
       defaultValue: ExpectedValueWithVariantsType
       variant: true
+      provides?: undefined
     }>()
 
     type Data = DataType<typeof def>
@@ -120,11 +125,12 @@ describe('Font Types', () => {
     const def = Font()
 
     type Config = typeof def.config
-    expectTypeOf<Config>().toEqualTypeOf<{
+    expectTypeOf<Flatten<Config>>().toEqualTypeOf<{
       label?: string
       description?: string
       defaultValue?: ExpectedValueWithVariantsType
       variant: true
+      provides?: undefined
     }>()
 
     type Data = DataType<typeof def>

--- a/packages/controls/src/controls/font/font.test.types.ts
+++ b/packages/controls/src/controls/font/font.test.types.ts
@@ -1,7 +1,5 @@
 import { expectTypeOf } from 'expect-type'
 
-import { Flatten } from '../../testing/util-types'
-
 import { ControlDataTypeKey } from '../../common'
 
 import {
@@ -33,7 +31,7 @@ describe('Font Types', () => {
     })
 
     type Config = typeof def.config
-    expectTypeOf<Flatten<Config>>().toEqualTypeOf<{
+    expectTypeOf<Config>().toEqualTypeOf<{
       label?: string
       description?: string
       defaultValue: ExpectedValueWithoutVariantsType
@@ -60,7 +58,7 @@ describe('Font Types', () => {
     })
 
     type Config = typeof def.config
-    expectTypeOf<Flatten<Config>>().toEqualTypeOf<{
+    expectTypeOf<Config>().toEqualTypeOf<{
       label?: string
       description?: string
       defaultValue?: ExpectedValueWithoutVariantsType
@@ -100,7 +98,7 @@ describe('Font Types', () => {
     })
 
     type Config = typeof def.config
-    expectTypeOf<Flatten<Config>>().toEqualTypeOf<{
+    expectTypeOf<Config>().toEqualTypeOf<{
       label?: string
       description?: string
       defaultValue: ExpectedValueWithVariantsType
@@ -125,7 +123,7 @@ describe('Font Types', () => {
     const def = Font()
 
     type Config = typeof def.config
-    expectTypeOf<Flatten<Config>>().toEqualTypeOf<{
+    expectTypeOf<Config>().toEqualTypeOf<{
       label?: string
       description?: string
       defaultValue?: ExpectedValueWithVariantsType

--- a/packages/controls/src/controls/font/font.ts
+++ b/packages/controls/src/controls/font/font.ts
@@ -19,24 +19,28 @@ import {
 import { DefaultControlInstance, type ControlInstanceArgs } from '../instance'
 import { ControlDefinitionVisitor } from '../visitor'
 
+type DefinitionSchema<P extends AnyContextValue = AnyContextValue> = ReturnType<
+  typeof Definition.schema<P>
+>
+
 type Config<P extends AnyContextValue = AnyContextValue> = z.infer<
-  | typeof Definition.schema.withVariants.relaxed.config
-  | typeof Definition.schema.withVariants.strict.config
-  | typeof Definition.schema.withoutVariants.relaxed.config
-  | typeof Definition.schema.withoutVariants.strict.config
-> &
-  ProvidesConfig<P>
+  | DefinitionSchema<P>['withVariants']['relaxed']['config']
+  | DefinitionSchema<P>['withVariants']['strict']['config']
+  | DefinitionSchema<P>['withoutVariants']['relaxed']['config']
+  | DefinitionSchema<P>['withoutVariants']['strict']['config']
+>
 
 type SchemaByVariantAndDefaultValue<
   V extends Config['variant'],
   D extends Config['defaultValue'],
+  P extends AnyContextValue = AnyContextValue,
 > = V extends false
   ? undefined extends D
-    ? typeof Definition.schema.withoutVariants.relaxed
-    : typeof Definition.schema.withoutVariants.strict
+    ? DefinitionSchema<P>['withoutVariants']['relaxed']
+    : DefinitionSchema<P>['withoutVariants']['strict']
   : undefined extends D
-    ? typeof Definition.schema.withVariants.relaxed
-    : typeof Definition.schema.withVariants.strict
+    ? DefinitionSchema<P>['withVariants']['relaxed']
+    : DefinitionSchema<P>['withVariants']['strict']
 
 type Schema<C extends Config> = SchemaByVariantAndDefaultValue<
   C['variant'],
@@ -69,7 +73,9 @@ class Definition<C extends Config> extends ControlDefinition<
   } as const
   static readonly type = 'makeswift::controls::font' as const
 
-  static get schema() {
+  static schema<P extends AnyContextValue = AnyContextValue>() {
+    const provides = ContextValueSchema.provides as SchemaType<P>
+
     const version = z.literal(1)
     const type = z.literal(this.type)
 
@@ -113,7 +119,7 @@ class Definition<C extends Config> extends ControlDefinition<
         description: z.string().optional(),
         defaultValue: value,
         variant,
-        provides: ContextValueSchema.provides.optional(),
+        provides: provides.optional(),
       })
 
       const definition = z.object({
@@ -171,8 +177,8 @@ class Definition<C extends Config> extends ControlDefinition<
 
     const { config, version } = z
       .union([
-        Definition.schema.withVariants.relaxed.definition,
-        Definition.schema.withoutVariants.relaxed.definition,
+        Definition.schema().withVariants.relaxed.definition,
+        Definition.schema().withoutVariants.relaxed.definition,
       ])
       .parse(data)
     return new FontDefinition(config, version)
@@ -180,7 +186,7 @@ class Definition<C extends Config> extends ControlDefinition<
 
   constructor(
     config: C,
-    readonly version: z.infer<typeof Definition.schema.version>,
+    readonly version: z.infer<DefinitionSchema['version']>,
   ) {
     super(config)
   }
@@ -190,7 +196,7 @@ class Definition<C extends Config> extends ControlDefinition<
   }
 
   get schema(): ReturnedSchemaType<C> {
-    const { withVariants, withoutVariants, ...baseSchema } = Definition.schema
+    const { withVariants, withoutVariants, ...baseSchema } = Definition.schema()
 
     const refinedSchema = this.refinedSchema
 
@@ -209,11 +215,11 @@ class Definition<C extends Config> extends ControlDefinition<
   get refinedSchema() {
     return this.config.variant === false
       ? this.config.defaultValue === undefined
-        ? Definition.schema.withoutVariants.relaxed
-        : Definition.schema.withoutVariants.strict
+        ? Definition.schema().withoutVariants.relaxed
+        : Definition.schema().withoutVariants.strict
       : this.config.defaultValue === undefined
-        ? Definition.schema.withVariants.relaxed
-        : Definition.schema.withVariants.strict
+        ? Definition.schema().withVariants.relaxed
+        : Definition.schema().withVariants.strict
   }
 
   get dataSchema(): Schema<C>['data'] {
@@ -281,18 +287,24 @@ export class FontDefinition<C extends Config = Config> extends Definition<C> {}
 
 type DefaultValueByVariant<V extends Config['variant']> = z.infer<
   false extends V
-    ? typeof Definition.schema.withoutVariants.strict.config
-    : typeof Definition.schema.withVariants.strict.config
+    ? DefinitionSchema['withoutVariants']['strict']['config']
+    : DefinitionSchema['withVariants']['strict']['config']
 >['defaultValue']
 
-type UserConfigRequiredDefault<V extends Config['variant']> = {
+type UserConfigRequiredDefault<
+  V extends Config['variant'],
+  P extends AnyContextValue,
+> = ProvidesConfig<P> & {
   label?: string
   description?: string
   variant?: V
   defaultValue: DefaultValueByVariant<V>
 }
 
-type UserConfigOptionalDefault<V extends Config['variant']> = {
+type UserConfigOptionalDefault<
+  V extends Config['variant'],
+  P extends AnyContextValue,
+> = ProvidesConfig<P> & {
   label?: string
   description?: string
   variant?: V
@@ -303,28 +315,27 @@ type NormedConfig<
   V extends Config['variant'],
   D extends Config['defaultValue'],
   P extends AnyContextValue,
-> = z.infer<SchemaByVariantAndDefaultValue<V, D>['config']> & ProvidesConfig<P>
+> = z.infer<SchemaByVariantAndDefaultValue<V, D, P>['config']>
 
 export function Font<
   V extends Config['variant'] = true,
   P extends AnyContextValue = never,
 >(
-  config: UserConfigRequiredDefault<V> & ProvidesConfig<P>,
+  config: UserConfigRequiredDefault<V, P>,
 ): FontDefinition<NormedConfig<V, DefaultValueByVariant<V>, P>>
 
 export function Font<
   V extends Config['variant'] = true,
   P extends AnyContextValue = never,
 >(
-  config?: UserConfigOptionalDefault<V> & ProvidesConfig<P>,
+  config?: UserConfigOptionalDefault<V, P>,
 ): FontDefinition<NormedConfig<V, DefaultValueByVariant<V> | undefined, P>>
 
 export function Font<
   V extends Config['variant'],
   P extends AnyContextValue = never,
 >(
-  config?: (UserConfigRequiredDefault<V> | UserConfigOptionalDefault<V>) &
-    ProvidesConfig<P>,
+  config?: UserConfigRequiredDefault<V, P> | UserConfigOptionalDefault<V, P>,
 ): FontDefinition<NormedConfig<V, DefaultValueByVariant<V> | undefined, P>> {
   return new FontDefinition(
     (config ? { variant: true, ...config } : { variant: true }) as NormedConfig<

--- a/packages/controls/src/controls/font/font.ts
+++ b/packages/controls/src/controls/font/font.ts
@@ -7,6 +7,11 @@ import { ControlDataTypeKey } from '../../common'
 import { type DeserializedRecord } from '../../serialization'
 
 import {
+  ContextValueSchema,
+  type AnyContextValue,
+  type ProvidesConfig,
+} from '../context-value'
+import {
   ControlDefinition,
   type Resolvable,
   type SchemaType,
@@ -14,12 +19,13 @@ import {
 import { DefaultControlInstance, type ControlInstanceArgs } from '../instance'
 import { ControlDefinitionVisitor } from '../visitor'
 
-type Config = z.infer<
+type Config<P extends AnyContextValue = AnyContextValue> = z.infer<
   | typeof Definition.schema.withVariants.relaxed.config
   | typeof Definition.schema.withVariants.strict.config
   | typeof Definition.schema.withoutVariants.relaxed.config
   | typeof Definition.schema.withoutVariants.strict.config
->
+> &
+  ProvidesConfig<P>
 
 type SchemaByVariantAndDefaultValue<
   V extends Config['variant'],
@@ -107,6 +113,7 @@ class Definition<C extends Config> extends ControlDefinition<
         description: z.string().optional(),
         defaultValue: value,
         variant,
+        provides: ContextValueSchema.provides.optional(),
       })
 
       const definition = z.object({
@@ -295,23 +302,35 @@ type UserConfigOptionalDefault<V extends Config['variant']> = {
 type NormedConfig<
   V extends Config['variant'],
   D extends Config['defaultValue'],
-> = z.infer<SchemaByVariantAndDefaultValue<V, D>['config']>
+  P extends AnyContextValue,
+> = z.infer<SchemaByVariantAndDefaultValue<V, D>['config']> & ProvidesConfig<P>
 
-export function Font<V extends Config['variant'] = true>(
-  config: UserConfigRequiredDefault<V>,
-): FontDefinition<NormedConfig<V, DefaultValueByVariant<V>>>
+export function Font<
+  V extends Config['variant'] = true,
+  P extends AnyContextValue = never,
+>(
+  config: UserConfigRequiredDefault<V> & ProvidesConfig<P>,
+): FontDefinition<NormedConfig<V, DefaultValueByVariant<V>, P>>
 
-export function Font<V extends Config['variant'] = true>(
-  config?: UserConfigOptionalDefault<V>,
-): FontDefinition<NormedConfig<V, DefaultValueByVariant<V> | undefined>>
+export function Font<
+  V extends Config['variant'] = true,
+  P extends AnyContextValue = never,
+>(
+  config?: UserConfigOptionalDefault<V> & ProvidesConfig<P>,
+): FontDefinition<NormedConfig<V, DefaultValueByVariant<V> | undefined, P>>
 
-export function Font<V extends Config['variant']>(
-  config?: UserConfigRequiredDefault<V> | UserConfigOptionalDefault<V>,
-): FontDefinition<NormedConfig<V, DefaultValueByVariant<V> | undefined>> {
+export function Font<
+  V extends Config['variant'],
+  P extends AnyContextValue = never,
+>(
+  config?: (UserConfigRequiredDefault<V> | UserConfigOptionalDefault<V>) &
+    ProvidesConfig<P>,
+): FontDefinition<NormedConfig<V, DefaultValueByVariant<V> | undefined, P>> {
   return new FontDefinition(
     (config ? { variant: true, ...config } : { variant: true }) as NormedConfig<
       V,
-      DefaultValueByVariant<V> | undefined
+      DefaultValueByVariant<V> | undefined,
+      P
     >,
     1,
   )

--- a/packages/controls/src/controls/icon-radio-group/icon-radio-group.test.ts
+++ b/packages/controls/src/controls/icon-radio-group/icon-radio-group.test.ts
@@ -3,6 +3,8 @@ import { TestSerializationVisitor } from '../../testing/test-serialization-visit
 
 import { deserializeRecord, type SerializedRecord } from '../../serialization'
 
+import { unstable_ContextValue } from '../context-value'
+
 import {
   IconRadioGroup,
   IconRadioGroupDefinition,
@@ -163,6 +165,12 @@ describe('IconRadioGroup', () => {
     )
     assignTest(
       IconRadioGroup({ label: undefined, options, defaultValue: undefined }),
+    )
+    assignTest(
+      IconRadioGroup({
+        options,
+        provides: unstable_ContextValue('icon').ofType<string>(),
+      }),
     )
   })
 })

--- a/packages/controls/src/controls/icon-radio-group/icon-radio-group.test.types.ts
+++ b/packages/controls/src/controls/icon-radio-group/icon-radio-group.test.types.ts
@@ -5,6 +5,7 @@ import {
   type ResolvedValueType,
   type ValueType,
 } from '../associated-types'
+import { unstable_ContextValue } from '../context-value'
 
 import { IconRadioGroup, IconRadioGroupIcon } from './icon-radio-group'
 
@@ -83,6 +84,28 @@ describe('IconRadioGroup Types', () => {
 
       type Resolved = ResolvedValueType<typeof def>
       expectTypeOf<Resolved>().toEqualTypeOf<'a' | 'b'>()
+    })
+
+    test('context provided', () => {
+      const iconContext = unstable_ContextValue('icon').ofType<'a' | 'b'>()
+
+      const def = IconRadioGroup({
+        label: 'Icons',
+        options: [
+          { value: 'a', label: 'code', icon: IconRadioGroup.Icon.Code },
+          {
+            value: 'b',
+            label: 'superscript',
+            icon: IconRadioGroup.Icon.Superscript,
+          },
+        ],
+        provides: iconContext,
+      })
+
+      type Config = typeof def.config
+      expectTypeOf<Config['provides']>().toEqualTypeOf<
+        typeof iconContext | undefined
+      >()
     })
   })
 })

--- a/packages/controls/src/controls/icon-radio-group/icon-radio-group.ts
+++ b/packages/controls/src/controls/icon-radio-group/icon-radio-group.ts
@@ -7,6 +7,11 @@ import { type CopyContext } from '../../context'
 import { type DeserializedRecord } from '../../serialization'
 
 import {
+  ContextValueSchema,
+  type AnyContextValue,
+  type ProvidesConfig,
+} from '../context-value'
+import {
   ControlDefinition,
   type Resolvable,
   type SchemaType,
@@ -26,7 +31,10 @@ type Option<T extends string> = {
 
 type OptionList<T extends string> = readonly [Option<T>, ...Option<T>[]]
 
-type Config<T extends string = string> = {
+type Config<
+  T extends string = string,
+  P extends AnyContextValue = AnyContextValue,
+> = ProvidesConfig<P> & {
   readonly options: OptionList<T>
   readonly defaultValue?: T
   readonly label?: string
@@ -77,6 +85,7 @@ class Definition<C extends Config> extends ControlDefinition<
         )
         .nonempty(),
       defaultValue,
+      provides: ContextValueSchema.provides.optional(),
       label: z.string().optional(),
     })
 
@@ -196,14 +205,16 @@ export class IconRadioGroupDefinition<
 type UserConfig<
   T extends string,
   D extends Config<T>['defaultValue'],
-> = Config<T> & {
+  P extends AnyContextValue,
+> = Config<T, P> & {
   defaultValue?: D
 }
 
 type NormedConfig<
   T extends string,
   D extends Config<T>['defaultValue'],
-> = Config<T> &
+  P extends AnyContextValue,
+> = Config<T, P> &
   (undefined extends D
     ? {
         readonly defaultValue?: T
@@ -213,10 +224,11 @@ type NormedConfig<
 export function IconRadioGroup<
   const T extends string,
   D extends Config<T>['defaultValue'],
+  P extends AnyContextValue = never,
 >(
-  config: UserConfig<T, D> & { readonly options: OptionList<T> },
-): IconRadioGroupDefinition<NormedConfig<T, D>> {
-  return new IconRadioGroupDefinition(config as NormedConfig<T, D>)
+  config: UserConfig<T, D, P> & { readonly options: OptionList<T> },
+): IconRadioGroupDefinition<NormedConfig<T, D, P>> {
+  return new IconRadioGroupDefinition(config as NormedConfig<T, D, P>)
 }
 
 IconRadioGroup.Icon = Definition.Icon

--- a/packages/controls/src/controls/number/number.test.ts
+++ b/packages/controls/src/controls/number/number.test.ts
@@ -1,5 +1,7 @@
 import { testDefinition, testResolveValue } from '../../testing/test-definition'
 
+import { unstable_ContextValue } from '../context-value'
+
 import { Number, NumberDefinition } from './number'
 
 describe('Number', () => {
@@ -38,6 +40,12 @@ describe('Number', () => {
 
     assignTest(Number({ defaultValue: undefined, min: 0, max: 100 }))
     assignTest(Number({ label: undefined, defaultValue: undefined }))
+    assignTest(
+      Number({
+        defaultValue: 1,
+        provides: unstable_ContextValue('count').ofType<number>(),
+      }),
+    )
   })
 })
 

--- a/packages/controls/src/controls/number/number.test.types.ts
+++ b/packages/controls/src/controls/number/number.test.types.ts
@@ -7,6 +7,7 @@ import {
   type ResolvedValueType,
   type ValueType,
 } from '../associated-types'
+import { unstable_ContextValue } from '../context-value'
 
 import { Number } from './number'
 
@@ -69,6 +70,24 @@ describe('Number Types', () => {
 
       type Resolved = ResolvedValueType<typeof def>
       expectTypeOf<Resolved>().toEqualTypeOf<number>
+    })
+
+    test('context provided', () => {
+      const countContext = unstable_ContextValue('count').ofType<number>()
+      const def = Number({ defaultValue: 1, provides: countContext })
+
+      type Config = typeof def.config
+      expectTypeOf<Config>().toEqualTypeOf<{
+        label?: string
+        labelOrientation?: 'horizontal' | 'vertical'
+        description?: string
+        defaultValue: number
+        min?: number
+        max?: number
+        step?: number
+        suffix?: string
+        provides?: typeof countContext
+      }>()
     })
   })
 })

--- a/packages/controls/src/controls/number/number.test.types.ts
+++ b/packages/controls/src/controls/number/number.test.types.ts
@@ -1,5 +1,7 @@
 import { expectTypeOf } from 'expect-type'
 
+import { Flatten } from '../../testing/util-types'
+
 import { AcceptedNumberDataTypes, ControlDataTypeKey } from '../../common'
 
 import {
@@ -23,7 +25,7 @@ describe('Number Types', () => {
       const def = Number()
 
       type Config = typeof def.config
-      expectTypeOf<Config>().toEqualTypeOf<{
+      expectTypeOf<Flatten<Config>>().toEqualTypeOf<{
         label?: string
         labelOrientation?: 'horizontal' | 'vertical'
         description?: string
@@ -32,6 +34,7 @@ describe('Number Types', () => {
         max?: number
         step?: number
         suffix?: string
+        provides?: undefined
       }>()
 
       type Data = DataType<typeof def>
@@ -48,7 +51,7 @@ describe('Number Types', () => {
       const def = Number({ defaultValue: 4 })
 
       type Config = typeof def.config
-      expectTypeOf<Config>().toEqualTypeOf<{
+      expectTypeOf<Flatten<Config>>().toEqualTypeOf<{
         label?: string | undefined
         labelOrientation?: 'vertical' | 'horizontal' | undefined
         description?: string
@@ -57,6 +60,7 @@ describe('Number Types', () => {
         max?: number | undefined
         step?: number | undefined
         suffix?: string | undefined
+        provides?: undefined
       }>()
 
       type Data = DataType<typeof def>

--- a/packages/controls/src/controls/number/number.test.types.ts
+++ b/packages/controls/src/controls/number/number.test.types.ts
@@ -1,7 +1,5 @@
 import { expectTypeOf } from 'expect-type'
 
-import { Flatten } from '../../testing/util-types'
-
 import { AcceptedNumberDataTypes, ControlDataTypeKey } from '../../common'
 
 import {
@@ -25,7 +23,7 @@ describe('Number Types', () => {
       const def = Number()
 
       type Config = typeof def.config
-      expectTypeOf<Flatten<Config>>().toEqualTypeOf<{
+      expectTypeOf<Config>().toEqualTypeOf<{
         label?: string
         labelOrientation?: 'horizontal' | 'vertical'
         description?: string
@@ -51,7 +49,7 @@ describe('Number Types', () => {
       const def = Number({ defaultValue: 4 })
 
       type Config = typeof def.config
-      expectTypeOf<Flatten<Config>>().toEqualTypeOf<{
+      expectTypeOf<Config>().toEqualTypeOf<{
         label?: string | undefined
         labelOrientation?: 'vertical' | 'horizontal' | undefined
         description?: string

--- a/packages/controls/src/controls/number/number.ts
+++ b/packages/controls/src/controls/number/number.ts
@@ -9,6 +9,11 @@ import { type CopyContext } from '../../context'
 import { type DeserializedRecord } from '../../serialization'
 
 import {
+  ContextValueSchema,
+  type AnyContextValue,
+  type ProvidesConfig,
+} from '../context-value'
+import {
   ControlDefinition,
   type Resolvable,
   type SchemaType,
@@ -16,7 +21,10 @@ import {
 import { DefaultControlInstance, type ControlInstanceArgs } from '../instance'
 import { ControlDefinitionVisitor } from '../visitor'
 
-type Config = z.infer<typeof Definition.schema.relaxed.config>
+type Config<P extends AnyContextValue = AnyContextValue> = z.infer<
+  typeof Definition.schema.relaxed.config
+> &
+  ProvidesConfig<P>
 
 type SchemaByDefaultValue<D extends Config['defaultValue']> =
   undefined extends D
@@ -70,6 +78,7 @@ class Definition<C extends Config> extends ControlDefinition<
         max: z.number().optional(),
         step: z.number().optional(),
         suffix: z.string().optional(),
+        provides: ContextValueSchema.provides.optional(),
       })
 
       const definition = z.object({
@@ -196,16 +205,21 @@ export class NumberDefinition<
   C extends Config = Config,
 > extends Definition<C> {}
 
-type UserConfig<D extends Config['defaultValue']> = Config & {
+type UserConfig<
+  D extends Config['defaultValue'],
+  P extends AnyContextValue,
+> = Config<P> & {
   defaultValue?: D
 }
 
-type NormedConfig<D extends Config['defaultValue']> = z.infer<
-  SchemaByDefaultValue<D>['config']
->
+type NormedConfig<
+  D extends Config['defaultValue'],
+  P extends AnyContextValue,
+> = z.infer<SchemaByDefaultValue<D>['config']> & ProvidesConfig<P>
 
-export function Number<D extends Config['defaultValue']>(
-  config?: UserConfig<D>,
-): NumberDefinition<NormedConfig<D>> {
-  return new NumberDefinition((config ?? {}) as NormedConfig<D>, 1)
+export function Number<
+  D extends Config['defaultValue'],
+  P extends AnyContextValue = never,
+>(config?: UserConfig<D, P>): NumberDefinition<NormedConfig<D, P>> {
+  return new NumberDefinition((config ?? {}) as NormedConfig<D, P>, 1)
 }

--- a/packages/controls/src/controls/number/number.ts
+++ b/packages/controls/src/controls/number/number.ts
@@ -8,11 +8,7 @@ import { NumberDataTypes } from '../../common/data-types'
 import { type CopyContext } from '../../context'
 import { type DeserializedRecord } from '../../serialization'
 
-import {
-  ContextValueSchema,
-  type AnyContextValue,
-  type ProvidesConfig,
-} from '../context-value'
+import { ContextValueSchema, type AnyContextValue } from '../context-value'
 import {
   ControlDefinition,
   type Resolvable,
@@ -21,15 +17,20 @@ import {
 import { DefaultControlInstance, type ControlInstanceArgs } from '../instance'
 import { ControlDefinitionVisitor } from '../visitor'
 
-type Config<P extends AnyContextValue = AnyContextValue> = z.infer<
-  typeof Definition.schema.relaxed.config
-> &
-  ProvidesConfig<P>
+type DefinitionSchema<P extends AnyContextValue = AnyContextValue> = ReturnType<
+  typeof Definition.schema<P>
+>
 
-type SchemaByDefaultValue<D extends Config['defaultValue']> =
-  undefined extends D
-    ? typeof Definition.schema.relaxed
-    : typeof Definition.schema.strict
+type Config<P extends AnyContextValue = AnyContextValue> = z.infer<
+  DefinitionSchema<P>['relaxed']['config']
+>
+
+type SchemaByDefaultValue<
+  D extends Config['defaultValue'],
+  P extends AnyContextValue = AnyContextValue,
+> = undefined extends D
+  ? DefinitionSchema<P>['relaxed']
+  : DefinitionSchema<P>['strict']
 
 type Schema<C extends Config> = SchemaByDefaultValue<C['defaultValue']>
 type DataType<C extends Config> = z.infer<Schema<C>['data']>
@@ -37,8 +38,8 @@ type ValueType<C extends Config> = z.infer<Schema<C>['value']>
 type ResolvedValueType<C extends Config> = z.infer<Schema<C>['resolvedValue']>
 
 type ReturnedSchemaType<C extends Config> = {
-  definition: typeof Definition.schema.relaxed.definition
-  type: typeof Definition.schema.relaxed.type
+  definition: DefinitionSchema['relaxed']['definition']
+  type: DefinitionSchema['relaxed']['type']
   data: SchemaType<DataType<C>>
   value: SchemaType<ValueType<C>>
   resolvedValue: SchemaType<ResolvedValueType<C>>
@@ -58,7 +59,9 @@ class Definition<C extends Config> extends ControlDefinition<
 
   static readonly type = 'makeswift::controls::number' as const
 
-  static get schema() {
+  static schema<P extends AnyContextValue = AnyContextValue>() {
+    const provides = ContextValueSchema.provides as SchemaType<P>
+
     const version = z.literal(1).optional()
 
     const versionedData = z.object({
@@ -78,7 +81,7 @@ class Definition<C extends Config> extends ControlDefinition<
         max: z.number().optional(),
         step: z.number().optional(),
         suffix: z.string().optional(),
-        provides: ContextValueSchema.provides.optional(),
+        provides: provides.optional(),
       })
 
       const definition = z.object({
@@ -116,13 +119,14 @@ class Definition<C extends Config> extends ControlDefinition<
       )
     }
 
-    const { version, config } = Definition.schema.relaxed.definition.parse(data)
+    const { version, config } =
+      Definition.schema().relaxed.definition.parse(data)
     return new NumberDefinition(config, version)
   }
 
   constructor(
     config: C,
-    readonly version: z.infer<typeof Definition.schema.relaxed.version>,
+    readonly version: z.infer<DefinitionSchema['relaxed']['version']>,
   ) {
     super(config)
   }
@@ -132,14 +136,14 @@ class Definition<C extends Config> extends ControlDefinition<
   }
 
   get schema(): ReturnedSchemaType<C> {
-    return Definition.schema.relaxed
+    return Definition.schema().relaxed
   }
 
   get dataSchema() {
     return (
       (this.config.defaultValue === undefined
-        ? Definition.schema.relaxed
-        : Definition.schema.strict) as Schema<C>
+        ? Definition.schema().relaxed
+        : Definition.schema().strict) as Schema<C>
     ).data
   }
 
@@ -215,7 +219,7 @@ type UserConfig<
 type NormedConfig<
   D extends Config['defaultValue'],
   P extends AnyContextValue,
-> = z.infer<SchemaByDefaultValue<D>['config']> & ProvidesConfig<P>
+> = z.infer<SchemaByDefaultValue<D, P>['config']>
 
 export function Number<
   D extends Config['defaultValue'],

--- a/packages/controls/src/controls/select/select.test.ts
+++ b/packages/controls/src/controls/select/select.test.ts
@@ -52,6 +52,7 @@ describe('Select', () => {
     // assignTest(Select({ options, defaultValue: undefined }))
     // assignTest(Select({ label: 'Block type', options, defaultValue: undefined }))
     // assignTest(Select({ label: undefined, options, defaultValue: undefined }))
+    // assignTest(Select({ options, provides: unstable_ContextValue('selection').ofType<string>() }))
   })
 })
 

--- a/packages/controls/src/controls/select/select.test.types.ts
+++ b/packages/controls/src/controls/select/select.test.types.ts
@@ -5,6 +5,7 @@ import {
   type ResolvedValueType,
   type ValueType,
 } from '../associated-types'
+import { unstable_ContextValue } from '../context-value'
 
 import { Select } from './select'
 
@@ -80,6 +81,29 @@ describe('Select Types', () => {
 
       type Resolved = ResolvedValueType<typeof def>
       expectTypeOf<Resolved>().toEqualTypeOf<'a' | 'b'>()
+    })
+
+    test('context provided', () => {
+      const selectionContext = unstable_ContextValue('selection').ofType<
+        'a' | 'b'
+      >()
+
+      const def = Select({
+        label: 'Nato',
+        options: [
+          { value: 'a', label: 'alpha' },
+          { value: 'b', label: 'beta' },
+        ],
+        provides: selectionContext,
+      })
+
+      type Config = typeof def.config
+      expectTypeOf<Config['provides']>().toEqualTypeOf<
+        typeof selectionContext | undefined
+      >()
+      expectTypeOf<Config['defaultValue']>().toEqualTypeOf<
+        'a' | 'b' | undefined
+      >()
     })
   })
 })

--- a/packages/controls/src/controls/select/select.ts
+++ b/packages/controls/src/controls/select/select.ts
@@ -7,6 +7,11 @@ import { type CopyContext } from '../../context'
 import { type DeserializedRecord } from '../../serialization'
 
 import {
+  ContextValueSchema,
+  type AnyContextValue,
+  type ProvidesConfig,
+} from '../context-value'
+import {
   ControlDefinition,
   type Resolvable,
   type SchemaType,
@@ -17,7 +22,10 @@ import { ControlDefinitionVisitor } from '../visitor'
 type Option<T extends string> = { readonly value: T; readonly label: string }
 type OptionList<T extends string> = readonly [Option<T>, ...Option<T>[]]
 
-type Config<T extends string = string> = {
+type Config<
+  T extends string = string,
+  P extends AnyContextValue = AnyContextValue,
+> = ProvidesConfig<P> & {
   readonly options: OptionList<T>
   readonly defaultValue?: T
   readonly label?: string
@@ -60,6 +68,7 @@ class Definition<C extends Config> extends ControlDefinition<
         .union([z.literal('horizontal'), z.literal('vertical')])
         .optional(),
       description: z.string().optional(),
+      provides: ContextValueSchema.provides.optional(),
     })
 
     const definition = z.object({
@@ -179,14 +188,16 @@ export class SelectDefinition<
 type UserConfig<
   T extends string,
   D extends Config<T>['defaultValue'],
-> = Config<T> & {
+  P extends AnyContextValue,
+> = Config<T, P> & {
   defaultValue?: D
 }
 
 type NormedConfig<
   T extends string,
   D extends Config<T>['defaultValue'],
-> = Config<T> &
+  P extends AnyContextValue,
+> = Config<T, P> &
   (undefined extends D
     ? {
         readonly defaultValue?: T
@@ -196,9 +207,10 @@ type NormedConfig<
 export function Select<
   const T extends string,
   D extends Config<T>['defaultValue'],
+  P extends AnyContextValue = never,
 >(
-  config: UserConfig<T, D> & { readonly options: OptionList<T> },
-): SelectDefinition<NormedConfig<T, D>> {
-  return new SelectDefinition(config as NormedConfig<T, D>)
+  config: UserConfig<T, D, P> & { readonly options: OptionList<T> },
+): SelectDefinition<NormedConfig<T, D, P>> {
+  return new SelectDefinition(config as NormedConfig<T, D, P>)
 }
 export { type Config as SelectConfig }

--- a/packages/controls/src/controls/slider/slider.test.ts
+++ b/packages/controls/src/controls/slider/slider.test.ts
@@ -1,5 +1,7 @@
 import { testDefinition, testResolveValue } from '../../testing/test-definition'
 
+import { unstable_ContextValue } from '../context-value'
+
 import { Slider, SliderDefinition } from './slider'
 
 describe('Slider', () => {
@@ -51,6 +53,12 @@ describe('Slider', () => {
     assignTest(Slider({ defaultValue: undefined }))
     assignTest(Slider({ min: 0, max: 100 }))
     assignTest(Slider({ min: 0, max: 100, step: 1 }))
+    assignTest(
+      Slider({
+        defaultValue: 50,
+        provides: unstable_ContextValue('volume').ofType<number>(),
+      }),
+    )
   })
 })
 

--- a/packages/controls/src/controls/slider/slider.test.types.ts
+++ b/packages/controls/src/controls/slider/slider.test.types.ts
@@ -1,0 +1,42 @@
+import { expectTypeOf } from 'expect-type'
+
+import { unstable_ContextValue } from '../context-value'
+
+import { Slider } from './slider'
+
+describe('Slider Types', () => {
+  describe('infers types from control definitions', () => {
+    test('empty config', () => {
+      const def = Slider()
+
+      type Config = typeof def.config
+      expectTypeOf<Config>().toEqualTypeOf<{
+        label?: string
+        description?: string
+        defaultValue?: number
+        min?: number
+        max?: number
+        step?: number
+        showInput?: boolean
+        provides?: undefined
+      }>()
+    })
+
+    test('context provided', () => {
+      const volumeContext = unstable_ContextValue('volume').ofType<number>()
+      const def = Slider({ defaultValue: 50, provides: volumeContext })
+
+      type Config = typeof def.config
+      expectTypeOf<Config>().toEqualTypeOf<{
+        label?: string
+        description?: string
+        defaultValue: number
+        min?: number
+        max?: number
+        step?: number
+        showInput?: boolean
+        provides?: typeof volumeContext
+      }>()
+    })
+  })
+})

--- a/packages/controls/src/controls/slider/slider.ts
+++ b/packages/controls/src/controls/slider/slider.ts
@@ -8,11 +8,7 @@ import { NumberDataTypes } from '../../common/data-types'
 import { type CopyContext } from '../../context'
 import { type DeserializedRecord } from '../../serialization'
 
-import {
-  ContextValueSchema,
-  type AnyContextValue,
-  type ProvidesConfig,
-} from '../context-value'
+import { ContextValueSchema, type AnyContextValue } from '../context-value'
 import {
   ControlDefinition,
   type Resolvable,
@@ -21,15 +17,20 @@ import {
 import { DefaultControlInstance, type ControlInstanceArgs } from '../instance'
 import { ControlDefinitionVisitor } from '../visitor'
 
-type Config<P extends AnyContextValue = AnyContextValue> = z.infer<
-  typeof Definition.schema.relaxed.config
-> &
-  ProvidesConfig<P>
+type DefinitionSchema<P extends AnyContextValue = AnyContextValue> = ReturnType<
+  typeof Definition.schema<P>
+>
 
-type SchemaByDefaultValue<D extends Config['defaultValue']> =
-  undefined extends D
-    ? typeof Definition.schema.relaxed
-    : typeof Definition.schema.strict
+type Config<P extends AnyContextValue = AnyContextValue> = z.infer<
+  DefinitionSchema<P>['relaxed']['config']
+>
+
+type SchemaByDefaultValue<
+  D extends Config['defaultValue'],
+  P extends AnyContextValue = AnyContextValue,
+> = undefined extends D
+  ? DefinitionSchema<P>['relaxed']
+  : DefinitionSchema<P>['strict']
 
 type Schema<C extends Config> = SchemaByDefaultValue<C['defaultValue']>
 type DataType<C extends Config> = z.infer<Schema<C>['data']>
@@ -37,8 +38,8 @@ type ValueType<C extends Config> = z.infer<Schema<C>['value']>
 type ResolvedValueType<C extends Config> = z.infer<Schema<C>['resolvedValue']>
 
 type ReturnedSchemaType<C extends Config> = {
-  definition: typeof Definition.schema.relaxed.definition
-  type: typeof Definition.schema.relaxed.type
+  definition: DefinitionSchema['relaxed']['definition']
+  type: DefinitionSchema['relaxed']['type']
   data: SchemaType<DataType<C>>
   value: SchemaType<ValueType<C>>
   resolvedValue: SchemaType<ResolvedValueType<C>>
@@ -61,7 +62,9 @@ class Definition<C extends Config> extends ControlDefinition<
 
   static readonly type = 'makeswift::controls::slider' as const
 
-  static get schema() {
+  static schema<P extends AnyContextValue = AnyContextValue>() {
+    const provides = ContextValueSchema.provides as SchemaType<P>
+
     const version = z.literal(1).optional()
 
     const versionedData = z.object({
@@ -80,7 +83,7 @@ class Definition<C extends Config> extends ControlDefinition<
         max: z.number().optional(),
         step: z.number().optional(),
         showInput: z.boolean().optional(),
-        provides: ContextValueSchema.provides.optional(),
+        provides: provides.optional(),
       })
 
       const definition = z.object({
@@ -118,13 +121,14 @@ class Definition<C extends Config> extends ControlDefinition<
       )
     }
 
-    const { version, config } = Definition.schema.relaxed.definition.parse(data)
+    const { version, config } =
+      Definition.schema().relaxed.definition.parse(data)
     return new SliderDefinition(config, version)
   }
 
   constructor(
     config: C,
-    readonly version: z.infer<typeof Definition.schema.relaxed.version>,
+    readonly version: z.infer<DefinitionSchema['relaxed']['version']>,
   ) {
     super(config)
   }
@@ -134,14 +138,14 @@ class Definition<C extends Config> extends ControlDefinition<
   }
 
   get schema(): ReturnedSchemaType<C> {
-    return Definition.schema.relaxed
+    return Definition.schema().relaxed
   }
 
   get dataSchema() {
     return (
       (this.config.defaultValue === undefined
-        ? Definition.schema.relaxed
-        : Definition.schema.strict) as Schema<C>
+        ? Definition.schema().relaxed
+        : Definition.schema().strict) as Schema<C>
     ).data
   }
 
@@ -217,7 +221,7 @@ type UserConfig<
 type NormedConfig<
   D extends Config['defaultValue'],
   P extends AnyContextValue,
-> = z.infer<SchemaByDefaultValue<D>['config']> & ProvidesConfig<P>
+> = z.infer<SchemaByDefaultValue<D, P>['config']>
 
 export function Slider<
   D extends Config['defaultValue'],

--- a/packages/controls/src/controls/slider/slider.ts
+++ b/packages/controls/src/controls/slider/slider.ts
@@ -9,6 +9,11 @@ import { type CopyContext } from '../../context'
 import { type DeserializedRecord } from '../../serialization'
 
 import {
+  ContextValueSchema,
+  type AnyContextValue,
+  type ProvidesConfig,
+} from '../context-value'
+import {
   ControlDefinition,
   type Resolvable,
   type SchemaType,
@@ -16,7 +21,10 @@ import {
 import { DefaultControlInstance, type ControlInstanceArgs } from '../instance'
 import { ControlDefinitionVisitor } from '../visitor'
 
-type Config = z.infer<typeof Definition.schema.relaxed.config>
+type Config<P extends AnyContextValue = AnyContextValue> = z.infer<
+  typeof Definition.schema.relaxed.config
+> &
+  ProvidesConfig<P>
 
 type SchemaByDefaultValue<D extends Config['defaultValue']> =
   undefined extends D
@@ -72,6 +80,7 @@ class Definition<C extends Config> extends ControlDefinition<
         max: z.number().optional(),
         step: z.number().optional(),
         showInput: z.boolean().optional(),
+        provides: ContextValueSchema.provides.optional(),
       })
 
       const definition = z.object({
@@ -198,16 +207,21 @@ export class SliderDefinition<
   C extends Config = Config,
 > extends Definition<C> {}
 
-type UserConfig<D extends Config['defaultValue']> = Config & {
+type UserConfig<
+  D extends Config['defaultValue'],
+  P extends AnyContextValue,
+> = Config<P> & {
   defaultValue?: D
 }
 
-type NormedConfig<D extends Config['defaultValue']> = z.infer<
-  SchemaByDefaultValue<D>['config']
->
+type NormedConfig<
+  D extends Config['defaultValue'],
+  P extends AnyContextValue,
+> = z.infer<SchemaByDefaultValue<D>['config']> & ProvidesConfig<P>
 
-export function Slider<D extends Config['defaultValue']>(
-  config?: UserConfig<D>,
-): SliderDefinition<NormedConfig<D>> {
-  return new SliderDefinition((config ?? {}) as NormedConfig<D>, 1)
+export function Slider<
+  D extends Config['defaultValue'],
+  P extends AnyContextValue = never,
+>(config?: UserConfig<D, P>): SliderDefinition<NormedConfig<D, P>> {
+  return new SliderDefinition((config ?? {}) as NormedConfig<D, P>, 1)
 }

--- a/packages/controls/src/controls/style/v2/style-v2.test.types.ts
+++ b/packages/controls/src/controls/style/v2/style-v2.test.types.ts
@@ -1,7 +1,5 @@
 import { expectTypeOf } from 'expect-type'
 
-import { Flatten } from '../../../testing/util-types'
-
 import {
   type DataType,
   type ResolvedValueType,
@@ -21,19 +19,15 @@ describe('StyleV2 Types', () => {
     })
 
     type Config = typeof def.config
-    // The nested checkbox config is an intersection (`z.infer<...> &
-    // ProvidesConfig<P>`), which `toEqualTypeOf` does not consider equal to
-    // the identical flat object type, so assert its members separately.
-    expectTypeOf<Config['type']>().toMatchTypeOf<CheckboxDefinition>()
-    expectTypeOf<Flatten<Config['type']['config']>>().toEqualTypeOf<{
-      defaultValue: boolean
-      description?: string
-      label?: string
-      provides?: undefined
+    expectTypeOf<Config>().toEqualTypeOf<{
+      type: CheckboxDefinition<{
+        defaultValue: boolean
+        description?: string
+        label?: string
+        provides?: undefined
+      }>
+      getStyle: (item: boolean | undefined) => StylesObject
     }>()
-    expectTypeOf<Config['getStyle']>().toEqualTypeOf<
-      (item: boolean | undefined) => StylesObject
-    >()
 
     type Data = DataType<typeof def>
 

--- a/packages/controls/src/controls/style/v2/style-v2.test.types.ts
+++ b/packages/controls/src/controls/style/v2/style-v2.test.types.ts
@@ -1,5 +1,7 @@
 import { expectTypeOf } from 'expect-type'
 
+import { Flatten } from '../../../testing/util-types'
+
 import {
   type DataType,
   type ResolvedValueType,
@@ -19,14 +21,19 @@ describe('StyleV2 Types', () => {
     })
 
     type Config = typeof def.config
-    expectTypeOf<Config>().toEqualTypeOf<{
-      type: CheckboxDefinition<{
-        defaultValue: boolean
-        description?: string
-        label?: string
-      }>
-      getStyle: (item: boolean | undefined) => StylesObject
+    // The nested checkbox config is an intersection (`z.infer<...> &
+    // ProvidesConfig<P>`), which `toEqualTypeOf` does not consider equal to
+    // the identical flat object type, so assert its members separately.
+    expectTypeOf<Config['type']>().toMatchTypeOf<CheckboxDefinition>()
+    expectTypeOf<Flatten<Config['type']['config']>>().toEqualTypeOf<{
+      defaultValue: boolean
+      description?: string
+      label?: string
+      provides?: undefined
     }>()
+    expectTypeOf<Config['getStyle']>().toEqualTypeOf<
+      (item: boolean | undefined) => StylesObject
+    >()
 
     type Data = DataType<typeof def>
 

--- a/packages/controls/src/controls/text-area/text-area.test.ts
+++ b/packages/controls/src/controls/text-area/text-area.test.ts
@@ -4,6 +4,8 @@ import { TestMergeTranslationsVisitor } from '../../testing/test-merge-translati
 import { ControlDataTypeKey } from '../../common'
 import { MergeTranslatableDataContext, TranslationDto } from '../../context'
 
+import { unstable_ContextValue } from '../context-value'
+
 import { TextArea, TextAreaDefinition } from './text-area'
 
 describe('TextArea', () => {
@@ -40,6 +42,12 @@ describe('TextArea', () => {
     assignTest(TextArea({ defaultValue: undefined, rows: undefined }))
     assignTest(
       TextArea({ label: undefined, defaultValue: undefined, rows: undefined }),
+    )
+    assignTest(
+      TextArea({
+        defaultValue: 'text',
+        provides: unstable_ContextValue('text').ofType<string>(),
+      }),
     )
   })
 

--- a/packages/controls/src/controls/text-area/text-area.test.types.ts
+++ b/packages/controls/src/controls/text-area/text-area.test.types.ts
@@ -7,6 +7,7 @@ import {
   type ResolvedValueType,
   type ValueType,
 } from '../associated-types'
+import { unstable_ContextValue } from '../context-value'
 
 import { TextArea } from './text-area'
 
@@ -61,6 +62,20 @@ describe('TextArea Types', () => {
 
       type Resolved = ResolvedValueType<typeof def>
       expectTypeOf<Resolved>().toEqualTypeOf<string>
+    })
+
+    test('context provided', () => {
+      const textContext = unstable_ContextValue('text').ofType<string>()
+      const def = TextArea({ defaultValue: 'text', provides: textContext })
+
+      type Config = typeof def.config
+      expectTypeOf<Config>().toEqualTypeOf<{
+        label?: string
+        description?: string
+        defaultValue: string
+        rows?: number
+        provides?: typeof textContext
+      }>()
     })
   })
 })

--- a/packages/controls/src/controls/text-area/text-area.test.types.ts
+++ b/packages/controls/src/controls/text-area/text-area.test.types.ts
@@ -1,5 +1,7 @@
 import { expectTypeOf } from 'expect-type'
 
+import { Flatten } from '../../testing/util-types'
+
 import { AcceptedTextDataTypes, ControlDataTypeKey } from '../../common'
 
 import {
@@ -23,11 +25,12 @@ describe('TextArea Types', () => {
       const def = TextArea()
 
       type Config = typeof def.config
-      expectTypeOf<Config>().toEqualTypeOf<{
+      expectTypeOf<Flatten<Config>>().toEqualTypeOf<{
         label?: string
         description?: string
         defaultValue?: string
         rows?: number
+        provides?: undefined
       }>()
 
       type Data = DataType<typeof def>
@@ -44,11 +47,12 @@ describe('TextArea Types', () => {
       const def = TextArea({ defaultValue: 'test' })
 
       type Config = typeof def.config
-      expectTypeOf<Config>().toEqualTypeOf<{
+      expectTypeOf<Flatten<Config>>().toEqualTypeOf<{
         defaultValue: string
         label?: string
         description?: string
         rows?: number
+        provides?: undefined
       }>()
 
       type Data = DataType<typeof def>

--- a/packages/controls/src/controls/text-area/text-area.test.types.ts
+++ b/packages/controls/src/controls/text-area/text-area.test.types.ts
@@ -1,7 +1,5 @@
 import { expectTypeOf } from 'expect-type'
 
-import { Flatten } from '../../testing/util-types'
-
 import { AcceptedTextDataTypes, ControlDataTypeKey } from '../../common'
 
 import {
@@ -25,7 +23,7 @@ describe('TextArea Types', () => {
       const def = TextArea()
 
       type Config = typeof def.config
-      expectTypeOf<Flatten<Config>>().toEqualTypeOf<{
+      expectTypeOf<Config>().toEqualTypeOf<{
         label?: string
         description?: string
         defaultValue?: string
@@ -47,7 +45,7 @@ describe('TextArea Types', () => {
       const def = TextArea({ defaultValue: 'test' })
 
       type Config = typeof def.config
-      expectTypeOf<Flatten<Config>>().toEqualTypeOf<{
+      expectTypeOf<Config>().toEqualTypeOf<{
         defaultValue: string
         label?: string
         description?: string

--- a/packages/controls/src/controls/text-area/text-area.ts
+++ b/packages/controls/src/controls/text-area/text-area.ts
@@ -12,11 +12,7 @@ import { TextDataTypes } from '../../common/data-types'
 import { type CopyContext } from '../../context'
 import { type DeserializedRecord } from '../../serialization'
 
-import {
-  ContextValueSchema,
-  type AnyContextValue,
-  type ProvidesConfig,
-} from '../context-value'
+import { ContextValueSchema, type AnyContextValue } from '../context-value'
 import {
   ControlDefinition,
   type Resolvable,
@@ -25,15 +21,20 @@ import {
 import { DefaultControlInstance, type ControlInstanceArgs } from '../instance'
 import { ControlDefinitionVisitor } from '../visitor'
 
-type Config<P extends AnyContextValue = AnyContextValue> = z.infer<
-  typeof Definition.schema.relaxed.config
-> &
-  ProvidesConfig<P>
+type DefinitionSchema<P extends AnyContextValue = AnyContextValue> = ReturnType<
+  typeof Definition.schema<P>
+>
 
-type SchemaByDefaultValue<D extends Config['defaultValue']> =
-  undefined extends D
-    ? typeof Definition.schema.relaxed
-    : typeof Definition.schema.strict
+type Config<P extends AnyContextValue = AnyContextValue> = z.infer<
+  DefinitionSchema<P>['relaxed']['config']
+>
+
+type SchemaByDefaultValue<
+  D extends Config['defaultValue'],
+  P extends AnyContextValue = AnyContextValue,
+> = undefined extends D
+  ? DefinitionSchema<P>['relaxed']
+  : DefinitionSchema<P>['strict']
 
 type Schema<C extends Config> = SchemaByDefaultValue<C['defaultValue']>
 type DataType<C extends Config> = z.infer<Schema<C>['data']>
@@ -41,8 +42,8 @@ type ValueType<C extends Config> = z.infer<Schema<C>['value']>
 type ResolvedValueType<C extends Config> = z.infer<Schema<C>['resolvedValue']>
 
 type ReturnedSchemaType<C extends Config> = {
-  definition: typeof Definition.schema.relaxed.definition
-  type: typeof Definition.schema.relaxed.type
+  definition: DefinitionSchema['relaxed']['definition']
+  type: DefinitionSchema['relaxed']['type']
   data: SchemaType<DataType<C>>
   value: SchemaType<ValueType<C>>
   resolvedValue: SchemaType<ResolvedValueType<C>>
@@ -62,7 +63,9 @@ class Definition<C extends Config> extends ControlDefinition<
 
   static readonly type = 'makeswift::controls::text-area' as const
 
-  static get schema() {
+  static schema<P extends AnyContextValue = AnyContextValue>() {
+    const provides = ContextValueSchema.provides as SchemaType<P>
+
     const version = z.literal(1).optional()
     const versionedData = z.object({
       [ControlDataTypeKey]: z.enum(AcceptedTextDataTypes),
@@ -77,7 +80,7 @@ class Definition<C extends Config> extends ControlDefinition<
         description: z.string().optional(),
         defaultValue: value,
         rows: z.number().optional(),
-        provides: ContextValueSchema.provides.optional(),
+        provides: provides.optional(),
       })
 
       const definition = z.object({
@@ -115,13 +118,14 @@ class Definition<C extends Config> extends ControlDefinition<
       )
     }
 
-    const { version, config } = Definition.schema.relaxed.definition.parse(data)
+    const { version, config } =
+      Definition.schema().relaxed.definition.parse(data)
     return new TextAreaDefinition(config, version)
   }
 
   constructor(
     config: C,
-    readonly version: z.infer<typeof Definition.schema.relaxed.version>,
+    readonly version: z.infer<DefinitionSchema['relaxed']['version']>,
   ) {
     super(config)
   }
@@ -131,14 +135,14 @@ class Definition<C extends Config> extends ControlDefinition<
   }
 
   get schema(): ReturnedSchemaType<C> {
-    return Definition.schema.relaxed
+    return Definition.schema().relaxed
   }
 
   get dataSchema() {
     return (
       (this.config.defaultValue === undefined
-        ? Definition.schema.relaxed
-        : Definition.schema.strict) as Schema<C>
+        ? Definition.schema().relaxed
+        : Definition.schema().strict) as Schema<C>
     ).data
   }
 
@@ -218,7 +222,7 @@ type UserConfig<
 type NormedConfig<
   D extends Config['defaultValue'],
   P extends AnyContextValue,
-> = z.infer<SchemaByDefaultValue<D>['config']> & ProvidesConfig<P>
+> = z.infer<SchemaByDefaultValue<D, P>['config']>
 
 export function TextArea<
   D extends Config['defaultValue'],

--- a/packages/controls/src/controls/text-area/text-area.ts
+++ b/packages/controls/src/controls/text-area/text-area.ts
@@ -13,6 +13,11 @@ import { type CopyContext } from '../../context'
 import { type DeserializedRecord } from '../../serialization'
 
 import {
+  ContextValueSchema,
+  type AnyContextValue,
+  type ProvidesConfig,
+} from '../context-value'
+import {
   ControlDefinition,
   type Resolvable,
   type SchemaType,
@@ -20,7 +25,10 @@ import {
 import { DefaultControlInstance, type ControlInstanceArgs } from '../instance'
 import { ControlDefinitionVisitor } from '../visitor'
 
-type Config = z.infer<typeof Definition.schema.relaxed.config>
+type Config<P extends AnyContextValue = AnyContextValue> = z.infer<
+  typeof Definition.schema.relaxed.config
+> &
+  ProvidesConfig<P>
 
 type SchemaByDefaultValue<D extends Config['defaultValue']> =
   undefined extends D
@@ -69,6 +77,7 @@ class Definition<C extends Config> extends ControlDefinition<
         description: z.string().optional(),
         defaultValue: value,
         rows: z.number().optional(),
+        provides: ContextValueSchema.provides.optional(),
       })
 
       const definition = z.object({
@@ -199,16 +208,21 @@ export class TextAreaDefinition<
   C extends Config = Config,
 > extends Definition<C> {}
 
-type UserConfig<D extends Config['defaultValue']> = Config & {
+type UserConfig<
+  D extends Config['defaultValue'],
+  P extends AnyContextValue,
+> = Config<P> & {
   defaultValue?: D
 }
 
-type NormedConfig<D extends Config['defaultValue']> = z.infer<
-  SchemaByDefaultValue<D>['config']
->
+type NormedConfig<
+  D extends Config['defaultValue'],
+  P extends AnyContextValue,
+> = z.infer<SchemaByDefaultValue<D>['config']> & ProvidesConfig<P>
 
-export function TextArea<D extends Config['defaultValue']>(
-  config?: UserConfig<D>,
-): TextAreaDefinition<NormedConfig<D>> {
-  return new TextAreaDefinition(config ?? ({} as NormedConfig<D>), 1)
+export function TextArea<
+  D extends Config['defaultValue'],
+  P extends AnyContextValue = never,
+>(config?: UserConfig<D, P>): TextAreaDefinition<NormedConfig<D, P>> {
+  return new TextAreaDefinition((config ?? {}) as NormedConfig<D, P>, 1)
 }

--- a/packages/controls/src/controls/text-input/text-input.test.ts
+++ b/packages/controls/src/controls/text-input/text-input.test.ts
@@ -4,6 +4,8 @@ import { TestMergeTranslationsVisitor } from '../../testing/test-merge-translati
 import { ControlDataTypeKey } from '../../common'
 import { MergeTranslatableDataContext, TranslationDto } from '../../context'
 
+import { unstable_ContextValue } from '../context-value'
+
 import { TextInput, TextInputDefinition } from './text-input'
 
 describe('TextInput', () => {
@@ -39,6 +41,12 @@ describe('TextInput', () => {
     assignTest(TextInput({ defaultValue: 'text' as string }))
     assignTest(TextInput({ label: 'TextInput', defaultValue: undefined }))
     assignTest(TextInput({ label: undefined, defaultValue: undefined }))
+    assignTest(
+      TextInput({
+        defaultValue: 'text',
+        provides: unstable_ContextValue('text').ofType<string>(),
+      }),
+    )
   })
 
   describe('getTranslatableData', () => {

--- a/packages/controls/src/controls/text-input/text-input.test.types.ts
+++ b/packages/controls/src/controls/text-input/text-input.test.types.ts
@@ -1,7 +1,5 @@
 import { expectTypeOf } from 'expect-type'
 
-import { Flatten } from '../../testing/util-types'
-
 import { AcceptedTextDataTypes, ControlDataTypeKey } from '../../common'
 
 import {
@@ -25,7 +23,7 @@ describe('TextInput Types', () => {
       const def = TextInput()
 
       type Config = typeof def.config
-      expectTypeOf<Flatten<Config>>().toEqualTypeOf<{
+      expectTypeOf<Config>().toEqualTypeOf<{
         label?: string
         description?: string
         defaultValue?: string
@@ -49,7 +47,7 @@ describe('TextInput Types', () => {
       const def = TextInput({ defaultValue: 'test' })
 
       type Config = typeof def.config
-      expectTypeOf<Flatten<Config>>().toEqualTypeOf<{
+      expectTypeOf<Config>().toEqualTypeOf<{
         label?: string
         description?: string
         defaultValue: string

--- a/packages/controls/src/controls/text-input/text-input.test.types.ts
+++ b/packages/controls/src/controls/text-input/text-input.test.types.ts
@@ -1,5 +1,7 @@
 import { expectTypeOf } from 'expect-type'
 
+import { Flatten } from '../../testing/util-types'
+
 import { AcceptedTextDataTypes, ControlDataTypeKey } from '../../common'
 
 import {
@@ -23,11 +25,12 @@ describe('TextInput Types', () => {
       const def = TextInput()
 
       type Config = typeof def.config
-      expectTypeOf<Config>().toEqualTypeOf<{
+      expectTypeOf<Flatten<Config>>().toEqualTypeOf<{
         label?: string
         description?: string
         defaultValue?: string
         selectAll?: boolean
+        provides?: undefined
       }>()
 
       type Data = DataType<typeof def>
@@ -46,11 +49,12 @@ describe('TextInput Types', () => {
       const def = TextInput({ defaultValue: 'test' })
 
       type Config = typeof def.config
-      expectTypeOf<Config>().toEqualTypeOf<{
+      expectTypeOf<Flatten<Config>>().toEqualTypeOf<{
         label?: string
         description?: string
         defaultValue: string
         selectAll?: boolean
+        provides?: undefined
       }>()
 
       type Data = DataType<typeof def>

--- a/packages/controls/src/controls/text-input/text-input.test.types.ts
+++ b/packages/controls/src/controls/text-input/text-input.test.types.ts
@@ -7,6 +7,7 @@ import {
   type ResolvedValueType,
   type ValueType,
 } from '../associated-types'
+import { unstable_ContextValue } from '../context-value'
 
 import { TextInput } from './text-input'
 
@@ -63,6 +64,20 @@ describe('TextInput Types', () => {
 
       type Resolved = ResolvedValueType<typeof def>
       expectTypeOf<Resolved>().toEqualTypeOf<string>
+    })
+
+    test('context provided', () => {
+      const textContext = unstable_ContextValue('text').ofType<string>()
+      const def = TextInput({ defaultValue: 'text', provides: textContext })
+
+      type Config = typeof def.config
+      expectTypeOf<Config>().toEqualTypeOf<{
+        label?: string
+        description?: string
+        defaultValue: string
+        selectAll?: boolean
+        provides?: typeof textContext
+      }>()
     })
   })
 })

--- a/packages/controls/src/controls/text-input/text-input.ts
+++ b/packages/controls/src/controls/text-input/text-input.ts
@@ -12,11 +12,7 @@ import { TextDataTypes } from '../../common/data-types'
 import { type CopyContext } from '../../context'
 import { type DeserializedRecord } from '../../serialization'
 
-import {
-  ContextValueSchema,
-  type AnyContextValue,
-  type ProvidesConfig,
-} from '../context-value'
+import { ContextValueSchema, type AnyContextValue } from '../context-value'
 import {
   ControlDefinition,
   type Resolvable,
@@ -25,15 +21,20 @@ import {
 import { DefaultControlInstance, type ControlInstanceArgs } from '../instance'
 import { ControlDefinitionVisitor } from '../visitor'
 
-type Config<P extends AnyContextValue = AnyContextValue> = z.infer<
-  typeof Definition.schema.relaxed.config
-> &
-  ProvidesConfig<P>
+type DefinitionSchema<P extends AnyContextValue = AnyContextValue> = ReturnType<
+  typeof Definition.schema<P>
+>
 
-type SchemaByDefaultValue<D extends Config['defaultValue']> =
-  undefined extends D
-    ? typeof Definition.schema.relaxed
-    : typeof Definition.schema.strict
+type Config<P extends AnyContextValue = AnyContextValue> = z.infer<
+  DefinitionSchema<P>['relaxed']['config']
+>
+
+type SchemaByDefaultValue<
+  D extends Config['defaultValue'],
+  P extends AnyContextValue = AnyContextValue,
+> = undefined extends D
+  ? DefinitionSchema<P>['relaxed']
+  : DefinitionSchema<P>['strict']
 
 type Schema<C extends Config> = SchemaByDefaultValue<C['defaultValue']>
 type DataType<C extends Config> = z.infer<Schema<C>['data']>
@@ -41,8 +42,8 @@ type ValueType<C extends Config> = z.infer<Schema<C>['value']>
 type ResolvedValueType<C extends Config> = z.infer<Schema<C>['resolvedValue']>
 
 type ReturnedSchemaType<C extends Config> = {
-  definition: typeof Definition.schema.relaxed.definition
-  type: typeof Definition.schema.relaxed.type
+  definition: DefinitionSchema['relaxed']['definition']
+  type: DefinitionSchema['relaxed']['type']
   data: SchemaType<DataType<C>>
   value: SchemaType<ValueType<C>>
   resolvedValue: SchemaType<ResolvedValueType<C>>
@@ -62,7 +63,9 @@ class Definition<C extends Config> extends ControlDefinition<
 
   static readonly type = 'makeswift::controls::text-input' as const
 
-  static get schema() {
+  static schema<P extends AnyContextValue = AnyContextValue>() {
+    const provides = ContextValueSchema.provides as SchemaType<P>
+
     const version = z.literal(1).optional()
     const versionedData = z.object({
       [ControlDataTypeKey]: z.enum(AcceptedTextDataTypes),
@@ -77,7 +80,7 @@ class Definition<C extends Config> extends ControlDefinition<
         description: z.string().optional(),
         defaultValue: value,
         selectAll: z.boolean().optional(),
-        provides: ContextValueSchema.provides.optional(),
+        provides: provides.optional(),
       })
 
       const definition = z.object({
@@ -115,13 +118,14 @@ class Definition<C extends Config> extends ControlDefinition<
       )
     }
 
-    const { version, config } = Definition.schema.relaxed.definition.parse(data)
+    const { version, config } =
+      Definition.schema().relaxed.definition.parse(data)
     return new TextInputDefinition(config, version)
   }
 
   constructor(
     config: C,
-    readonly version: z.infer<typeof Definition.schema.relaxed.version>,
+    readonly version: z.infer<DefinitionSchema['relaxed']['version']>,
   ) {
     super(config)
   }
@@ -131,14 +135,14 @@ class Definition<C extends Config> extends ControlDefinition<
   }
 
   get schema(): ReturnedSchemaType<C> {
-    return Definition.schema.relaxed
+    return Definition.schema().relaxed
   }
 
   get dataSchema() {
     return (
       (this.config.defaultValue === undefined
-        ? Definition.schema.relaxed
-        : Definition.schema.strict) as Schema<C>
+        ? Definition.schema().relaxed
+        : Definition.schema().strict) as Schema<C>
     ).data
   }
 
@@ -218,7 +222,7 @@ type UserConfig<
 type NormedConfig<
   D extends Config['defaultValue'],
   P extends AnyContextValue,
-> = z.infer<SchemaByDefaultValue<D>['config']> & ProvidesConfig<P>
+> = z.infer<SchemaByDefaultValue<D, P>['config']>
 
 export function TextInput<
   D extends Config['defaultValue'],

--- a/packages/controls/src/controls/text-input/text-input.ts
+++ b/packages/controls/src/controls/text-input/text-input.ts
@@ -13,6 +13,11 @@ import { type CopyContext } from '../../context'
 import { type DeserializedRecord } from '../../serialization'
 
 import {
+  ContextValueSchema,
+  type AnyContextValue,
+  type ProvidesConfig,
+} from '../context-value'
+import {
   ControlDefinition,
   type Resolvable,
   type SchemaType,
@@ -20,7 +25,10 @@ import {
 import { DefaultControlInstance, type ControlInstanceArgs } from '../instance'
 import { ControlDefinitionVisitor } from '../visitor'
 
-type Config = z.infer<typeof Definition.schema.relaxed.config>
+type Config<P extends AnyContextValue = AnyContextValue> = z.infer<
+  typeof Definition.schema.relaxed.config
+> &
+  ProvidesConfig<P>
 
 type SchemaByDefaultValue<D extends Config['defaultValue']> =
   undefined extends D
@@ -69,6 +77,7 @@ class Definition<C extends Config> extends ControlDefinition<
         description: z.string().optional(),
         defaultValue: value,
         selectAll: z.boolean().optional(),
+        provides: ContextValueSchema.provides.optional(),
       })
 
       const definition = z.object({
@@ -199,16 +208,21 @@ export class TextInputDefinition<
   C extends Config = Config,
 > extends Definition<C> {}
 
-type UserConfig<D extends Config['defaultValue']> = Config & {
+type UserConfig<
+  D extends Config['defaultValue'],
+  P extends AnyContextValue,
+> = Config<P> & {
   defaultValue?: D
 }
 
-type NormedConfig<D extends Config['defaultValue']> = z.infer<
-  SchemaByDefaultValue<D>['config']
->
+type NormedConfig<
+  D extends Config['defaultValue'],
+  P extends AnyContextValue,
+> = z.infer<SchemaByDefaultValue<D>['config']> & ProvidesConfig<P>
 
-export function TextInput<D extends Config['defaultValue']>(
-  config?: UserConfig<D>,
-): TextInputDefinition<NormedConfig<D>> {
-  return new TextInputDefinition((config ?? {}) as NormedConfig<D>, 1)
+export function TextInput<
+  D extends Config['defaultValue'],
+  P extends AnyContextValue = never,
+>(config?: UserConfig<D, P>): TextInputDefinition<NormedConfig<D, P>> {
+  return new TextInputDefinition((config ?? {}) as NormedConfig<D, P>, 1)
 }

--- a/packages/controls/src/testing/util-types.ts
+++ b/packages/controls/src/testing/util-types.ts
@@ -1,0 +1,1 @@
+export type Flatten<T> = { [K in keyof T]: T[K] }

--- a/packages/controls/src/testing/util-types.ts
+++ b/packages/controls/src/testing/util-types.ts
@@ -1,1 +1,0 @@
-export type Flatten<T> = { [K in keyof T]: T[K] }


### PR DESCRIPTION
### What
This PR adds support for `provides` declarations to all non-composite control configs whose definitions return a defined value from `resolveValueFromData`.

### Why
This is required to support the various input types referenced by Product Image inputs for MoS.

### Implementation Note
Config types derived from Zod schemas have their provides field typed generically via an intersection with `ProvidesConfig<P>`. This causes toEqualTypeOf to fail when comparing the intersection to the flattened expected type. Flattening the config type fixes this and still tests for assignability.