### PR TITLE
feat(controls): Allow for context providers inside lists

### DIFF
--- a/.changeset/eager-trains-shop.md
+++ b/.changeset/eager-trains-shop.md
@@ -1,0 +1,6 @@
+---
+'@makeswift/controls': patch
+'@makeswift/runtime': patch
+---
+
+Allow controls inside multi-value controls to provide context values scoped to their item's subtree.

--- a/packages/controls/src/controls/context-value/context-value.test.types.ts
+++ b/packages/controls/src/controls/context-value/context-value.test.types.ts
@@ -10,12 +10,12 @@ import { Shape } from '../shape/v1'
 
 import { unstable_ContextValue } from '.'
 import type {
+  AllProvidedIds,
   ContextDependencyIds,
   ContextValues,
   ContextValue as ContextValueType,
   DuplicateIds,
   MismatchedProvidedIds,
-  MultiValueProvidedIds,
   PropsWithValidContextUsage,
   ProvidedContextId,
   ProvidedIds,
@@ -136,9 +136,6 @@ describe('the prop-tree walk', () => {
 
     expectTypeOf<[ProvidedIds<typeof group>]>().toEqualTypeOf<['stateName']>()
     expectTypeOf<[RequiredIds<typeof group>]>().toEqualTypeOf<['stateName']>()
-    expectTypeOf<[MultiValueProvidedIds<typeof group>]>().toEqualTypeOf<
-      [never]
-    >()
   })
 
   test('finds them through a Shape', () => {
@@ -168,15 +165,12 @@ describe('the prop-tree walk', () => {
 
     expectTypeOf<[RequiredIds<typeof list>]>().toEqualTypeOf<['stateName']>()
     expectTypeOf<[ProvidedIds<typeof list>]>().toEqualTypeOf<[never]>()
-    expectTypeOf<[MultiValueProvidedIds<typeof list>]>().toEqualTypeOf<
-      [never]
-    >()
   })
 
-  test('a provider inside a List is flagged, however deeply nested', () => {
+  test('a provider inside a List is scoped to the item, however deeply nested', () => {
     const shallow = List({ type: stateCombobox() })
     expectTypeOf<[ProvidedIds<typeof shallow>]>().toEqualTypeOf<[never]>()
-    expectTypeOf<[MultiValueProvidedIds<typeof shallow>]>().toEqualTypeOf<
+    expectTypeOf<[AllProvidedIds<typeof shallow>]>().toEqualTypeOf<
       ['stateName']
     >()
 
@@ -185,9 +179,27 @@ describe('the prop-tree walk', () => {
         props: { inner: Group({ props: { s: stateCombobox() } }) },
       }),
     })
-    expectTypeOf<[MultiValueProvidedIds<typeof deep>]>().toEqualTypeOf<
-      ['stateName']
-    >()
+    expectTypeOf<[ProvidedIds<typeof deep>]>().toEqualTypeOf<[never]>()
+    expectTypeOf<[AllProvidedIds<typeof deep>]>().toEqualTypeOf<['stateName']>()
+  })
+
+  test('an id provided within an item satisfies that item and does not bubble out', () => {
+    const selfContained = List({
+      type: Group({ props: { s: stateCombobox(), c: cityCombobox() } }),
+    })
+
+    expectTypeOf<[RequiredIds<typeof selfContained>]>().toEqualTypeOf<[never]>()
+    expectTypeOf<[ProvidedIds<typeof selfContained>]>().toEqualTypeOf<[never]>()
+  })
+
+  test('a provider in an outer item is visible in nested item scopes', () => {
+    const nested = List({
+      type: Group({
+        props: { s: stateCombobox(), inner: List({ type: cityCombobox() }) },
+      }),
+    })
+
+    expectTypeOf<[RequiredIds<typeof nested>]>().toEqualTypeOf<[never]>()
   })
 
   test('leaf controls contribute nothing', () => {
@@ -208,6 +220,11 @@ describe('the prop-tree walk', () => {
       getOptions: (_query: string) => [{ id: 'x', value: 1, label: 'one' }],
     })
     expectTypeOf<[MismatchedProvidedIds<typeof bad>]>().toEqualTypeOf<
+      ['stateName']
+    >()
+
+    const badInItem = List({ type: bad })
+    expectTypeOf<[MismatchedProvidedIds<typeof badInItem>]>().toEqualTypeOf<
       ['stateName']
     >()
   })
@@ -251,12 +268,73 @@ describe('component props validation', () => {
     })
   })
 
-  test('rejects a provider inside a List', () => {
+  test('accepts a provider inside a List', () => {
     register({
-      // @ts-expect-error — a List provider has one value per item
       stops: List({ type: stateCombobox() }),
       noise: Number({ defaultValue: 0 }),
     })
+  })
+
+  test('accepts a provider and consumer within the same List item', () => {
+    register({
+      stops: List({
+        type: Group({ props: { s: stateCombobox(), c: cityCombobox() } }),
+      }),
+    })
+  })
+
+  test('accepts an outer-item provider consumed in a nested item scope', () => {
+    register({
+      stops: List({
+        type: Group({
+          props: { s: stateCombobox(), inner: List({ type: cityCombobox() }) },
+        }),
+      }),
+    })
+  })
+
+  test('rejects a consumer outside the List of an item-scoped provider', () => {
+    register({
+      stops: List({ type: stateCombobox() }),
+      // @ts-expect-error — the item-scoped provider is not visible outside
+      cityName: cityCombobox(),
+    })
+
+    const stops = List({ type: stateCombobox() })
+    type P = { stops: typeof stops; cityName: ReturnType<typeof cityCombobox> }
+    expectTypeOf<
+      PropsWithValidContextUsage<P>['cityName']
+    >().toEqualTypeOf<'This control depends on context (stateName) that is provided inside a multi-value control'>()
+  })
+
+  test('rejects a consumer in one List of an id provided only in a sibling List', () => {
+    register({
+      providing: List({ type: stateCombobox() }),
+      // @ts-expect-error — the sibling item scope is not visible here
+      consuming: List({ type: cityCombobox() }),
+    })
+
+    const providing = List({ type: stateCombobox() })
+    const consuming = List({ type: cityCombobox() })
+    type P = { providing: typeof providing; consuming: typeof consuming }
+    expectTypeOf<
+      PropsWithValidContextUsage<P>['consuming']
+    >().toEqualTypeOf<'This control depends on context (stateName) that is provided inside a multi-value control'>()
+  })
+
+  test('rejects a consumer inside a List with no provider in scope', () => {
+    register({
+      // @ts-expect-error — nothing provides `stateName`
+      stops: List({ type: cityCombobox() }),
+      noise: Number({ defaultValue: 0 }),
+    })
+  })
+
+  test('rejects a consumer with no provider', () => {
+    type P = { cityName: ReturnType<typeof cityCombobox> }
+    expectTypeOf<
+      PropsWithValidContextUsage<P>['cityName']
+    >().toEqualTypeOf<'This control depends on context (stateName) that nothing in this component provides'>()
   })
 
   test('rejects a provider whose resolved value type does not match', () => {
@@ -328,10 +406,33 @@ describe('duplicate provider detection', () => {
     expectTypeOf<[DuplicateIds<P>]>().toEqualTypeOf<[never]>()
   })
 
-  test('providers inside a List are not counted — already a FanOutProvider error', () => {
+  test('a List provider shadowing an outer provider is a duplicate', () => {
     const list = List({ type: stateCombobox() })
     type P = { a: ReturnType<typeof stateCombobox>; b: typeof list }
-    expectTypeOf<[DuplicateIds<P>]>().toEqualTypeOf<[never]>()
+    expectTypeOf<[DuplicateIds<P>]>().toEqualTypeOf<['stateName']>()
+  })
+
+  test('a nested-item provider shadowing an outer-item provider is a duplicate', () => {
+    const nested = List({
+      type: Group({
+        props: { s: stateCombobox(), inner: List({ type: stateCombobox() }) },
+      }),
+    })
+    expectTypeOf<[DuplicateIds<{ p: typeof nested }>]>().toEqualTypeOf<
+      ['stateName']
+    >()
+  })
+
+  test('sibling Lists may provide the same id', () => {
+    const a = List({ type: stateCombobox() })
+    const b = List({
+      type: Group({ props: { s: stateCombobox(), c: cityCombobox() } }),
+    })
+    expectTypeOf<[DuplicateIds<{ a: typeof a; b: typeof b }>]>().toEqualTypeOf<
+      [never]
+    >()
+
+    register({ a: List({ type: stateCombobox() }), b })
   })
 
   test('registerComponent rejects duplicate providers', () => {
@@ -340,6 +441,15 @@ describe('duplicate provider detection', () => {
       stateName: stateCombobox(),
       // @ts-expect-error — `stateName` is provided twice
       alsoStateName: stateCombobox(),
+    })
+  })
+
+  test('registerComponent rejects a shadowing List provider', () => {
+    register({
+      // @ts-expect-error — `stateName` is also provided inside the List
+      stateName: stateCombobox(),
+      // @ts-expect-error — `stateName` is also provided in the enclosing scope
+      stops: List({ type: stateCombobox() }),
     })
   })
 })

--- a/packages/controls/src/controls/context-value/types.ts
+++ b/packages/controls/src/controls/context-value/types.ts
@@ -98,20 +98,19 @@ type RequiredIdsImpl<Def, C = ContainerType<Def>> = [C] extends [
 ]
   ? { [K in keyof Defs]: RequiredIds<Defs[K]> }[keyof Defs]
   : [C] extends [MultiValueContainer<infer Item>]
-    ? RequiredIds<Item>
+    ? Exclude<RequiredIds<Item>, ProvidedIds<Item>>
     : ContextDependencyIds<Def>
 
-/** Context ids provided under a multivalue container. */
-export type MultiValueProvidedIds<Def> = Def extends unknown
-  ? MultiValueProvidedIdsImpl<Def>
+export type AllProvidedIds<Def> = Def extends unknown
+  ? AllProvidedIdsImpl<Def>
   : never
-type MultiValueProvidedIdsImpl<Def, C = ContainerType<Def>> = [C] extends [
+type AllProvidedIdsImpl<Def, C = ContainerType<Def>> = [C] extends [
   KeyedContainer<infer Defs>,
 ]
-  ? { [K in keyof Defs]: MultiValueProvidedIds<Defs[K]> }[keyof Defs]
+  ? { [K in keyof Defs]: AllProvidedIds<Defs[K]> }[keyof Defs]
   : [C] extends [MultiValueContainer<infer Item>]
-    ? ProvidedIds<Item> | MultiValueProvidedIds<Item>
-    : never
+    ? AllProvidedIds<Item>
+    : ProvidedContextId<Def>
 
 // Non-distributive on purpose: a resolved value type is usually a union
 // (`T | undefined`), and a distributive conditional would union `unknown` in
@@ -143,25 +142,26 @@ type MismatchedProvidedIdsOf<Def, C = ContainerType<Def>> = [C] extends [
         ? never
         : ProvidedContextId<Def>
 
-/**
- * Ids provided more than once within a record of definitions.
- */
-export type DuplicateIds<R> = {
+export type DuplicateIds<R, Scoped extends string = never> = {
   [K in keyof R]:
-    | DuplicateIdsWithin<R[K]>
-    | Extract<ProvidedIds<R[K]>, ProvidedIds<R[Exclude<keyof R, K>]>>
+    | DuplicateIdsWithin<
+        R[K],
+        Scoped | Extract<ProvidedIds<R[Exclude<keyof R, K>]>, string>
+      >
+    | Extract<ProvidedIds<R[K]>, Scoped | ProvidedIds<R[Exclude<keyof R, K>]>>
 }[keyof R]
 
-type DuplicateIdsWithin<Def> = Def extends unknown
-  ? DuplicateIdsWithinImpl<Def>
+type DuplicateIdsWithin<Def, Scoped extends string> = Def extends unknown
+  ? DuplicateIdsWithinImpl<Def, Scoped>
   : never
-type DuplicateIdsWithinImpl<Def, C = ContainerType<Def>> = [C] extends [
-  KeyedContainer<infer Defs>,
-]
-  ? DuplicateIds<Defs>
+type DuplicateIdsWithinImpl<
+  Def,
+  Scoped extends string,
+  C = ContainerType<Def>,
+> = [C] extends [KeyedContainer<infer Defs>]
+  ? DuplicateIds<Defs, Scoped>
   : [C] extends [MultiValueContainer<infer Item>]
-    ? // a provider in here is already a `ProviderInMultiValue` error
-      DuplicateIdsWithin<Item>
+    ? DuplicateIdsWithin<Item, Scoped> | Extract<ProvidedIds<Item>, Scoped>
     : never
 
 // Validation errors
@@ -169,9 +169,9 @@ export type UnprovidedContext<Ids extends string> = [Ids] extends [never]
   ? never
   : `This control depends on context (${Ids}) that nothing in this component provides`
 
-export type ProviderInMultiValue<Ids extends string> = [Ids] extends [never]
+export type OutOfScopeContext<Ids extends string> = [Ids] extends [never]
   ? never
-  : `controls inside multi value controls cannot provide context (${Ids})`
+  : `This control depends on context (${Ids}) that is provided inside a multi-value control`
 
 export type ProvidesMismatch<Ids extends string> = [Ids] extends [never]
   ? never
@@ -181,20 +181,29 @@ export type DuplicateProvider<Ids extends string> = [Ids] extends [never]
   ? never
   : `more than one prop in this component provides this context (${Ids}).A context must have exactly one provider`
 
-type ErrorsFor<Def, Provided, Duplicated> =
-  | DuplicateProvider<Extract<ProvidedIds<Def>, Duplicated>>
-  | UnprovidedContext<Exclude<RequiredIds<Def>, Provided>>
-  | ProviderInMultiValue<MultiValueProvidedIds<Def>>
+type ErrorsFor<
+  Def,
+  Provided,
+  Duplicated,
+  ScopedOnly extends string,
+  Unprovided extends string = Exclude<RequiredIds<Def>, Provided>,
+> =
+  | DuplicateProvider<Extract<AllProvidedIds<Def>, Duplicated>>
+  | OutOfScopeContext<Extract<Unprovided, ScopedOnly>>
+  | UnprovidedContext<Exclude<Unprovided, ScopedOnly>>
   | ProvidesMismatch<MismatchedProvidedIds<Def>>
 
-type ValidatedAgainst<P, Provided, Duplicated> = {
-  [K in keyof P]: [ErrorsFor<P[K], Provided, Duplicated>] extends [never]
+type ValidatedAgainst<P, Provided, Duplicated, ScopedOnly extends string> = {
+  [K in keyof P]: [ErrorsFor<P[K], Provided, Duplicated, ScopedOnly>] extends [
+    never,
+  ]
     ? P[K]
-    : ErrorsFor<P[K], Provided, Duplicated>
+    : ErrorsFor<P[K], Provided, Duplicated, ScopedOnly>
 }
 
 export type PropsWithValidContextUsage<P> = ValidatedAgainst<
   P,
   ProvidedIds<P[keyof P]>,
-  DuplicateIds<P>
+  DuplicateIds<P>,
+  Extract<Exclude<AllProvidedIds<P[keyof P]>, ProvidedIds<P[keyof P]>>, string>
 >

--- a/packages/runtime/src/runtimes/react/__tests__/react-runtime.register-component.test.tsx
+++ b/packages/runtime/src/runtimes/react/__tests__/react-runtime.register-component.test.tsx
@@ -4,6 +4,7 @@ import {
   Checkbox,
   Combobox,
   Color,
+  Group,
   Image,
   Link,
   List,
@@ -208,13 +209,41 @@ describe('options context validation', () => {
     })
   })
 
-  test('rejects a provider inside a List', () => {
+  test('accepts an item-scoped provider inside a List', () => {
     createReactRuntime().registerComponent(Noop, {
-      type: 'fan-out-provider',
-      label: 'Fan out',
+      type: 'item-scoped-provider',
+      label: 'Item scoped',
       props: {
-        // @ts-expect-error — a List provider has one value per item
-        stops: List({ type: stateCombobox() }),
+        places: List({
+          type: Group({
+            props: { stateName: stateCombobox(), cityName: cityCombobox() },
+          }),
+        }),
+      },
+    })
+  })
+
+  test('rejects a List provider that shadows an outer provider', () => {
+    createReactRuntime().registerComponent(Noop, {
+      type: 'shadowing-provider',
+      label: 'Shadowing',
+      props: {
+        // @ts-expect-error — `stateName` is also provided inside the List
+        stateName: stateCombobox(),
+        // @ts-expect-error — `stateName` is also provided in the enclosing scope
+        stateNames: List({ type: stateCombobox() }),
+      },
+    })
+  })
+
+  test('rejects a consumer outside the List of an item-scoped provider', () => {
+    createReactRuntime().registerComponent(Noop, {
+      type: 'out-of-scope-consumer',
+      label: 'Out of scope',
+      props: {
+        stateNames: List({ type: stateCombobox() }),
+        // @ts-expect-error — the item-scoped provider is not visible outside
+        cityName: cityCombobox(),
       },
     })
   })


### PR DESCRIPTION
This PR implements the ability to declare context providers inside of lists, adding new prop validation logic to surface errors when controls attempt to consume the context from outside of the list (otherwise it would be unclear which list element should be used to resolve the single context value). 

This allows for element scoped context used to implement a list of pairs of product ids and product images.