### PR TITLE
fix: lowercase "click" in link plugin label

### DIFF
--- a/.changeset/arr-1116-lowercase-click-label.md
+++ b/.changeset/arr-1116-lowercase-click-label.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/runtime': patch
+---
+
+Lowercases "click" in the link plugin's "On click" label.

--- a/packages/runtime/src/controls/rich-text-v2/__tests__/__snapshots__/serialization.test.ts.snap
+++ b/packages/runtime/src/controls/rich-text-v2/__tests__/__snapshots__/serialization.test.ts.snap
@@ -134,7 +134,7 @@ RichTextV2Definition {
       "control": {
         "definition": LinkDefinition {
           "config": {
-            "label": "On Click",
+            "label": "On click",
           },
         },
       },
@@ -289,7 +289,7 @@ exports[`RichTextV2 serialization deserialized definition in block mode contains
         "control": {
           "definition": {
             "config": {
-              "label": "On Click",
+              "label": "On click",
             },
             "type": "makeswift::controls::link",
           },

--- a/packages/runtime/src/slate/LinkPlugin/index.tsx
+++ b/packages/runtime/src/slate/LinkPlugin/index.tsx
@@ -61,7 +61,7 @@ export function LinkPlugin() {
   return Plugin({
     control: {
       definition: Link({
-        label: 'On Click',
+        label: 'On click',
       }),
       onChange,
       getValue,


### PR DESCRIPTION
Lowercases "Click" in the `LinkPlugin` label ("On Click" → "On click") for consistency, as requested in [RED-1945](https://linear.app/makeswift/issue/RED-1945/styles-recently-changed-for-input-under-open-page-option-in-link#comment-a5d82f75).