### PR TITLE
feat(controls): add suffix option to Slider control

### DIFF
--- a/.changeset/slider-suffix.md
+++ b/.changeset/slider-suffix.md
@@ -1,0 +1,5 @@
+---
+'@makeswift/controls': patch
+---
+
+Add an optional `suffix` config option to the `Slider` control, allowing a unit such as `%` or `px` to be displayed next to the slider value in the builder.

--- a/packages/controls/src/controls/slider/__snapshots__/slider.test.ts.snap
+++ b/packages/controls/src/controls/slider/__snapshots__/slider.test.ts.snap
@@ -61,6 +61,19 @@ SliderDefinition {
 }
 `;
 
+exports[`Slider constructor creates slider with suffix 1`] = `
+SliderDefinition {
+  "config": {
+    "defaultValue": 50,
+    "label": "width",
+    "max": 100,
+    "min": 0,
+    "suffix": "%",
+  },
+  "version": 1,
+}
+`;
+
 exports[`Slider definition w/ config {"defaultValue":50,"label":"volume","min":0,"max":100} toData returns v1 data for \`0\` when definition version is 1 1`] = `
 {
   "@@makeswift/type": "number::v1",

--- a/packages/controls/src/controls/slider/slider.test.ts
+++ b/packages/controls/src/controls/slider/slider.test.ts
@@ -32,6 +32,18 @@ describe('Slider', () => {
       ).toMatchSnapshot()
     })
 
+    test('creates slider with suffix', () => {
+      expect(
+        Slider({
+          label: 'width',
+          defaultValue: 50,
+          min: 0,
+          max: 100,
+          suffix: '%',
+        }),
+      ).toMatchSnapshot()
+    })
+
     test('disallows extraneous properties', () => {
       Slider({
         label: undefined,
@@ -53,6 +65,7 @@ describe('Slider', () => {
     assignTest(Slider({ defaultValue: undefined }))
     assignTest(Slider({ min: 0, max: 100 }))
     assignTest(Slider({ min: 0, max: 100, step: 1 }))
+    assignTest(Slider({ suffix: 'px' }))
     assignTest(
       Slider({
         defaultValue: 50,

--- a/packages/controls/src/controls/slider/slider.test.types.ts
+++ b/packages/controls/src/controls/slider/slider.test.types.ts
@@ -18,6 +18,7 @@ describe('Slider Types', () => {
         max?: number
         step?: number
         showInput?: boolean
+        suffix?: string
         provides?: undefined
       }>()
     })
@@ -35,6 +36,7 @@ describe('Slider Types', () => {
         max?: number
         step?: number
         showInput?: boolean
+        suffix?: string
         provides?: typeof volumeContext
       }>()
     })

--- a/packages/controls/src/controls/slider/slider.ts
+++ b/packages/controls/src/controls/slider/slider.ts
@@ -83,6 +83,7 @@ class Definition<C extends Config> extends ControlDefinition<
         max: z.number().optional(),
         step: z.number().optional(),
         showInput: z.boolean().optional(),
+        suffix: z.string().optional(),
         provides: provides.optional(),
       })
 


### PR DESCRIPTION
## Summary

Adds an optional `suffix` to the `Slider` config so the builder can render a unit such as `%` or `px` next to the value, mirroring the existing option on `Number`. Maps from the BigCommerce widget `range` setting's `typeMeta.rangeValues.unit`.

Companion builder PR: https://github.com/makeswift/cosmos/pull/3344

Linear: https://linear.app/commerce/issue/ARR-1056/add-suffix-to-slider-control