### PR TITLE
feat(vite-rsc): `serverOnly` wrapper + Vite plugin

### DIFF
--- a/.changeset/lucky-boats-shout.md
+++ b/.changeset/lucky-boats-shout.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/vite-rsc': patch
+---
+
+Add the `serverOnly` wrapper for server component loaders and a corresponding Vite plugin removing inline server-only loaders from non-RSC module graphs.

--- a/apps/vite-rsc-hono-react-cloudflare/src/lib/makeswift/components/rsc-kitchen-sink/register.ts
+++ b/apps/vite-rsc-hono-react-cloudflare/src/lib/makeswift/components/rsc-kitchen-sink/register.ts
@@ -1,5 +1,4 @@
-import { lazy } from 'react'
-import { ReactRuntime } from '@makeswift/vite-rsc'
+import { ReactRuntime, serverOnly } from '@makeswift/vite-rsc'
 
 import {
   Checkbox,
@@ -18,7 +17,7 @@ import {
 
 export const registerRscMarkdownComponent = (runtime: ReactRuntime) =>
   runtime.registerComponent(
-    lazy(() =>
+    serverOnly(() =>
       import('./server').then((mod) => ({ default: mod.RscKitchenSink })),
     ),
     {

--- a/apps/vite-rsc-hono-react-cloudflare/src/lib/makeswift/components/rsc-kitchen-sink/server.tsx
+++ b/apps/vite-rsc-hono-react-cloudflare/src/lib/makeswift/components/rsc-kitchen-sink/server.tsx
@@ -1,5 +1,4 @@
-// FIXME
-// import 'server-only'
+import 'server-only'
 
 import {
   Fragment,

--- a/apps/vite-rsc-hono-react-cloudflare/vite.config.ts
+++ b/apps/vite-rsc-hono-react-cloudflare/vite.config.ts
@@ -2,6 +2,8 @@ import { cloudflare } from '@cloudflare/vite-plugin'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import rsc from '@vitejs/plugin-rsc'
+import makeswift from '@makeswift/vite-rsc/plugin'
+
 import { defineConfig } from 'vite'
 
 export default defineConfig({
@@ -9,6 +11,7 @@ export default defineConfig({
     dedupe: ['react', 'react-dom'],
   },
   plugins: [
+    makeswift(),
     react(),
     tailwindcss(),
     rsc({

--- a/packages/vite-rsc/jest.config.json
+++ b/packages/vite-rsc/jest.config.json
@@ -1,5 +1,6 @@
 {
   "transform": {
     "^.+\\.(t|j)sx?$": "@swc/jest"
-  }
+  },
+  "setupFiles": ["./jest.setup.ts"]
 }

--- a/packages/vite-rsc/jest.setup.ts
+++ b/packages/vite-rsc/jest.setup.ts
@@ -1,0 +1,3 @@
+import { name as PACKAGE_NAME, version as PACKAGE_VERSION } from './package.json'
+
+Object.assign(globalThis, { PACKAGE_NAME, PACKAGE_VERSION })

--- a/packages/vite-rsc/package.json
+++ b/packages/vite-rsc/package.json
@@ -23,6 +23,11 @@
       "require": "./dist/cjs/index.js",
       "import": "./dist/esm/index.js",
       "types": "./dist/types/index.d.ts"
+    },
+    "./plugin": {
+      "types": "./dist/types/plugin/index.d.ts",
+      "import": "./dist/esm/plugin/index.js",
+      "require": "./dist/cjs/plugin/index.js"
     }
   },
   "scripts": {
@@ -35,14 +40,16 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
-    "@makeswift/runtime": "workspace:*"
+    "@makeswift/runtime": "workspace:*",
+    "magic-string": "^0.30.21"
   },
   "peerDependencies": {
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-rsc": "^0.5.34",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "vite": "^8.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {
@@ -58,11 +65,13 @@
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-rsc": "^0.5.34",
+    "acorn": "^8.18.0",
     "concurrently": "^8.2.2",
     "jest": "^29.7.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "tsup": "^8.0.2",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "vite": "^8.2.2"
   }
 }

--- a/packages/vite-rsc/src/global.d.ts
+++ b/packages/vite-rsc/src/global.d.ts
@@ -1,0 +1,6 @@
+declare global {
+  const PACKAGE_NAME: string
+  const PACKAGE_VERSION: string
+}
+
+export {}

--- a/packages/vite-rsc/src/index.rsc.ts
+++ b/packages/vite-rsc/src/index.rsc.ts
@@ -1,3 +1,4 @@
 export { type SiteVersion } from '@makeswift/runtime/unstable-framework-support'
 export { RSCReactRuntime as ReactRuntime } from './runtime'
 export { ViteRSCFrameworkProvider } from './framework-provider'
+export { serverOnly } from './server-only'

--- a/packages/vite-rsc/src/index.ts
+++ b/packages/vite-rsc/src/index.ts
@@ -1,3 +1,4 @@
 export { type SiteVersion } from '@makeswift/runtime/unstable-framework-support'
 export { ReactRuntime } from './runtime'
 export { ViteRSCFrameworkProvider } from './framework-provider'
+export { serverOnlyNoOp as serverOnly } from './server-only'

--- a/packages/vite-rsc/src/plugin/index.ts
+++ b/packages/vite-rsc/src/plugin/index.ts
@@ -30,7 +30,7 @@ export default function makeswiftViteRSC(): Plugin {
 
         return replaceServerLoaders({
           code,
-          ast: this.parse(code),
+          parse: code => this.parse(code),
           replacementExpr:
             '() => Promise.reject(new Error("Attempt to load server component outside the RSC environment"))',
         })

--- a/packages/vite-rsc/src/plugin/index.ts
+++ b/packages/vite-rsc/src/plugin/index.ts
@@ -1,0 +1,40 @@
+import { type Plugin } from 'vite'
+
+import { MARKER_SYMBOL, replaceServerLoaders } from './transform.js'
+
+export default function makeswiftViteRSC(): Plugin {
+  return {
+    name: '@makeswift/vite-rsc',
+
+    /**
+     * Removes server-component loaders wrapped in the `serverOnly` call
+     * (e.g. `serverOnly(() => import('./server'))`) from non-RSC module graphs.
+     *
+     * Although `ReactRuntimeCore` never loads registered server components
+     * outside the RSC environment, Vite would otherwise still discover these
+     * imports and add the corresponding modules to client and SSR graphs.
+     * Without a `server-only` guard in the server component code, this could
+     * emit discoverable client chunks containing server code or statically
+     * embedded secrets. With the guard, RSC import validation rejects the
+     * non-RSC graph and the production build fails.
+     */
+    transform: {
+      filter: {
+        code: new RegExp(`\\b${MARKER_SYMBOL}\\b`),
+      },
+      handler(code, id) {
+        // don't transform if it's an external module or we're compiling for RSC
+        if (id.includes('/node_modules/') || this.environment.name === 'rsc') {
+          return null
+        }
+
+        return replaceServerLoaders({
+          code,
+          ast: this.parse(code),
+          replacementExpr:
+            '() => Promise.reject(new Error("Attempt to load server component outside the RSC environment"))',
+        })
+      },
+    },
+  }
+}

--- a/packages/vite-rsc/src/plugin/transform.test.ts
+++ b/packages/vite-rsc/src/plugin/transform.test.ts
@@ -1,0 +1,76 @@
+import { parse } from 'acorn'
+import { type ESTree } from 'vite'
+
+import { replaceServerLoaders } from './transform'
+
+const REPLACEMENT_EXPR = "() => Promise.reject(new Error('Invalid import'))"
+
+const transform = (code: string) =>
+  replaceServerLoaders({
+    code,
+    ast: parse(code, { ecmaVersion: 'latest', sourceType: 'module' }) as ESTree.Program,
+    replacementExpr: REPLACEMENT_EXPR,
+  })
+
+describe('replaceServerLoaders', () => {
+  test('replaces an inline loader registered through `serverOnly`', () => {
+    const loader = "() => import('./server')"
+    const code = [
+      `import { serverOnly } from '${PACKAGE_NAME}'`,
+      `function register(rtm) { rtm.registerComponent(serverOnly(${loader}), {}) }`,
+    ].join('\n')
+
+    expect(transform(code)?.code).toBe(code.replace(loader, REPLACEMENT_EXPR))
+  })
+
+  test('supports an aliased `serverOnly` import', () => {
+    const loader = "() => import('./server')"
+    const code = [
+      `import { serverOnly as ifServer } from '${PACKAGE_NAME}'`,
+      `runtime.registerComponent(ifServer(${loader}), {})`,
+    ].join('\n')
+
+    expect(transform(code)?.code).toBe(code.replace(loader, REPLACEMENT_EXPR))
+  })
+
+  test.each([
+    {
+      name: 'marker imported from another package',
+      code: [
+        "import { serverOnly } from 'another-package'",
+        "runtime.registerComponent(serverOnly(() => import('./server')), {})",
+      ].join('\n'),
+    },
+    {
+      name: 'marker of unknown origin',
+      code: [
+        'const serverOnly = (callback) => callback()',
+        "runtime.registerComponent(serverOnly(() => import('./server')), {})",
+      ].join('\n'),
+    },
+    {
+      name: 'marker call outside component registration',
+      code: [
+        `import { serverOnly } from '${PACKAGE_NAME}'`,
+        "serverOnly(() => import('./server'))",
+      ].join('\n'),
+    },
+    {
+      name: 'loader defined outside component registration',
+      code: [
+        `import { serverOnly } from '${PACKAGE_NAME}'`,
+        "const load = () => import('./server')",
+        'runtime.registerComponent(serverOnly(load), {})',
+      ].join('\n'),
+    },
+    {
+      name: 'non-member `registerComponent` calls',
+      code: [
+        `import { serverOnly } from '${PACKAGE_NAME}'`,
+        "registerComponent(() => import('./server'), {})",
+      ].join('\n'),
+    },
+  ])('ignores $name', ({ code }) => {
+    expect(transform(code)).toBeNull()
+  })
+})

--- a/packages/vite-rsc/src/plugin/transform.test.ts
+++ b/packages/vite-rsc/src/plugin/transform.test.ts
@@ -8,7 +8,7 @@ const REPLACEMENT_EXPR = "() => Promise.reject(new Error('Invalid import'))"
 const transform = (code: string) =>
   replaceServerLoaders({
     code,
-    ast: parse(code, { ecmaVersion: 'latest', sourceType: 'module' }) as ESTree.Program,
+    parse: code => parse(code, { ecmaVersion: 'latest', sourceType: 'module' }) as ESTree.Program,
     replacementExpr: REPLACEMENT_EXPR,
   })
 

--- a/packages/vite-rsc/src/plugin/transform.ts
+++ b/packages/vite-rsc/src/plugin/transform.ts
@@ -1,0 +1,135 @@
+import { type ESTree } from 'vite'
+
+import MagicString from 'magic-string'
+
+export const MARKER_SYMBOL = 'serverOnly'
+
+/**
+ * Replaces inline loader functions passed to `serverOnly` or its alias with
+ * `replacementExpr` when the `serverOnly` call used as the component argument
+ * to `.registerComponent()`, e.g.
+ *
+ *   runtime.registerComponent(
+ *     serverOnly(() =>
+ *       import('./server').then((mod) => ({ default: mod.RscMarkdown })),
+ *     ),
+ *     {
+ *     ...
+ *     })
+ */
+export function replaceServerLoaders({
+  code,
+  ast,
+  replacementExpr,
+}: {
+  code: string
+  ast: ESTree.Program
+  replacementExpr: string
+}) {
+  const markerSymbols = collectMarkerSymbols(ast)
+  if (markerSymbols.size === 0) return null
+
+  const output = new MagicString(code)
+  let changed = false
+
+  visit(ast, node => {
+    const loaderExpr = getServerLoaderExpr(markerSymbols, node)
+    if (loaderExpr) {
+      const { start, end } = loaderExpr
+      output.overwrite(start, end, replacementExpr)
+      changed = true
+    }
+  })
+
+  if (!changed) return null
+
+  return {
+    code: output.toString(),
+    map: output.generateMap({ hires: 'boundary' }),
+  }
+}
+
+/**
+ * Scans AST for imports of the marker symbol from this package
+ */
+const collectMarkerSymbols = (ast: ESTree.Program): Set<string> => {
+  const result = new Set<string>()
+
+  for (const node of ast.body) {
+    if (node.type !== 'ImportDeclaration' || node.source.value !== PACKAGE_NAME) continue
+
+    for (const specifier of node.specifiers) {
+      if (
+        specifier.type === 'ImportSpecifier' &&
+        specifier.imported.type === 'Identifier' &&
+        specifier.imported.name === MARKER_SYMBOL
+      ) {
+        result.add(specifier.local.name)
+      }
+    }
+  }
+
+  return result
+}
+
+/**
+ * Returns the inline server loader from the component argument of a
+ * `.registerComponent()` call, or `null` when the node does not match
+ */
+const getServerLoaderExpr = (
+  markerSymbols: Set<string>,
+  node: ESTree.Node,
+): ESTree.Expression | null => {
+  if (!isRegisterComponentCall(node)) return null
+
+  const component = node.arguments[0]
+  if (component == null || component.type !== 'CallExpression') return null
+
+  return getMarkedLoaderExpr(markerSymbols, component)
+}
+
+const isRegisterComponentCall = (node: ESTree.Node): node is ESTree.CallExpression =>
+  node.type === 'CallExpression' &&
+  node.callee.type === 'MemberExpression' &&
+  !node.callee.computed &&
+  node.callee.property.type === 'Identifier' &&
+  node.callee.property.name === 'registerComponent'
+
+/**
+ * Returns the inline function passed to a recognized marker call, or `null`
+ * when the call does not match
+ */
+const getMarkedLoaderExpr = (
+  markerSymbols: Set<string>,
+  call: ESTree.CallExpression,
+): ESTree.Expression | null => {
+  if (
+    call.callee.type !== 'Identifier' ||
+    !markerSymbols.has(call.callee.name) ||
+    call.arguments.length !== 1
+  ) {
+    return null
+  }
+
+  const loader = call.arguments[0]
+  return loader.type === 'ArrowFunctionExpression' || loader.type === 'FunctionExpression'
+    ? loader
+    : null
+}
+
+function visit(node: ESTree.Node, callback: (node: ESTree.Node) => void) {
+  callback(node)
+
+  for (const value of Object.values(node)) {
+    if (Array.isArray(value)) {
+      for (const child of value) {
+        if (isNode(child)) visit(child, callback)
+      }
+    } else if (isNode(value)) {
+      visit(value, callback)
+    }
+  }
+}
+
+const isNode = (value: unknown): value is ESTree.Node =>
+  typeof value === 'object' && value != null && 'type' in value

--- a/packages/vite-rsc/src/plugin/transform.ts
+++ b/packages/vite-rsc/src/plugin/transform.ts
@@ -19,13 +19,14 @@ export const MARKER_SYMBOL = 'serverOnly'
  */
 export function replaceServerLoaders({
   code,
-  ast,
+  parse,
   replacementExpr,
 }: {
   code: string
-  ast: ESTree.Program
+  parse: (code: string) => ESTree.Program
   replacementExpr: string
 }) {
+  const ast = parse(code)
   const markerSymbols = collectMarkerSymbols(ast)
   if (markerSymbols.size === 0) return null
 

--- a/packages/vite-rsc/src/server-only.ts
+++ b/packages/vite-rsc/src/server-only.ts
@@ -1,0 +1,20 @@
+import { lazy, type ReactNode, type ComponentType } from 'react'
+
+/**
+ * Server component loader wrapper for RSC env; redirects to `React.lazy`.
+ */
+export function serverOnly<T extends ComponentType<any>>(load: () => Promise<{ default: T }>) {
+  return lazy(load)
+}
+
+/**
+ * Server component loader wrapper for all other envs including SSR; ignores the
+ * loader and returns a no-op component that should never be rendered.
+ *
+ * On the compilation side, the Vite plugin (`./plugin/index.ts`) uses the
+ * `serverOnly` import as a marker for inline loaders whose server-only
+ * imports need to be removed from non-RSC module graphs.
+ */
+export function serverOnlyNoOp<T extends ComponentType<any>>(_load: () => Promise<{ default: T }>) {
+  return (): ReactNode => null
+}

--- a/packages/vite-rsc/tsup.config.ts
+++ b/packages/vite-rsc/tsup.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig, Options } from 'tsup'
-import { version } from './package.json'
+import { name, version } from './package.json'
 
 export default defineConfig(() => {
   const commonOptions = {
@@ -14,6 +14,7 @@ export default defineConfig(() => {
     sourcemap: true,
     legacyOutput: true,
     define: {
+      PACKAGE_NAME: JSON.stringify(name),
       PACKAGE_VERSION: JSON.stringify(version),
     },
     esbuildOptions(options, { format }) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,7 +163,7 @@ importers:
         version: 19.2.3(@types/react@19.2.15)
       '@vitejs/plugin-react':
         specifier: latest
-        version: 6.1.0(vite@8.2.2(@types/node@20.14.11)(esbuild@0.28.1)(jiti@2.7.0))
+        version: 6.1.1(vite@8.2.2(@types/node@20.14.11)(esbuild@0.28.1)(jiti@2.7.0))
       '@vitejs/plugin-rsc':
         specifier: latest
         version: 0.5.34(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.2.2(@types/node@20.14.11)(esbuild@0.28.1)(jiti@2.7.0))
@@ -813,6 +813,9 @@ importers:
       '@makeswift/runtime':
         specifier: workspace:*
         version: link:../runtime
+      magic-string:
+        specifier: ^0.30.21
+        version: 0.30.21
     devDependencies:
       '@swc/jest':
         specifier: ^0.2.36
@@ -828,7 +831,10 @@ importers:
         version: 19.2.3(@types/react@19.2.15)
       '@vitejs/plugin-rsc':
         specifier: ^0.5.34
-        version: 0.5.34(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@8.2.2(@types/node@20.14.11)(esbuild@0.28.1)(jiti@2.7.0))
+        version: 0.5.34(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@8.2.2(@types/node@20.14.11)(esbuild@0.19.12)(jiti@2.7.0))
+      acorn:
+        specifier: ^8.18.0
+        version: 8.18.0
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
@@ -847,6 +853,9 @@ importers:
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
+      vite:
+        specifier: ^8.2.2
+        version: 8.2.2(@types/node@20.14.11)(esbuild@0.19.12)(jiti@2.7.0)
 
 packages:
 
@@ -2628,9 +2637,6 @@ packages:
     resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
     engines: {node: '>=6.0.0'}
 
-  '@jridgewell/sourcemap-codec@1.4.11':
-    resolution: {integrity: sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==}
-
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
@@ -3440,6 +3446,9 @@ packages:
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
   '@types/express-serve-static-core@5.0.7':
     resolution: {integrity: sha512-R+33OsgWw7rOhD1emjU7dzCDHucJrgJXMA5PYCzJxVil0dsyx5iBEPHqpPfiKNJQb7lZ1vxwoLR4Z87bBUpeGQ==}
 
@@ -3908,8 +3917,8 @@ packages:
     peerDependencies:
       react: '>= 16.8.0'
 
-  '@vitejs/plugin-react@6.1.0':
-    resolution: {integrity: sha512-qd2BzUBehkov86WFhg0JkEFEYyCLG9uPCe6qWTY/kRlss9OvJrOF2UbIWT7p+8IzZHkEu0DNGHc4HSv+JdDLsw==}
+  '@vitejs/plugin-react@6.1.1':
+    resolution: {integrity: sha512-yxLaQV9gkhS8ezJqCM6+ndU7mDY6gqAg75NQ+0IjwEI8IYOmQCgkRwHKVSfWXW076DsqMo0Dk+0FK1U+M5RgFw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
@@ -3967,18 +3976,13 @@ packages:
     resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
     engines: {node: '>=0.4.0'}
 
-  acorn@8.11.3:
-    resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
-  acorn@8.14.0:
-    resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -12255,7 +12259,7 @@ snapshots:
   '@jridgewell/gen-mapping@0.3.2':
     dependencies:
       '@jridgewell/set-array': 1.1.2
-      '@jridgewell/sourcemap-codec': 1.4.11
+      '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.15
 
   '@jridgewell/gen-mapping@0.3.5':
@@ -12274,8 +12278,6 @@ snapshots:
   '@jridgewell/set-array@1.1.2': {}
 
   '@jridgewell/set-array@1.2.1': {}
-
-  '@jridgewell/sourcemap-codec@1.4.11': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -12919,6 +12921,8 @@ snapshots:
 
   '@types/estree@1.0.6': {}
 
+  '@types/estree@1.0.9': {}
+
   '@types/express-serve-static-core@5.0.7':
     dependencies:
       '@types/node': 20.14.11
@@ -13441,12 +13445,12 @@ snapshots:
       '@use-gesture/core': 10.2.24
       react: 19.2.3
 
-  '@vitejs/plugin-react@6.1.0(vite@8.2.2(@types/node@20.14.11)(esbuild@0.28.1)(jiti@2.7.0))':
+  '@vitejs/plugin-react@6.1.1(vite@8.2.2(@types/node@20.14.11)(esbuild@0.28.1)(jiti@2.7.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.2.2(@types/node@20.14.11)(esbuild@0.28.1)(jiti@2.7.0)
 
-  '@vitejs/plugin-rsc@0.5.34(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@8.2.2(@types/node@20.14.11)(esbuild@0.28.1)(jiti@2.7.0))':
+  '@vitejs/plugin-rsc@0.5.34(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@8.2.2(@types/node@20.14.11)(esbuild@0.19.12)(jiti@2.7.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       es-module-lexer: 2.3.2
@@ -13457,8 +13461,8 @@ snapshots:
       srvx: 0.12.7
       strip-literal: 3.1.0
       turbo-stream: 3.2.1
-      vite: 8.2.2(@types/node@20.14.11)(esbuild@0.28.1)(jiti@2.7.0)
-      vitefu: 1.1.3(vite@8.2.2(@types/node@20.14.11)(esbuild@0.28.1)(jiti@2.7.0))
+      vite: 8.2.2(@types/node@20.14.11)(esbuild@0.19.12)(jiti@2.7.0)
+      vitefu: 1.1.3(vite@8.2.2(@types/node@20.14.11)(esbuild@0.19.12)(jiti@2.7.0))
 
   '@vitejs/plugin-rsc@0.5.34(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.2.2(@types/node@20.14.11)(esbuild@0.28.1)(jiti@2.7.0))':
     dependencies:
@@ -13495,10 +13499,6 @@ snapshots:
       acorn: 8.15.0
       acorn-walk: 8.3.2
 
-  acorn-jsx@5.3.2(acorn@8.14.0):
-    dependencies:
-      acorn: 8.14.0
-
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -13507,14 +13507,12 @@ snapshots:
 
   acorn-walk@8.3.4:
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.18.0
     optional: true
 
-  acorn@8.11.3: {}
-
-  acorn@8.14.0: {}
-
   acorn@8.15.0: {}
+
+  acorn@8.18.0: {}
 
   address@1.2.0: {}
 
@@ -15250,7 +15248,7 @@ snapshots:
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
@@ -15307,8 +15305,8 @@ snapshots:
       debug: 4.4.1
       enhanced-resolve: 5.14.1
       eslint: 8.56.0
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.15.1
@@ -15336,7 +15334,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -15369,7 +15367,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -15380,7 +15378,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
@@ -15390,7 +15388,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -15763,8 +15761,8 @@ snapshots:
 
   espree@10.2.0:
     dependencies:
-      acorn: 8.14.0
-      acorn-jsx: 5.3.2(acorn@8.14.0)
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
       eslint-visitor-keys: 4.1.0
 
   espree@10.4.0:
@@ -15775,8 +15773,8 @@ snapshots:
 
   espree@9.6.1:
     dependencies:
-      acorn: 8.14.0
-      acorn-jsx: 5.3.2(acorn@8.14.0)
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
       eslint-visitor-keys: 3.4.3
 
   esprima@4.0.1: {}
@@ -15795,7 +15793,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.9
 
   esutils@2.0.3: {}
 
@@ -17787,7 +17785,7 @@ snapshots:
   jsdom@20.0.3:
     dependencies:
       abab: 2.0.6
-      acorn: 8.11.3
+      acorn: 8.15.0
       acorn-globals: 7.0.1
       cssom: 0.5.0
       cssstyle: 2.3.0
@@ -20579,7 +20577,7 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 20.14.11
-      acorn: 8.15.0
+      acorn: 8.18.0
       acorn-walk: 8.3.4
       arg: 4.1.3
       create-require: 1.1.1
@@ -21047,6 +21045,19 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite@8.2.2(@types/node@20.14.11)(esbuild@0.19.12)(jiti@2.7.0):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rolldown: 1.2.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 20.14.11
+      esbuild: 0.19.12
+      fsevents: 2.3.3
+      jiti: 2.7.0
+
   vite@8.2.2(@types/node@20.14.11)(esbuild@0.28.1)(jiti@2.7.0):
     dependencies:
       lightningcss: 1.33.0
@@ -21059,6 +21070,10 @@ snapshots:
       esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.7.0
+
+  vitefu@1.1.3(vite@8.2.2(@types/node@20.14.11)(esbuild@0.19.12)(jiti@2.7.0)):
+    optionalDependencies:
+      vite: 8.2.2(@types/node@20.14.11)(esbuild@0.19.12)(jiti@2.7.0)
 
   vitefu@1.1.3(vite@8.2.2(@types/node@20.14.11)(esbuild@0.28.1)(jiti@2.7.0)):
     optionalDependencies:


### PR DESCRIPTION
Add the `serverOnly` wrapper for server component loaders and a corresponding Vite plugin removing inline server-only loaders from non-RSC module graphs.

Problem statement/demo:

https://github.com/user-attachments/assets/af83cb40-1354-46de-8935-957e5bd19ca7

Best reviewed commit-by-commit.